### PR TITLE
Make SLANG_SERVER_TESTS and env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,5 @@ endif()
 
 if(SLANG_SERVER_INCLUDE_TESTS)
   enable_testing()
-  # Define SLANG_SERVER_TESTS for the library when building tests
-  target_compile_definitions(slang_server_obj_lib PRIVATE SLANG_SERVER_TESTS)
   add_subdirectory(tests/cpp)
 endif()

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -33,6 +33,9 @@
 #include "slang/text/SourceManager.h"
 #include "slang/util/OS.h"
 #include "slang/util/TimeTrace.h"
+
+namespace fs = std::filesystem;
+
 namespace server {
 
 SlangServer::SlangServer(SlangLspClient& client) :
@@ -297,12 +300,11 @@ void SlangServer::loadConfig() {
         auto fsPath = std::filesystem::path(m_workspaceFolder.value().uri.getPath());
         confPaths.push_back((fsPath / ".slang" / "server.json").string());
     }
-#ifndef SLANG_SERVER_TESTS
-    if (getenv("HOME")) {
-        fs::path homePath = getenv("HOME");
+    auto home = std::getenv("HOME");
+    if (home && !std::getenv("SLANG_SERVER_TESTS")) {
+        fs::path homePath(home);
         confPaths.push_back((homePath / ".slang" / "server.json").string());
     }
-#endif
     if (m_workspaceFolder) {
         // std::string workspacePath(m_workspaceFolder.value().uri.getPath());
         auto fsPath = std::filesystem::path(m_workspaceFolder.value().uri.getPath());

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -16,8 +16,6 @@ target_include_directories(
 target_link_libraries(server_unittests PRIVATE reflectcpp)
 
 target_link_libraries(server_unittests PRIVATE slang::slang Catch2::Catch2)
-target_compile_definitions(server_unittests PRIVATE UNITTESTS
-                                                    SLANG_SERVER_TESTS)
 target_include_directories(
   server_unittests PRIVATE ${PROJECT_SOURCE_DIR}/external/slang/tests/unittests)
 

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -9,6 +9,10 @@
 #include "slang/util/BumpAllocator.h"
 #include "slang/util/OS.h"
 
+#ifdef _WIN32
+#    include <windows.h>
+#endif
+
 namespace slang {
 
 BumpAllocator alloc;
@@ -26,6 +30,13 @@ bool g_updateGoldenFlag = false;
 int main(int argc, char** argv) {
     slang::OS::setupConsole();
     slang::syntax::SyntaxTree::getDefaultSourceManager().setDisableProximatePaths(true);
+
+// Let slang-server know we're running tests
+#ifdef _WIN32
+    SetEnvironmentVariable(TEXT("SLANG_SERVER_TESTS"), TEXT("YES"));
+#else
+    setenv("SLANG_SERVER_TESTS", "YES", true);
+#endif
 
     // We create a Catch2 session
     Catch::Session session;


### PR DESCRIPTION
Having `SLANG_SERVER_TESTS` be a compiler flag means you can't use a build for both CI and integration testing.  It's also confusing when the server silently fails to pick up the home dir conf file.  Making this an environment variable to circumvent this frustration / confusion.

Also, the python tests already thought it was an env var?  See `conftest.py`.