### PR TITLE
adjustments from experimenting on opentitan

### DIFF
--- a/include/completions/Completions.h
+++ b/include/completions/Completions.h
@@ -50,7 +50,8 @@ lsp::CompletionItem getMemberCompletion(const slang::ast::Symbol& symbol,
 
 /// Add completions for members in a scope to results
 void getMemberCompletions(std::vector<lsp::CompletionItem>& results, const slang::ast::Scope* scope,
-                          bool isLhs, const slang::ast::Scope* originalScope);
+                          bool isLhs, const slang::ast::Scope* originalScope,
+                          bool isOriginalCall = true);
 
 /// Resolve additional information for a member completion
 void resolveMemberCompletion(const slang::ast::Scope& scope, lsp::CompletionItem& item);

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -44,6 +44,7 @@ ServerDriver::ServerDriver(Indexer& indexer, SlangLspClient& client, std::string
     parseOpts.ignoreDuplicates = true;
 
     bool ok = driver.parseCommandLine(flags, parseOpts);
+    driver.options.errorLimit = 0;
     ok &= driver.processOptions(false);
     if (!ok) {
         client.showError(fmt::format("Failed to parse config flags: {}", flags));
@@ -60,7 +61,6 @@ ServerDriver::ServerDriver(Indexer& indexer, SlangLspClient& client, std::string
     }
 
     // Configure diagnostic engine
-    diagEngine.setErrorLimit(1000);
     diagEngine.setIgnoreAllWarnings(false);
     diagEngine.setIgnoreAllNotes(false);
     diagEngine.addClient(diagClient);

--- a/src/completions/CompletionDispatch.cpp
+++ b/src/completions/CompletionDispatch.cpp
@@ -58,11 +58,11 @@ void CompletionDispatch::getInvokedCompletions(std::vector<lsp::CompletionItem>&
         // Add packages as completions, because we may grab a value from those
         // Add these after though, since local vars are the common case
         // TODO: add these when we can sort completions
-        // for (auto& [name, info] : m_indexer.symbolToFiles.getAllEntries()) {
-        //     if (info.kind == lsp::SymbolKind::Package) {
-        //         results.push_back(completions::getModuleCompletion(name, info.kind));
-        //     }
-        // }
+        for (auto& [name, info] : m_indexer.symbolToFiles.getAllEntries()) {
+            if (info.kind == lsp::SymbolKind::Package) {
+                results.push_back(completions::getModuleCompletion(name, info.kind));
+            }
+        }
     }
 }
 

--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -351,7 +351,6 @@ lsp::CompletionItem getMemberCompletion(const slang::ast::Symbol& symbol,
                                     ifaceConn.second ? ifaceConn.second->name : "<generic>");
         }
         else {
-            INFO("Falling back to sym kind for {}", symbol.getHierarchicalPath());
             detailStr = toString(symbol.kind);
         }
     }
@@ -442,7 +441,7 @@ void resolveMemberCompletion(const slang::ast::Scope& scope, lsp::CompletionItem
 
 /// Get completions for members in a scope, recursing up until hitting a module instance
 void getMemberCompletions(std::vector<lsp::CompletionItem>& results, const slang::ast::Scope* scope,
-                          bool isLhs, const slang::ast::Scope* originalScope) {
+                          bool isLhs, const slang::ast::Scope* originalScope, bool isOriginalCall) {
 
     if (!scope) {
         ERROR("No scope for member completion");
@@ -490,12 +489,14 @@ void getMemberCompletions(std::vector<lsp::CompletionItem>& results, const slang
         }
 
         // Add wildcard imports
-        if (auto importData = currentScope->getWildcardImportData()) {
-            for (auto import : importData->wildcardImports) {
-                auto package = import->getPackage();
-                if (package != nullptr) {
-                    INFO("Adding wildcard imports from package {}", package->name);
-                    getMemberCompletions(results, package, isLhs, originalScope);
+        if (isOriginalCall) {
+            if (auto importData = currentScope->getWildcardImportData()) {
+                for (auto import : importData->wildcardImports) {
+                    auto package = import->getPackage();
+                    if (package != nullptr) {
+                        INFO("Adding wildcard imports from package {}", package->name);
+                        getMemberCompletions(results, package, isLhs, originalScope, false);
+                    }
                 }
             }
         }

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -361,6 +361,11 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
         return def.definition;
     }
 
+    auto pkg = m_compilation->getPackage(declTok->valueText());
+    if (pkg) {
+        return pkg;
+    }
+
     return nullptr;
 }
 

--- a/tests/cpp/golden/ModuleMemberCompletion.json
+++ b/tests/cpp/golden/ModuleMemberCompletion.json
@@ -317,6 +317,34 @@
           "value": "````systemverilog\n// Interface port example\nsimple_interface intf();\n````"
         },
         "filterText": "intf"
+      },
+      {
+        "label": "base_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage base_pkg;\n````"
+        },
+        "filterText": "base_pkg",
+        "insertText": "base_pkg",
+        "insertTextFormat": "PlainText"
+      },
+      {
+        "label": "util_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage util_pkg;\n````"
+        },
+        "filterText": "util_pkg",
+        "insertText": "util_pkg",
+        "insertTextFormat": "PlainText"
       }
     ]
   }

--- a/tests/cpp/golden/WildcardImportCompletion.json
+++ b/tests/cpp/golden/WildcardImportCompletion.json
@@ -196,6 +196,34 @@
           "value": "````systemverilog\nfunction int find_max(int array[], int size);\n    int max_val = array[0];\n    for (int i = 1; i < size; i++) begin\n        if (array[i] > max_val)\n            max_val = array[i];\n    end\n    return max_val;\nendfunction\n````"
         },
         "filterText": "find_max"
+      },
+      {
+        "label": "base_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage base_pkg;\n````"
+        },
+        "filterText": "base_pkg",
+        "insertText": "base_pkg",
+        "insertTextFormat": "PlainText"
+      },
+      {
+        "label": "util_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage util_pkg;\n````"
+        },
+        "filterText": "util_pkg",
+        "insertText": "util_pkg",
+        "insertTextFormat": "PlainText"
       }
     ]
   },

--- a/tests/cpp/utils/ServerHarness.cpp
+++ b/tests/cpp/utils/ServerHarness.cpp
@@ -225,7 +225,7 @@ void DocumentHandle::append(std::string text) {
     insert(m_text.size(), text);
 }
 
-void DocumentHandle::erase(int start, int end) {
+void DocumentHandle::erase(size_t start, size_t end) {
     CHECK(state != DocState::Closed);
 
     pending_changes.push_back({lsp::TextDocumentContentChangePartial{

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -105,7 +105,7 @@ public:
     // onChange functions
     void insert(lsp::uint offset, std::string text);
     void append(std::string text);
-    void erase(int start, int end);
+    void erase(size_t start, size_t end);
 
     Cursor before(std::string before, lsp::uint start_pos = 0);
     Cursor after(std::string after, lsp::uint start_pos = 0);


### PR DESCRIPTION
Stacked PRs:
 * #47
 * #46
 * #48
 * __->__#45


--- --- ---

### adjustments from experimenting on opentitan
- wildcard imports only import for the first scope, not recursive calls. For opentitan this would stall the server, since there's a ton of wildcard imports.
- error limit should be infinite, since this won't get reset and is meant for not blowing up a terminal
- look up packages as a last resort for gotos- useful if you just have `some_pkg::`
- include packages in rhs completions- I was going to wait for adding completion ranking via the clangd hack, but I think it's better to have these in for now.
