### PR TITLE
use lexical path for scope info in hovers and completions

### DIFF
--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -289,7 +289,7 @@ lsp::CompletionItem getHierarchicalCompletion(const slang::ast::Symbol& parentSy
             .label = std::string{symbol.name},
             .labelDetails =
                 lsp::CompletionItemLabelDetails{.detail = " " + detailStr,
-                                                .description = parentSymbol.getHierarchicalPath()},
+                                                .description = parentSymbol.getLexicalPath()},
             .kind = getCompletionKind(symbol),
             .documentation = std::nullopt, // Will be populated during resolve
             .filterText = std::string{symbol.name},
@@ -365,7 +365,7 @@ lsp::CompletionItem getMemberCompletion(const slang::ast::Symbol& symbol,
     std::optional<std::string> descriptionStr;
     if (currentScope == nullptr ||
         (symbol.getParentScope() && symbol.getParentScope() != currentScope)) {
-        auto hierPath = symbol.getParentScope()->asSymbol().getHierarchicalPath();
+        auto hierPath = symbol.getParentScope()->asSymbol().getLexicalPath();
         if (!hierPath.empty()) {
             descriptionStr = hierPath;
         }

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -535,7 +535,7 @@ std::optional<lsp::Hover> ShallowAnalysis::getDocHover(const lsp::Position& posi
         auto lookupScope = getScopeAt(loc.value());
 
         if (lookupScope && symbolScope && lookupScope != symbolScope) {
-            auto hierPath = symbolScope->asSymbol().getHierarchicalPath();
+            auto hierPath = symbolScope->asSymbol().getLexicalPath();
             if (!hierPath.empty() && hierPath != "$unit") {
                 md = fmt::format("{}\n\n---\n\n{}",
                                  svCodeBlockString(fmt::format("// In {}", hierPath)), md);

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -133,8 +133,8 @@ macromodule m3;
     I d(.a(), .b());
     ^ Ref -> `interface I(.*);`
       ^ Sym d : HierarchicalInstance
-         ^ Ref -> `// In m3.d`\n\\n\---\n\\n\`input a`
-               ^ Ref -> `// In m3.d`\n\\n\---\n\\n\`output b`
+         ^ Ref -> `// In I`\n\\n\---\n\\n\`input a`
+               ^ Ref -> `// In I`\n\\n\---\n\\n\`output b`
 
 
 
@@ -149,7 +149,7 @@ macromodule m3;
     ^^ Ref -> `module m2 #(\n\    parameter i = 1,\n\    localparam j = i,\n\    parameter type x_t = bit\n\)\n\    (input int a[], (* bar = "asdf" *) output logic b = 1, ref c,\n\    input p::y2 d2,\n\     interface.mod d, .e());`
 
         .x_t(y_t)
-         ^^^ Ref -> `// In m3.m`\n\\n\---\n\\n\`x_t = bit`
+         ^^^ Ref -> `// In m2`\n\\n\---\n\\n\`x_t = bit`
              ^^^ Ref -> `typedef p::y_t y_t;`
 
     ) m (, b, c, d, );
@@ -173,27 +173,27 @@ macromodule m3;
     ^^ Ref -> `module m2 #(\n\    parameter i = 1,\n\    localparam j = i,\n\    parameter type x_t = bit\n\)\n\    (input int a[], (* bar = "asdf" *) output logic b = 1, ref c,\n\    input p::y2 d2,\n\     interface.mod d, .e());`
 
         .i(1),
-         ^ Ref -> `// In m3.m2_inst`\n\\n\---\n\\n\`parameter i = 1`
+         ^ Ref -> `// In m2`\n\\n\---\n\\n\`parameter i = 1`
 
         .x_t(y2)
-         ^^^ Ref -> `// In m3.m2_inst`\n\\n\---\n\\n\`x_t = bit`
+         ^^^ Ref -> `// In m2`\n\\n\---\n\\n\`x_t = bit`
              ^^ Ref -> `typedef p::y2 y2;`
 
     ) m2_inst (
       ^^^^^^^ Sym m2_inst : HierarchicalInstance
 
         .a({1, 2}),
-         ^ Ref -> `// In m3.m2_inst`\n\\n\---\n\\n\`input int a[]`
+         ^ Ref -> `// In m2`\n\\n\---\n\\n\`input int a[]`
 
         .b(b),
-         ^ Ref -> `// In m3.m2_inst`\n\\n\---\n\\n\`(* bar = "asdf" *) output logic b = 1`
+         ^ Ref -> `// In m2`\n\\n\---\n\\n\`(* bar = "asdf" *) output logic b = 1`
            ^ Ref -> `wire b;`
 
         .c(),
-         ^ Ref -> `// In m3.m2_inst`\n\\n\---\n\\n\`ref c`
+         ^ Ref -> `// In m2`\n\\n\---\n\\n\`ref c`
 
         .d(d),
-         ^ Ref -> `// In m3.m2_inst`\n\\n\---\n\\n\`interface.mod d`
+         ^ Ref -> `// In m2`\n\\n\---\n\\n\`interface.mod d`
            ^ Ref -> `I d(.a(), .b());`
 
         .e()
@@ -613,7 +613,7 @@ macromodule m3;
 
     defparam m3.m.i = 1:1:1;
                 ^ Ref -> `m2 #(\n\    .x_t(y_t)\n\) m (, b, c, d, );`
-                  ^ Ref -> `// In m3.m`\n\\n\---\n\\n\`parameter i = 1`
+                  ^ Ref -> `// In m2`\n\\n\---\n\\n\`parameter i = 1`
 
 
 
@@ -863,7 +863,7 @@ module m4;
     ^ Ref -> `module n(Iface.m a);`
       ^^ Sym n2 : HierarchicalInstance
          ^^ Ref -> `Iface i2();`
-            ^ Ref -> `// In m4.i2`\n\\n\---\n\\n\`modport m(export foo, function void bar(int, logic), task baz, export func);`
+            ^ Ref -> `// In Iface`\n\\n\---\n\\n\`modport m(export foo, function void bar(int, logic), task baz, export func);`
 
 
 
@@ -924,7 +924,7 @@ checker assert_window1 (
 );
 
     default clocking @clock; endclocking
-                      ^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`event clock = $inferred_clock`
+                      ^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`event clock = $inferred_clock`
 
     default disable iff reset;
                         ^^^^^ Ref -> `logic reset = $inferred_disable`
@@ -978,10 +978,10 @@ checker assert_window1 (
              ^^^^^^^^ Sym p_window : PropertyDeclaration
 
         start_event && !window |=> test_expr[+] ##0 end_event;
-        ^^^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`untyped start_event`
-                        ^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
-                                   ^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`logic test_expr`
-                                                    ^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`untyped end_event`
+        ^^^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`untyped start_event`
+                        ^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                                   ^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`logic test_expr`
+                                                    ^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`untyped end_event`
 
     endproperty
 
@@ -989,8 +989,8 @@ checker assert_window1 (
 
     a_window: assert property (p_window) else $error(error_msg);
     ^^^^^^^^ Sym a_window : AssertPropertyStatement
-                               ^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`property p_window;\n\    start_event && !window |=> test_expr[+] ##0 end_event;\n\endproperty`
-                                                     ^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`string error_msg = "violation"`
+                               ^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`property p_window;\n\    start_event && !window |=> test_expr[+] ##0 end_event;\n\endproperty`
+                                                     ^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`string error_msg = "violation"`
 
 
 
@@ -1001,8 +1001,8 @@ checker assert_window1 (
 
         cover_window_open: cover property (start_event && !window)
         ^^^^^^^^^^^^^^^^^ Sym cover_window_open : CoverPropertyStatement
-                                           ^^^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`untyped start_event`
-                                                           ^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                                           ^^^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`untyped start_event`
+                                                           ^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
         $display("window_open covered");
 
@@ -1010,16 +1010,16 @@ checker assert_window1 (
         ^^^^^^^^^^^^ Sym cover_window : CoverPropertyStatement
 
             start_event && !window
-            ^^^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`untyped start_event`
-                            ^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+            ^^^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`untyped start_event`
+                            ^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
             ##1 (!end_event && window) [*]
-                  ^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`untyped end_event`
-                               ^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                  ^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`untyped end_event`
+                               ^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
             ##1 end_event && window
-                ^^^^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`untyped end_event`
-                             ^^^^^^ Ref -> `// In m5.aw2`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                ^^^^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`untyped end_event`
+                             ^^^^^^ Ref -> `// In assert_window1`\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
         ) $display("window covered");
 
@@ -1216,7 +1216,7 @@ module m7;
     int i = g2.foo();
         ^ Sym i : Declarator
             ^^ Ref -> `G #(int) g2;`
-               ^^^ Ref -> `// In G#(int)`\n\\n\---\n\\n\`function G::T G::foo;\n\    return 0;\n\endfunction`
+               ^^^ Ref -> `// In G`\n\\n\---\n\\n\`function G::T G::foo;\n\    return 0;\n\endfunction`
 
     real r = D::foo();
          ^ Sym r : Declarator

--- a/tests/cpp/golden/FindSymbolRefHdl.out
+++ b/tests/cpp/golden/FindSymbolRefHdl.out
@@ -127,37 +127,37 @@ interface bus_if #(
 
     task automatic write_data(input logic [ADDR_WIDTH-1:0] address, input data_t write_data);
                    ^^^^^^^^^^ Sym write_data : TaskDeclaration
-                                           ^^^^^^^^^^ Ref -> `parameter int ADDR_WIDTH = 32`
+                                           ^^^^^^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`parameter int ADDR_WIDTH = 32`
                                                            ^^^^^^^ Sym address : Declarator
-                                                                          ^^^^^^ Ref -> `data_t = bit`
+                                                                          ^^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`data_t = bit`
                                                                                  ^^^^^^^^^^ Sym write_data : Declarator
 
         @(posedge clk);
-                  ^^^ Ref -> `input logic clk`
+                  ^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`input logic clk`
 
         addr <= address;
-        ^^^^ Ref -> `logic [ADDR_WIDTH-1:0] addr;`
+        ^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic [ADDR_WIDTH-1:0] addr;`
                 ^^^^^^^ Ref -> `input logic [ADDR_WIDTH-1:0] address`
 
         data <= write_data;
-        ^^^^ Ref -> `data_t data;`
+        ^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`data_t data;`
                 ^^^^^^^^^^ Ref -> `input data_t write_data`
 
         write_enable <= 1'b1;
-        ^^^^^^^^^^^^ Ref -> `logic write_enable;`
+        ^^^^^^^^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic write_enable;`
 
         valid <= 1'b1;
-        ^^^^^ Ref -> `logic valid;`
+        ^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic valid;`
 
         @(posedge clk iff ready);
-                  ^^^ Ref -> `input logic clk`
-                          ^^^^^ Ref -> `logic ready;`
+                  ^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`input logic clk`
+                          ^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic ready;`
 
         valid <= 1'b0;
-        ^^^^^ Ref -> `logic valid;`
+        ^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic valid;`
 
         write_enable <= 1'b0;
-        ^^^^^^^^^^^^ Ref -> `logic write_enable;`
+        ^^^^^^^^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic write_enable;`
 
     endtask
 
@@ -167,34 +167,34 @@ interface bus_if #(
 
     task automatic read_data(input logic [ADDR_WIDTH-1:0] address, output data_t read_data);
                    ^^^^^^^^^ Sym read_data : TaskDeclaration
-                                          ^^^^^^^^^^ Ref -> `parameter int ADDR_WIDTH = 32`
+                                          ^^^^^^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`parameter int ADDR_WIDTH = 32`
                                                           ^^^^^^^ Sym address : Declarator
-                                                                          ^^^^^^ Ref -> `data_t = bit`
+                                                                          ^^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`data_t = bit`
                                                                                  ^^^^^^^^^ Sym read_data : Declarator
 
         @(posedge clk);
-                  ^^^ Ref -> `input logic clk`
+                  ^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`input logic clk`
 
         addr <= address;
-        ^^^^ Ref -> `logic [ADDR_WIDTH-1:0] addr;`
+        ^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic [ADDR_WIDTH-1:0] addr;`
                 ^^^^^^^ Ref -> `input logic [ADDR_WIDTH-1:0] address`
 
         write_enable <= 1'b0;
-        ^^^^^^^^^^^^ Ref -> `logic write_enable;`
+        ^^^^^^^^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic write_enable;`
 
         valid <= 1'b1;
-        ^^^^^ Ref -> `logic valid;`
+        ^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic valid;`
 
         @(posedge clk iff ready);
-                  ^^^ Ref -> `input logic clk`
-                          ^^^^^ Ref -> `logic ready;`
+                  ^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`input logic clk`
+                          ^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic ready;`
 
         read_data = data;
         ^^^^^^^^^ Ref -> `output data_t read_data`
-                    ^^^^ Ref -> `data_t data;`
+                    ^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`data_t data;`
 
         valid <= 1'b0;
-        ^^^^^ Ref -> `logic valid;`
+        ^^^^^ Ref -> `// In bus_if`\n\\n\---\n\\n\`logic valid;`
 
     endtask
 
@@ -495,26 +495,26 @@ module NoDefaults #(
     ^^^ Ref -> `module Sub #(\n\    parameter int WIDTH = 16\n\)(\n\    input logic clk,\n\    input logic rst,\n\    input logic [WIDTH-1:0] data_in,\n\    output logic [WIDTH-1:0] data_out\n\);`
 
         .WIDTH(WIDTH)
-         ^^^^^ Ref -> `// In NoDefaults.sub_inst`\n\\n\---\n\\n\`parameter int WIDTH = 16`
+         ^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`parameter int WIDTH = 16`
                ^^^^^ Ref -> `parameter int WIDTH`
 
     ) sub_inst (
       ^^^^^^^^ Sym sub_inst : HierarchicalInstance
 
         .clk(clk),
-         ^^^ Ref -> `// In NoDefaults.sub_inst`\n\\n\---\n\\n\`input logic clk`
+         ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic clk`
              ^^^ Ref -> `input logic clk`
 
         .rst(rst),
-         ^^^ Ref -> `// In NoDefaults.sub_inst`\n\\n\---\n\\n\`input logic rst`
+         ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic rst`
              ^^^ Ref -> `input logic rst`
 
         .data_in(data_in),
-         ^^^^^^^ Ref -> `// In NoDefaults.sub_inst`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+         ^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
                  ^^^^^^^ Ref -> `input logic [WIDTH-1:0] data_in`
 
         .data_out(data_out)
-         ^^^^^^^^ Ref -> `// In NoDefaults.sub_inst`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+         ^^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
                   ^^^^^^^^ Ref -> `output logic [WIDTH-1:0] data_out`
 
     );
@@ -534,26 +534,26 @@ module NoDefaults #(
         ^^^ Ref -> `module Sub #(\n\    parameter int WIDTH = 16\n\)(\n\    input logic clk,\n\    input logic rst,\n\    input logic [WIDTH-1:0] data_in,\n\    output logic [WIDTH-1:0] data_out\n\);`
 
             .WIDTH(WIDTH)
-             ^^^^^ Ref -> `// In NoDefaults.gen_loop[0].sub`\n\\n\---\n\\n\`parameter int WIDTH = 16`
+             ^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`parameter int WIDTH = 16`
                    ^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`parameter int WIDTH`
 
          ) sub (
            ^^^ Sym sub : HierarchicalInstance
 
             .clk(clk),
-             ^^^ Ref -> `// In NoDefaults.gen_loop[0].sub`\n\\n\---\n\\n\`input logic clk`
+             ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic clk`
                  ^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic clk`
 
             .rst(rst),
-             ^^^ Ref -> `// In NoDefaults.gen_loop[0].sub`\n\\n\---\n\\n\`input logic rst`
+             ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic rst`
                  ^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic rst`
 
             .data_in(data_in),
-             ^^^^^^^ Ref -> `// In NoDefaults.gen_loop[0].sub`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+             ^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
                      ^^^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
 
             .data_out(data_out)
-             ^^^^^^^^ Ref -> `// In NoDefaults.gen_loop[0].sub`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+             ^^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
                       ^^^^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
 
         );
@@ -570,26 +570,26 @@ module NoDefaults #(
         ^^^ Ref -> `module Sub #(\n\    parameter int WIDTH = 16\n\)(\n\    input logic clk,\n\    input logic rst,\n\    input logic [WIDTH-1:0] data_in,\n\    output logic [WIDTH-1:0] data_out\n\);`
 
             .WIDTH(WIDTH)
-             ^^^^^ Ref -> `// In NoDefaults.gen_branch_block.sub_branch`\n\\n\---\n\\n\`parameter int WIDTH = 16`
+             ^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`parameter int WIDTH = 16`
                    ^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`parameter int WIDTH`
 
         ) sub_branch (
           ^^^^^^^^^^ Sym sub_branch : HierarchicalInstance
 
             .clk(clk),
-             ^^^ Ref -> `// In NoDefaults.gen_branch_block.sub_branch`\n\\n\---\n\\n\`input logic clk`
+             ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic clk`
                  ^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic clk`
 
             .rst(rst),
-             ^^^ Ref -> `// In NoDefaults.gen_branch_block.sub_branch`\n\\n\---\n\\n\`input logic rst`
+             ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic rst`
                  ^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic rst`
 
             .data_in(data_in),
-             ^^^^^^^ Ref -> `// In NoDefaults.gen_branch_block.sub_branch`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+             ^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
                      ^^^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
 
             .data_out(data_out)
-             ^^^^^^^^ Ref -> `// In NoDefaults.gen_branch_block.sub_branch`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+             ^^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
                       ^^^^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
 
         );
@@ -601,26 +601,26 @@ module NoDefaults #(
         ^^^ Ref -> `module Sub #(\n\    parameter int WIDTH = 16\n\)(\n\    input logic clk,\n\    input logic rst,\n\    input logic [WIDTH-1:0] data_in,\n\    output logic [WIDTH-1:0] data_out\n\);`
 
             .WIDTH(WIDTH)
-             ^^^^^ Ref -> `// In NoDefaults.gen_no_branch_block.sub_no_branch`\n\\n\---\n\\n\`parameter int WIDTH = 16`
+             ^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`parameter int WIDTH = 16`
                    ^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`parameter int WIDTH`
 
         ) sub_no_branch (
           ^^^^^^^^^^^^^ Sym sub_no_branch : HierarchicalInstance
 
             .clk(clk),
-             ^^^ Ref -> `// In NoDefaults.gen_no_branch_block.sub_no_branch`\n\\n\---\n\\n\`input logic clk`
+             ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic clk`
                  ^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic clk`
 
             .rst(rst),
-             ^^^ Ref -> `// In NoDefaults.gen_no_branch_block.sub_no_branch`\n\\n\---\n\\n\`input logic rst`
+             ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic rst`
                  ^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic rst`
 
             .data_in(data_in),
-             ^^^^^^^ Ref -> `// In NoDefaults.gen_no_branch_block.sub_no_branch`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+             ^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
                      ^^^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
 
             .data_out(data_out)
-             ^^^^^^^^ Ref -> `// In NoDefaults.gen_no_branch_block.sub_no_branch`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+             ^^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
                       ^^^^^^^^ Ref -> `// In NoDefaults`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
 
         );

--- a/tests/cpp/golden/HierarchicalStructCompletion.json
+++ b/tests/cpp/golden/HierarchicalStructCompletion.json
@@ -5,7 +5,7 @@
         "label": "addr",
         "labelDetails": {
           "detail": " logic[7:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "addr"
@@ -14,7 +14,7 @@
         "label": "data",
         "labelDetails": {
           "detail": " logic[31:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "data"
@@ -23,7 +23,7 @@
         "label": "valid",
         "labelDetails": {
           "detail": " logic",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "valid"
@@ -36,7 +36,7 @@
         "label": "inner",
         "labelDetails": {
           "detail": " simple_struct_t",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "inner"
@@ -45,7 +45,7 @@
         "label": "tag",
         "labelDetails": {
           "detail": " logic[15:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "tag"
@@ -54,7 +54,7 @@
         "label": "ready",
         "labelDetails": {
           "detail": " logic",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "ready"
@@ -67,7 +67,7 @@
         "label": "level1",
         "labelDetails": {
           "detail": " nested_struct_t",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "level1"
@@ -76,7 +76,7 @@
         "label": "id",
         "labelDetails": {
           "detail": " logic[3:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "id"
@@ -85,7 +85,7 @@
         "label": "enable",
         "labelDetails": {
           "detail": " logic",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "enable"
@@ -98,7 +98,7 @@
         "label": "addr",
         "labelDetails": {
           "detail": " logic[7:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "addr"
@@ -107,7 +107,7 @@
         "label": "data",
         "labelDetails": {
           "detail": " logic[31:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "data"
@@ -116,7 +116,7 @@
         "label": "valid",
         "labelDetails": {
           "detail": " logic",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "valid"
@@ -129,7 +129,7 @@
         "label": "inner",
         "labelDetails": {
           "detail": " simple_struct_t",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "inner"
@@ -138,7 +138,7 @@
         "label": "tag",
         "labelDetails": {
           "detail": " logic[15:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "tag"
@@ -147,7 +147,7 @@
         "label": "ready",
         "labelDetails": {
           "detail": " logic",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "ready"
@@ -160,7 +160,7 @@
         "label": "addr",
         "labelDetails": {
           "detail": " logic[7:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "addr"
@@ -169,7 +169,7 @@
         "label": "data",
         "labelDetails": {
           "detail": " logic[31:0]",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "data"
@@ -178,7 +178,7 @@
         "label": "valid",
         "labelDetails": {
           "detail": " logic",
-          "description": "$unit"
+          "description": ""
         },
         "kind": "Property",
         "filterText": "valid"


### PR DESCRIPTION
Stacked PRs:
 * #54
 * #53
 * __->__#52


--- --- ---

### use lexical path for scope info in hovers and completions

These are much more useful, and also allow us to take out the $unit check.

commit-id:96f73c0f
