### PR TITLE
Fix submodule config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/MikePopoloski/slang.git
 [submodule "external/reflect-cpp"]
 	path = external/reflect-cpp
-	url = git@github.com:getml/reflect-cpp.git
+	url = https://github.com/getml/reflect-cpp.git


### PR DESCRIPTION
`s/git/https` so that building has fewer requirements.  Also, until we squash all the slang library changes we'll need them on a fork somewhere.