### PR TITLE
Better neovim sync

### DIFF
--- a/.github/workflows/neovim-sync.yml
+++ b/.github/workflows/neovim-sync.yml
@@ -17,11 +17,14 @@ jobs:
 
     - name: Mirror the subdirectory to the plugin repo
       run: |
+        git log -n1 --format=%B > ${{ runner.temp }}/commit.msg
+        echo "From:" >> ${{ runner.temp }}/commit.msg
+        echo -n "https://github.com/hudson-trading/slang-server/commit/" >> ${{ runner.temp }}/commit.msg
+        git rev-parse HEAD >> ${{ runner.temp }}/commit.msg
         git config --global user.name "Hudson River Trading"
         git config --global user.email "opensource@hudson-trading.com"
         git clone https://x-access-token:${{ secrets.NEOVIM_PAT }}@github.com/hudson-trading/slang-server.nvim.git neovim-sync
         rsync -av --delete --exclude '.git' clients/neovim/ neovim-sync/
-        cd neovim-sync
-        git add .
-        git commit -m "Sync from Slang Server repo"
-        git push
+        git -C neovim-sync add .
+        git -C neovim-sync commit -F ${{ runner.temp }}/commit.msg
+        git -C neovim-sync push


### PR DESCRIPTION
Tested locally.  Testing in GH CI is a bit of a pain.  We should probably force push to a dedicated branch on the mirror repo when we push to some branch here.  This also probably needs to be a Python script.  For now I think this cleans things up.