### PR TITLE
fixes from deleted URI default constructor

### DIFF
--- a/include/ast/HierarchicalView.h
+++ b/include/ast/HierarchicalView.h
@@ -216,30 +216,19 @@ static void handleInstanceArray(std::vector<HierItem_t>& result,
         }
     }
 
-    if (!elements.empty()) {
-        std::string declName;
-        lsp::Location declLoc;
-
-        // Extract declaration info from the array elements
-        rfl::visit(
-            [&](auto&& x) {
-                using sym_t = typename std::decay_t<decltype(x)>;
-                if constexpr (std::is_same<sym_t, Instance>()) {
-                    declName = fmt::format("{}{}", x.declName, array.range.toString());
-                    declLoc = x.declLoc;
-                }
-            },
-            elements.front());
-
-        result.push_back(HierItem_t(Instance{
-            .kind = SlangKind::InstanceArray,
-            .instName = std::string(array.getArrayName()),
-            .instLoc = toLocation(array.getSyntax()->sourceRange(), sm),
-            .declName = declName,
-            .declLoc = declLoc,
-            .children = elements,
-        }));
+    if (elements.empty()) {
+        return;
     }
+    // Extract declaration info from the first array element, and append array
+    auto& firstElement = rfl::get<Instance>(elements.front());
+    result.push_back(HierItem_t(Instance{
+        .kind = SlangKind::InstanceArray,
+        .instName = std::string(array.getArrayName()),
+        .instLoc = toLocation(array.getSyntax()->sourceRange(), sm),
+        .declName = fmt::format("{}{}", firstElement.declName, array.range.toString()),
+        .declLoc = firstElement.declLoc,
+        .children = elements,
+    }));
 }
 
 static void handleParameter(std::vector<HierItem_t>& result,

--- a/src/ast/ServerCompilation.cpp
+++ b/src/ast/ServerCompilation.cpp
@@ -164,7 +164,9 @@ std::optional<std::vector<lsp::CallHierarchyItem>> ServerCompilation::getDocPrep
         if (!isWcpVariable(instance)) {
             continue;
         }
-        result.emplace_back(lsp::CallHierarchyItem{.name = instance});
+        // TODO: change to doc of actual symbol, not the declToken
+        result.emplace_back(
+            lsp::CallHierarchyItem{.name = instance, .uri = params.textDocument.uri});
     }
     return std::optional(result);
 }

--- a/src/completions/CompletionDispatch.cpp
+++ b/src/completions/CompletionDispatch.cpp
@@ -93,7 +93,7 @@ void CompletionDispatch::getTriggerCompletions(char triggerChar, char prevChar,
 
         auto& [_, entry] = *start;
         auto completion = completions::getModuleCompletion(std::string{name}, entry.kind);
-        resolveModuleCompletion(completion, fs::path(entry.location.uri.getPath()), true);
+        resolveModuleCompletion(completion, fs::path(entry.uri.getPath()), true);
         results.push_back(completion);
     }
     else if (triggerChar == ':' && prevChar == ':') {

--- a/tests/cpp/IndexerTests.cpp
+++ b/tests/cpp/IndexerTests.cpp
@@ -198,27 +198,21 @@ endclass
 
     SECTION("Symbols") {
         GoldenMap expectedMap;
-        expectedMap.emplace("driver", Indexer::IndexMapEntry::fromSymbolData(
-                                          lsp::SymbolKind::Module, "wire_module",
-                                          lsp::LocationUriOnly{URI::fromFile(f2Path)}));
-        expectedMap.emplace("C", Indexer::IndexMapEntry::fromSymbolData(
-                                     lsp::SymbolKind::Class, "",
-                                     lsp::LocationUriOnly{URI::fromFile(f2Path)}));
+        expectedMap.emplace(
+            "driver", Indexer::IndexMapEntry::fromSymbolData(lsp::SymbolKind::Module, "wire_module",
+                                                             URI::fromFile(f2Path)));
+        expectedMap.emplace("C", Indexer::IndexMapEntry::fromSymbolData(lsp::SymbolKind::Class, "",
+                                                                        URI::fromFile(f2Path)));
         expectedMap.emplace("Iface", Indexer::IndexMapEntry::fromSymbolData(
-                                         lsp::SymbolKind::Interface, "",
-                                         lsp::LocationUriOnly{URI::fromFile(f1Path)}));
+                                         lsp::SymbolKind::Interface, "", URI::fromFile(f1Path)));
         expectedMap.emplace("m1", Indexer::IndexMapEntry::fromSymbolData(
-                                      lsp::SymbolKind::Module, "",
-                                      lsp::LocationUriOnly{URI::fromFile(f1Path)}));
+                                      lsp::SymbolKind::Module, "", URI::fromFile(f1Path)));
         expectedMap.emplace("m4", Indexer::IndexMapEntry::fromSymbolData(
-                                      lsp::SymbolKind::Module, "",
-                                      lsp::LocationUriOnly{URI::fromFile(f1Path)}));
-        expectedMap.emplace("n", Indexer::IndexMapEntry::fromSymbolData(
-                                     lsp::SymbolKind::Module, "",
-                                     lsp::LocationUriOnly{URI::fromFile(f1Path)}));
+                                      lsp::SymbolKind::Module, "", URI::fromFile(f1Path)));
+        expectedMap.emplace("n", Indexer::IndexMapEntry::fromSymbolData(lsp::SymbolKind::Module, "",
+                                                                        URI::fromFile(f1Path)));
         expectedMap.emplace("wire_module", Indexer::IndexMapEntry::fromSymbolData(
-                                               lsp::SymbolKind::Module, "",
-                                               lsp::LocationUriOnly{URI::fromFile(f2Path)}));
+                                               lsp::SymbolKind::Module, "", URI::fromFile(f2Path)));
         checkIndexedMap(indexer.symbolMap().getAllEntries(), expectedMap);
     }
 }


### PR DESCRIPTION
Stacked PRs:
 * #50
 * #49
 * __->__#47


--- --- ---

### fixes from deleted URI default constructor

The Neovim client can't handle empty URIs, so we should aim to not allow these to be constructed. While doing this I did some related cleanup with the indexer and instance arrays in the hierarchy view. https://github.com/hudson-trading/slang-server/issues/33 was fixed by another PR, but this should clean up more of that diagnostic logic.

commit-id:d6357aca