### PR TITLE
better vscode client debugging

### DIFF
--- a/.vscode/find-pid.sh
+++ b/.vscode/find-pid.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Define the path to your server executable
+SERVER_PATH="${1}/build/vscode/bin/slang-server"
+
+# Loop until a PID is found
+PID=$(pgrep -f "${SERVER_PATH}")
+while [ -z "$PID" ]; do
+    sleep 1
+    PID=$(pgrep -f "${SERVER_PATH}")
+done
+
+# Print the PID to standard output
+echo "$PID"

--- a/.vscode/launch.template.jsonc
+++ b/.vscode/launch.template.jsonc
@@ -4,7 +4,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Attach to running slang-server",
+            "name": "Attach to slang-server",
             "type": "cppdbg",
             "request": "attach",
             "program": "${workspaceFolder}/build/bin/slang-server",
@@ -24,7 +24,7 @@
             ],
         },
         {
-            "name": "Debug tests with gdb",
+            "name": "Debug server_unittests",
             "request": "launch",
             "type": "cppdbg",
             "program": "${workspaceFolder}/build/bin/server_unittests",
@@ -50,7 +50,65 @@
             "outFiles": ["${workspaceFolder}/clients/vscode/out/**"],
             "cwd": "${workspaceFolder}/clients/vscode",
             "resolveSourceMapLocations": ["${workspaceFolder}/clients/vscode/**", "!**/node_modules/**"],
-            "preLaunchTask": "build slang-vscode"
+            "preLaunchTask": "build slang-vscode",
+        },
+        {
+            "name": "Attach to slang-server (auto-attach)",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/build/vscode/bin/slang-server",
+            "processId": "${input:slangServerPID}",
+
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Enable break on all exceptions",
+                    "text": "catch throw",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "Run slang-vscode with custom server",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}/clients/vscode/"],
+            "outFiles": ["${workspaceFolder}/clients/vscode/out/**"],
+            "cwd": "${workspaceFolder}/clients/vscode",
+            "resolveSourceMapLocations": ["${workspaceFolder}/clients/vscode/**", "!**/node_modules/**"],
+            "preLaunchTask": "build ext deps",
+            "env": {
+                "SLANG_SERVER_PATH": "${workspaceFolder}/build/vscode/bin/slang-server"
+            },
         }
     ],
+    "compounds": [
+        {
+            "name": "Run slang-vscode and attach gdb",
+            "configurations": [
+                "Run slang-vscode with custom server",
+                "Attach to slang-server (auto-attach)"
+            ],
+        }
+    ],
+    "inputs": [
+        {
+            "id": "slangServerPID",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "command": "${workspaceFolder}/.vscode/find-pid.sh",
+                "args": [
+                    "${workspaceFolder}"
+                ],
+                "useFirstResult": true
+            },
+
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,25 @@
         },
         {
           "type": "shell",
+          "label": "build slang-server",
+          "command": "cmake --build build/vscode -j --target slang_server",
+          "options": {
+            "cwd": "${workspaceFolder}"
+          },
+          "group": {
+            "kind": "build",
+          }
+        },
+        {
+          "label": "build ext deps",
+          "dependsOn": [
+            "build slang-vscode",
+            "build slang-server"
+          ],
+          "problemMatcher": []
+        },
+        {
+          "type": "shell",
           "label": "__watch-tests",
           "command": "pnpm watch-tests",
           "problemMatcher": "$tsc-watch",
@@ -56,6 +75,6 @@
             "__watch-tests"
           ],
           "problemMatcher": []
-        }
+        },
       ]
     }

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -43,14 +43,19 @@ Logs are in `Output > slang-server` in the terminal area
 To refresh the server, run the command "Verilog: Restart Language Server"
 
 ## Vscode Client Testing
+Install the extension dependencies by following the instructions [here](clients/vscode/DEVELOPING.md)
 
 Copy the launch template:
 
 `cp .vscode/launch.template.jsonc .vscode/launch.json`
 
-Go to Debug > Run slang-vscode
+Configure a build for vscode to use
 
-Point to your build of slang-server if needed.
+`cmake -B build/vscode -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=DEBUG`
+
+Go to Debug > Run slang-vscode and attach gdb
+
+This will spin up the extension and automatically attach gdb to the slang-server process.
 
 ## Vscode Debugging
 
@@ -62,6 +67,11 @@ Type in `slang-server` to select the running server
 
 Now adding cpp breakpoints other vscode features should work.
 This method works when running slang-server with vscode or pygls
+
+You can use the auto-attach debug config by pointing your repo to the build/vscode server build, then doing the following after changes:
+- rebuild your changes if any for the build/vscode build
+- run the `Slang: Restart Lanugage Server` command
+- run the `Attach to slang-server (auto-attach)` debug option to reattach.
 
 ## LSP Stubs
 
@@ -98,6 +108,7 @@ GDB: Run with `--gdb <secs>`, then you'll have that long to attach. Then press '
 
 RR: Run with `--rr`, then run `rr replay`
 
+<!--
 ## Neovim Testing
 
-(TODO)
+(TODO) -->

--- a/clients/vscode/DEVELOPING.md
+++ b/clients/vscode/DEVELOPING.md
@@ -3,23 +3,23 @@
 Install nvm (Node Version Manager), or install Node 20
 
 ```
-git clone git@github.com:AndrewNolte/vscode-system-verilog.git
-cd vscode-system-verilog
-nvm use 20
-npm install
+git clone git@github.com:hudson-trading/slang-server.git
 code .
+cd slang-server/clients/vscode
+nvm use 20
+npm install -g pnpm
+pnpm install
 ```
-
-Go to `Run and Debug` in vscode, and click `Launch Extension`. Click refresh whenver you want to update code and restart the extension. (There's no hot reloading for extensions)
 
 ### Debugging
 
-- The logger logs to the `verilog` output channel on the new vscode window, and is also available in production
-- `console.log()` logs to the debug console of the vscode-system-verilog/ vscode window.
-- `vscode.window.showInformationMessage()` is useful for showing popups to debug
+- The server logs to the `slang-server` output channel. These are triggered with the `INFO`, `WARN` and `ERROR` macros.
+- The client logs to the `Slang` output channel using logger classes.
+- `console.log()` logs to the debug console of the slang-server/ vscode window.
+- `vscode.window.showInformationMessage()` is useful for showing popups for debugging. On the server side these can also be triggered with `LspClient::showInfo()`.
 
 ### Updating package.json (config paths, commands, etc.)
 
-Traditional vscode extension development requires many strings to match up between package.json and the code. I made a small library within this repo to generate package.json from the code where possible, so there's a single source of truth for these strings, and it's easy to add commands, buttons, and conifgurations.
+Traditional vscode extension development requires many strings to match up between package.json and the code. I made a small library within this repo to generate package.json from the code where possible, so there's a single source of truth for these strings, and it's easy to add commands, buttons, and congurations.
 
 To update the package.json after changing one of these components, Run "Extdev: update config (package.json and CONFIG.md)" in the vscode window you're debugging.

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode'
 import * as child_process from 'child_process'
 import { glob } from 'glob'
 import path from 'path'
+import * as process from 'process'
 import { promisify } from 'util'
 import * as vscodelc from 'vscode-languageclient/node'
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node'
@@ -118,7 +119,15 @@ export class SlangExtension extends ActivityBarComponent {
 
   async setupLanguageClient(): Promise<void> {
     this.logger.info('starting language server')
-    const slangServerPath = await this.path.getValueAsync()
+
+    // Check for environment variable set in launch.json when debugging in vscode
+    let slangServerPath = process.env.SLANG_SERVER_PATH
+    if (!slangServerPath) {
+      slangServerPath = await this.path.getValueAsync()
+    } else {
+      this.logger.info(`Using slang-server from environment variable: ${slangServerPath}`)
+    }
+
     if (slangServerPath === '') {
       await vscode.window.showErrorMessage(
         `"slang.path not configured. Configure the abs path at slang.path, add to PATH, or disable in config.`


### PR DESCRIPTION
Stacked PRs:
 * #54
 * #53
 * #52
 * __->__#50


--- --- ---

### Better vscode client debugging

This adds a vscode debug config that launches the extension client and connects debuggers to both the client and the server.

commit-id:9287b862