### PR TITLE
vaporview integration

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -46,5 +46,8 @@ jobs:
       # - name: Publish to Open Vsix
       #   working-directory: clients/vscode
       #   run: npx ovsx publish ${{ inputs.prerelease && '--pre-release' || '' }} --pat ${{ secrets.OPEN_VSX_TOKEN }}
-      - name: Push changes
-        run: git push
+      - name: Commit and push version bump
+        run: |
+          git add clients/vscode/package.json
+          git commit -m "Published vscode extension version $(jq -r .version clients/vscode/package.json)"
+          git push

--- a/clients/vscode/CONFIG.md
+++ b/clients/vscode/CONFIG.md
@@ -24,7 +24,7 @@
 
     mac:     `slang-server`
 
-  windows: `slang-server.exe`
+    windows: `slang-server.exe`
 
 - `slang.args`: array = []
 

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-slang",
   "displayName": "slang-server: Verilog/SystemVerilog LSP",
   "description": "Verilog and SystemVerilog support via the slang language server.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "Hudson-River-Trading",
   "keywords": [
     "verilog",
@@ -314,13 +314,21 @@
       {
         "command": "slang.project.instancesView.copyHierarchyPath",
         "title": "Copy Path",
-        "inlineContext": [
+        "viewItems": [
           "Instance"
         ],
-        "icon": {
-          "light": "./resources/light/files.svg",
-          "dark": "./resources/dark/files.svg"
-        }
+        "icon": "$(files)",
+        "isSubmenu": true,
+        "keybind": "cmd+c"
+      },
+      {
+        "command": "slang.project.instancesView.showInWaveform",
+        "title": "Show in Waveform",
+        "viewItems": [
+          "Instance"
+        ],
+        "icon": "$(graph-line)",
+        "keybind": "w"
       },
       {
         "command": "slang.project.setTopLevel",
@@ -333,18 +341,36 @@
         "icon": "$(chip)"
       },
       {
+        "command": "slang.project.selectTopLevel",
+        "title": "Slang: Select Top Level",
+        "shortTitle": "Select Top"
+      },
+      {
         "command": "slang.project.clearTopLevel",
         "title": "Clear Top Level",
         "icon": "$(panel-close)"
+      },
+      {
+        "command": "slang.project.fuzzyFindInstance",
+        "title": "Fuzzy Find Instances",
+        "icon": "$(search-view-icon)",
+        "keybind": "cmd+f",
+        "keybindContainer": true
       },
       {
         "command": "slang.project.setInstance",
         "title": "Slang: Select Instance"
       },
       {
+        "command": "slang.project.showBuildFile",
+        "title": "Slang: Open Build File",
+        "icon": "$(file)",
+        "shown": true
+      },
+      {
         "command": "slang.project.selectBuildFile",
         "title": "Slang: Select build file",
-        "icon": "$(file-code)",
+        "icon": "$(file-directory)",
         "shown": true
       },
       {
@@ -365,7 +391,7 @@
       {
         "command": "slang.project.showSourceFile",
         "title": "Show Module",
-        "inlineContext": [
+        "viewItems": [
           "Module"
         ],
         "icon": {
@@ -374,13 +400,37 @@
         }
       },
       {
+        "command": "slang.project.showInWaveform",
+        "title": "Show in Waveform",
+        "icon": "$(graph-line)",
+        "keybind": "w"
+      },
+      {
+        "command": "slang.project.showInEditorFromNetlist",
+        "title": "Show in Editor",
+        "icon": "$(file-code)",
+        "viewOverride": "waveformViewerNetlistView",
+        "keybind": "e"
+      },
+      {
+        "command": "slang.project.showInEditorFromVaporview",
+        "title": "Show in Editor",
+        "icon": "$(file-code)",
+        "group": "2_variables@2.1",
+        "editorId": "vaporview.waveformViewer",
+        "webviewSection": "signal",
+        "keybind": "e"
+      },
+      {
         "command": "slang.project.copyHierarchyPath",
         "title": "Copy Path",
-        "inlineContext": [],
+        "viewItems": [],
+        "isSubmenu": true,
         "icon": {
           "light": "./resources/light/files.svg",
           "dark": "./resources/dark/files.svg"
-        }
+        },
+        "keybind": "cmd+c"
       },
       {
         "command": "slang.rewrite",
@@ -441,6 +491,16 @@
           "when": "view == slang.project"
         },
         {
+          "command": "slang.project.fuzzyFindInstance",
+          "group": "navigation",
+          "when": "view == slang.project"
+        },
+        {
+          "command": "slang.project.showBuildFile",
+          "group": "navigation",
+          "when": "view == slang.project"
+        },
+        {
           "command": "slang.project.selectBuildFile",
           "group": "navigation",
           "when": "view == slang.project"
@@ -468,12 +528,27 @@
           "when": "view == slang.project && viewItem == Module"
         },
         {
-          "command": "slang.project.copyHierarchyPath",
+          "command": "slang.project.showInWaveform",
           "group": "inline",
           "when": "view == slang.project"
         },
         {
+          "command": "slang.project.showInEditorFromNetlist",
+          "group": "inline",
+          "when": "view == waveformViewerNetlistView"
+        },
+        {
+          "command": "slang.project.copyHierarchyPath",
+          "group": "submenu@4",
+          "when": "view == slang.project"
+        },
+        {
           "command": "slang.project.instancesView.copyHierarchyPath",
+          "group": "submenu@5",
+          "when": "view == slang.project.instancesView && viewItem == Instance"
+        },
+        {
+          "command": "slang.project.instancesView.showInWaveform",
           "group": "inline",
           "when": "view == slang.project.instancesView && viewItem == Instance"
         }
@@ -489,8 +564,55 @@
           "when": "resourceLangId == verilog || resourceLangId == systemverilog",
           "group": "navigation"
         }
+      ],
+      "webview/context": [
+        {
+          "command": "slang.project.showInEditorFromVaporview",
+          "group": "2_variables@2.1",
+          "when": "activeCustomEditorId == vaporview.waveformViewer && webviewSection == signal"
+        }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "key": "ctrl+f",
+        "command": "slang.project.fuzzyFindInstance",
+        "when": "sideBarFocus && activeViewlet == workbench.view.extension.slang && !inputFocus",
+        "mac": "cmd+f"
+      },
+      {
+        "key": "w",
+        "command": "slang.project.showInWaveform",
+        "when": "focusedView == slang.project && !inputFocus"
+      },
+      {
+        "key": "e",
+        "command": "slang.project.showInEditorFromNetlist",
+        "when": "focusedView == waveformViewerNetlistView && !inputFocus"
+      },
+      {
+        "key": "e",
+        "command": "slang.project.showInEditorFromVaporview",
+        "when": "activeCustomEditorId == vaporview.waveformViewer && !inputFocus"
+      },
+      {
+        "key": "ctrl+c",
+        "command": "slang.project.copyHierarchyPath",
+        "when": "focusedView == slang.project && !inputFocus",
+        "mac": "cmd+c"
+      },
+      {
+        "key": "ctrl+c",
+        "command": "slang.project.instancesView.copyHierarchyPath",
+        "when": "focusedView == slang.project.instancesView && !inputFocus",
+        "mac": "cmd+c"
+      },
+      {
+        "key": "w",
+        "command": "slang.project.instancesView.showInWaveform",
+        "when": "focusedView == slang.project.instancesView && !inputFocus"
+      }
+    ]
   },
   "scripts": {
     "clean": "rm -rf out dist .vscode-test",
@@ -515,7 +637,7 @@
     "lint": "pnpm lint:ts",
     "pretest": "pnpm clean:light && pnpm build-tests && pnpm build && pnpm lint",
     "syntax": "js-yaml ./languages/sv/systemverilog.tmLanguage.yaml > ./languages/sv/systemverilog.tmLanguage.json",
-    "genconfig": "slang-server --config-schema > src/config.schema.json && npx json2ts -i src/config.schema.json -o src/config.gen.ts"
+    "genconfig": "../../build/bin/slang-server --config-schema > resources/config.schema.json && npx json2ts -i resources/config.schema.json -o src/config.gen.ts"
   },
   "dependencies": {
     "js-yaml": "^4.1.0",

--- a/clients/vscode/resources/config.schema.json
+++ b/clients/vscode/resources/config.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$ref": "#/definitions/Config",
-  "definitions": {
+  "$ref": "#/$defs/Config",
+  "$defs": {
     "Config": {
       "type": "object",
       "properties": {
@@ -43,7 +43,18 @@
           ]
         },
         "buildPattern": {
-          "description": "Build file pattern, ex builds/{}.f",
+          "description": "Build file glob pattern, e.g. `builds/{}.f`. Used for selecting build files.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wavesPattern": {
+          "description": "Waveform file glob to open given a build. Name and top variables can be passed with {name}, {top})",
           "anyOf": [
             {
               "type": "string"
@@ -54,7 +65,7 @@
           ]
         },
         "wcpCommand": {
-          "description": "Waveform viewer command ({} will be replaced with the WCP port)",
+          "description": "Waveform viewer command ({} will be replaced with the WCP port), used for direct wcp connection with neovim and surfer.",
           "anyOf": [
             {
               "type": "string"

--- a/clients/vscode/scripts/copy_icon.py
+++ b/clients/vscode/scripts/copy_icon.py
@@ -2,12 +2,15 @@
 import subprocess
 import sys
 
+# See icons at https://code.visualstudio.com/api/references/icons-in-labels
+# Clone repo at https://github.com/microsoft/vscode-icons/tree/main/icons/light and VSCODE_ICON_REPO to the path
+
 
 def main():
     icon = sys.argv[1]
     for scheme in ["light", "dark"]:
         subprocess.run(
-            f"cp $VSCODE_ICON_REPO/icons/{scheme}/{icon}.svg resources/{scheme}/",
+            f"cp $VSCODE_ICON_REPO/icons/{scheme}/{icon}.svg clients/vscode/resources/{scheme}/",
             shell=True,
         )
 

--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -133,6 +133,10 @@ export async function getInstancesOfModule(declName: string): Promise<QualifiedI
 export async function getFilesContainingModule(moduleName: string): Promise<string[]> {
   return await vscode.commands.executeCommand('slang.getFilesContainingModule', moduleName)
 }
+
+export async function getModulesInFile(fsPath: string): Promise<string[]> {
+  return await vscode.commands.executeCommand('slang.getModulesInFile', fsPath)
+}
 ////////////////////////////////////////////////////////////
 /// server -> client is in commands in the project component
 ////////////////////////////////////////////////////////////

--- a/clients/vscode/src/config.gen.ts
+++ b/clients/vscode/src/config.gen.ts
@@ -8,37 +8,37 @@ export interface ConfigSchema {
   /**
    * Flags to pass to slang
    */
-  flags?: string | null
+  flags?: string
   /**
-   * Globs of what to index
+   * Globs of what to index. By default will index all sv and svh files in the workspace.
    */
-  indexGlobs?: string[] | null
+  indexGlobs?: string[]
   /**
    * Directories to exclude
    */
-  excludeDirs?: string[] | null
-  /**
-   * Globs for build.f files
-   */
-  buildGlobs?: string[] | null
+  excludeDirs?: string[]
   /**
    * Thread count to use for indexing
    */
-  indexingThreads?: number | null
+  indexingThreads?: number
   /**
    * Thread count to use for parsing
    */
-  parsingThreads?: number | null
+  parsingThreads?: number
   /**
-   * Build file
+   * Build file to use
    */
   build?: string | null
   /**
-   * Waveform to build file pattern
+   * Build file glob pattern, e.g. `builds/{}.f`. Used for selecting build files.
    */
   buildPattern?: string | null
   /**
-   * Waveform viewer command ({} will be replaced with the WCP port)
+   * Waveform file glob to open given a build. Name and top variables can be passed with {name}, {top})
+   */
+  wavesPattern?: string | null
+  /**
+   * Waveform viewer command ({} will be replaced with the WCP port), used for direct wcp connection with neovim and surfer.
    */
   wcpCommand?: string | null
   [k: string]: unknown

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -2,9 +2,10 @@
 import * as vscode from 'vscode'
 
 import * as child_process from 'child_process'
-import { glob } from 'glob'
+
 import path from 'path'
 import * as process from 'process'
+
 import * as vscodelc from 'vscode-languageclient/node'
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node'
 import { ExternalFormatter } from './ExternalFormatter'
@@ -20,6 +21,7 @@ import {
 import { ProjectComponent } from './sidebar/ProjectComponent'
 import * as slang from './SlangInterface'
 import { anyVerilogSelector, getWorkspaceFolder } from './utils'
+import { glob } from 'glob'
 
 export var ext: SlangExtension
 

--- a/clients/vscode/src/sidebar/VaporviewApi.ts
+++ b/clients/vscode/src/sidebar/VaporviewApi.ts
@@ -1,0 +1,283 @@
+/**
+ * Vaporview API TypeScript Functions
+ *
+ * Async wrapper functions for the Vaporview waveform viewer VSCode extension API
+ * Based on: https://github.com/Lramseyer/vaporview/blob/main/API_DOCS.md
+ */
+
+import * as vscode from 'vscode'
+import { setTimeout } from 'timers'
+import { URLSearchParams } from 'url'
+
+/**
+ * Opens a waveform dump file with Vaporview
+ */
+export async function openFile(args: {
+  uri: vscode.Uri
+  loadAll?: boolean
+  maxSignals?: number
+}): Promise<void> {
+  await vscode.commands.executeCommand('vaporview.openFile', args)
+  // Subsequent commands may fail if executed too quickly :(
+  await new Promise((r) => setTimeout(r, 200))
+}
+
+/**
+ * Variable identifier - must specify at least one of:
+ * 1. netlistId
+ * 2. instancePath
+ * 3. scopePath AND name
+ */
+export interface VariableIdentifier {
+  uri?: vscode.Uri
+  netlistId?: number
+  instancePath?: string
+  scopePath?: string
+  name?: string
+  msb?: number
+  lsb?: number
+}
+
+/**
+ * Add a variable to the waveform viewer
+ */
+export async function addVariable(args: VariableIdentifier): Promise<void> {
+  await vscode.commands.executeCommand('waveformViewer.addVariable', args)
+}
+
+/**
+ * Remove a variable from the waveform viewer
+ */
+export async function removeVariable(args: VariableIdentifier): Promise<void> {
+  await vscode.commands.executeCommand('waveformViewer.removeVariable', args)
+}
+
+/**
+ * Reveal a variable or scope in the netlist view
+ */
+export async function revealVariableInNetlistView(args: VariableIdentifier): Promise<void> {
+  await vscode.commands.executeCommand('waveformViewer.revealVariableInNetlistView', args)
+}
+
+export type TimeUnit = 'fs' | 'ps' | 'ns' | 'us' | 'µs' | 'ms' | 's' | 'ks'
+export type MarkerType = 0 | 1 // 0: Main Marker, 1: Alt Marker
+
+/**
+ * Set the marker or alt marker to a specific time in the viewer
+ */
+export async function setMarker(args: {
+  uri?: vscode.Uri
+  time: number
+  units?: TimeUnit
+  markerType?: MarkerType
+}): Promise<void> {
+  await vscode.commands.executeCommand('waveformViewer.setMarker', args)
+}
+
+/**
+ * Get a list of open waveform viewer documents
+ */
+export async function getOpenDocuments(): Promise<{
+  documents: vscode.Uri[]
+  lastActiveDocument: vscode.Uri
+}> {
+  return await vscode.commands.executeCommand('waveformViewer.getOpenDocuments')
+}
+
+/**
+ * Get the viewer state/settings in the same schema as the save file
+ */
+export async function getViewerState(uri?: vscode.Uri): Promise<ViewerSettings> {
+  return await vscode.commands.executeCommand('waveformViewer.getViewerState', { uri })
+}
+
+/**
+ * Get signal values at a specific time
+ *
+ * If time is not specified, uses the marker time for the document
+ */
+export async function getValuesAtTime(args: {
+  uri?: vscode.Uri
+  time?: number
+  instancePaths: string[]
+}): Promise<
+  Array<{
+    instancePath: string
+    value: any[] // [current value] or [previous value, current value]
+  }>
+> {
+  return await vscode.commands.executeCommand('waveformViewer.getValuesAtTime', args)
+}
+
+/**
+ * Add a signal value link that emits a custom command when clicked
+ */
+export async function addSignalValueLink(
+  args: VariableIdentifier & {
+    command: string
+  }
+): Promise<void> {
+  await vscode.commands.executeCommand('waveformViewer.addSignalValueLink', args)
+}
+
+let vaporviewExtension: vscode.Extension<VaporViewAPI> | null = null
+let onLoad: ((api: VaporViewAPI) => Promise<void>) | null = null
+
+export async function getVaporviewExtension(): Promise<vscode.Extension<VaporViewAPI> | undefined> {
+  if (vaporviewExtension) {
+    return vaporviewExtension
+  }
+  const vvExt = vscode.extensions.getExtension('lramseyer.vaporview')
+
+  if (!vvExt) {
+    const installCmd = vscode.Uri.parse('vscode:extension/Lramseyer.vaporview')
+    vscode.commands.executeCommand('vscode.open', installCmd)
+    vscode.window.showInformationMessage(
+      'Vaporview extension not found, please install for waveform features.'
+    )
+    return undefined
+  }
+
+  if (!vvExt.isActive) {
+    await vvExt.activate()
+  }
+
+  vaporviewExtension = vvExt
+  if (onLoad !== null) {
+    void onLoad(vvExt.exports)
+  }
+  return vvExt
+}
+
+// Use this to register vaporview subscriptions
+export async function onExtensionActivated(
+  func: (api: VaporViewAPI) => Promise<void>
+): Promise<void> {
+  onLoad = func
+}
+
+export interface ViewerSettings {
+  extensionVersion: string | undefined
+  fileName: string
+  markerTime: number | null
+  altMarkerTime: number | null
+  selectedSignal: {
+    name: string
+    numberFormat: string | undefined
+    msb: number | undefined
+    lsb: number | undefined
+  } | null
+  zoomRatio: number
+  scrollLeft: number
+  displayedSignals: any[]
+}
+
+/**
+ * The Vaporview Subscriptions API, from the repo
+ */
+export interface markerSetEvent {
+  uri: string
+  time: number
+  units: string
+}
+
+export type EventSource = 'netlistView' | 'viewer'
+
+export interface signalEvent {
+  uri: string
+  instancePath: string
+  netlistId: number
+  source: EventSource
+}
+
+export interface viewerDropEvent {
+  uri: string
+  resourceUriList: vscode.Uri[]
+  groupPath: string[]
+  index: number
+}
+
+export interface NetlistTreeItemData {
+  collapsibleState: vscode.TreeItemCollapsibleState
+  label: string
+  _onDidChangeCheckboxState?: { A: number }
+  numberFormat?: 'hexadecimal' | 'decimal' | 'binary' | 'octal'
+  fsdbVarLoaded?: boolean
+  resourceUri?: vscode.Uri
+  type: 'module' | 'wire' | 'reg' | 'logic' | string
+  encoding?: 'none' | string
+  width: number
+  signalId: number
+  netlistId: number
+  name: string
+  scopePath: string // this plus name is the full path
+  msb: number
+  lsb: number
+  scopeOffsetIdx: number
+  children: NetlistTreeItemData[]
+  tooltip?: string
+  contextValue?: string
+  iconPath?: vscode.ThemeIcon
+}
+
+export interface VaporViewAPI {
+  onDidSetMarker: vscode.Event<markerSetEvent>
+  onDidSelectSignal: vscode.Event<signalEvent>
+  onDidAddVariable: vscode.Event<signalEvent>
+  onDidRemoveVariable: vscode.Event<signalEvent>
+  onDidDropInWaveformViewer: vscode.Event<viewerDropEvent>
+}
+
+/**
+ * Message received from Vaporview webview events
+ */
+export interface SignalItemData {
+  preventDefaultContextMenuItems: boolean
+  webviewSelection: boolean
+  uri: {
+    $mid: number
+    path: string
+    scheme: string
+  }
+  webviewSection: string
+  scopePath: string
+  signalName: string
+  type: string
+  width: number
+  commandValid: boolean
+  netlistId: number
+  isAnalog: boolean
+  webview: string
+}
+
+export interface DecodedNetlistUri {
+  fsPath: string
+  path: string
+  scopeId?: string
+  id?: number
+}
+
+export function decodeNetlistUri(uri: vscode.Uri): DecodedNetlistUri {
+  if (uri.scheme !== 'waveform') {
+    throw new Error('Not a waveform URI')
+  }
+  const path = uri.path
+  const query = uri.fragment
+  const params = new URLSearchParams(query)
+  const result: DecodedNetlistUri = { fsPath: path, path: '' }
+
+  const scope = params.get('scope')
+  const net = params.get('net')
+  const id = params.get('id')
+
+  if (scope) {
+    result.scopeId = decodeURIComponent(scope)
+  }
+  if (net) {
+    result.path = decodeURIComponent(net)
+  }
+  if (id) {
+    result.id = parseInt(id)
+  }
+  return result
+}

--- a/clients/vscode/src/utils.ts
+++ b/clients/vscode/src/utils.ts
@@ -86,6 +86,13 @@ export function getAbsPath(inputPath: string): string {
   return path.join(wspath, inputPath)
 }
 
+export function getIcons(name: string) {
+  return {
+    light: `./resources/light/${name}.svg`,
+    dark: `./resources/dark/${name}.svg`,
+  }
+}
+
 export class FileDiagnostic extends vscode.Diagnostic {
   file: string
   constructor(
@@ -156,6 +163,15 @@ export function zip<T, U>(a: T[], b: U[]): [T, U][] {
 
 export function pathFilename(uri: vscode.Uri): string {
   return path.basename(uri.fsPath, path.extname(uri.fsPath))
+}
+
+/**
+ * Get the basename of a path without extension
+ * @param filePath - Path string to extract basename from
+ * @returns The basename without extension, or undefined if not found
+ */
+export function getBasename(filePath: string): string | undefined {
+  return filePath.split(/[\\/]/).pop()?.split('.')[0]
 }
 
 // end position in line

--- a/include/Config.h
+++ b/include/Config.h
@@ -7,8 +7,8 @@
 //------------------------------------------------------------------------------
 #pragma once
 #include "rfl/Description.hpp"
+#include <optional>
 #include <rfl/Result.hpp>
-
 /// A singleton to hold global configuration options.
 class SlangLspClient;
 class Config {
@@ -40,8 +40,15 @@ public:
     rfl::Description<"Thread count to use for indexing", int> indexingThreads = 0;
     rfl::Description<"Thread count to use for parsing", int> parsingThreads = 8;
     rfl::Description<"Build file to use", std::optional<std::string>> build;
-    rfl::Description<"Build file pattern, ex builds/{}.f", std::optional<std::string>> buildPattern;
-    rfl::Description<"Waveform viewer command ({} will be replaced with the WCP port)",
+    rfl::Description<"Build file glob pattern, e.g. `builds/{}.f`. Used for selecting build files.",
+                     std::optional<std::string>>
+        buildPattern;
+    rfl::Description<"Waveform file glob to open given a build. Name and top variables can be "
+                     "passed with {name}, {top})",
+                     std::optional<std::string>>
+        wavesPattern;
+    rfl::Description<"Waveform viewer command ({} will be replaced with the WCP port), used for "
+                     "direct wcp connection with neovim and surfer.",
                      std::optional<std::string>>
         wcpCommand;
 

--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -87,6 +87,8 @@ public:
 
     std::vector<std::shared_ptr<SlangDoc>> getDependentDocs(std::shared_ptr<SyntaxTree> tree);
 
+    std::vector<std::string> getModulesInFile(const std::string& path);
+
     /// @brief Creates a compilation from the given URI and top module name.
     /// @return True if the compilation was created successfully
     bool createCompilation(const URI& uri, std::string_view top);

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -116,6 +116,9 @@ public:
     // Returns the instances of a module
     std::vector<hier::QualifiedInstance> getInstancesOfModule(const std::string moduleName);
 
+    // Returns the modules defined in a file, used for the modules view
+    std::vector<std::string> getModulesInFile(const std::string path);
+
     // Returns the files that contain a specific module, used for terminal links
     std::vector<std::string> getFilesContainingModule(const std::string moduleName);
 

--- a/src/ServerDiagClient.cpp
+++ b/src/ServerDiagClient.cpp
@@ -113,7 +113,7 @@ void ServerDiagClient::report(const slang::ReportedDiagnostic& diag) {
                     totalRange.end() = std::max(totalRange.end(), loc);
                 }
             }
-            return toLocation(m_sourceManager.getFullyOriginalRange(totalRange), m_sourceManager);
+            return toLocation(totalRange, m_sourceManager);
         }
         return std::nullopt;
     };

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -231,6 +231,29 @@ std::vector<std::shared_ptr<SlangDoc>> ServerDriver::getDependentDocs(
     return result;
 }
 
+std::vector<std::string> ServerDriver::getModulesInFile(const std::string& path) {
+    // Find the document
+    auto uri = URI::fromFile(path);
+    auto it = docs.find(uri);
+    if (it == docs.end()) {
+        WARN("Document {} not found", path);
+        return {};
+    }
+
+    auto& doc = it->second;
+
+    // Get the module-like things from the document and collect into a vector
+    std::vector<std::string> moduleNames;
+    for (auto& name : doc->getSyntaxTree()->getMetadata().getDeclaredSymbols()) {
+        moduleNames.push_back(std::string{name});
+    }
+    if (moduleNames.empty()) {
+        WARN("No modules found in file {}", path);
+    }
+    INFO("Found {} modules in file {}", moduleNames.size(), path);
+    return moduleNames;
+}
+
 bool ServerDriver::createCompilation(const URI& uri, std::string_view top) {
     // Find the document
     auto it = docs.find(uri);

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -92,6 +92,9 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     // WCP Commands
     registerCommand<lsp::TextDocumentPositionParams, std::vector<std::string>,
                     &SlangServer::getInstances>("slang.getInstances");
+
+    registerCommand<std::string, std::vector<std::string>, &SlangServer::getModulesInFile>(
+        "slang.getModulesInFile");
     registerCommand<waves::ItemToWaveform, std::monostate, &SlangServer::addToWaveform>(
         "slang.addToWaveform");
     registerCommand<std::string, std::monostate, &SlangServer::openWaveform>("slang.openWaveform");
@@ -291,6 +294,11 @@ std::vector<std::string> SlangServer::getInstances(const lsp::TextDocumentPositi
         return {};
     }
     return m_driver->comp->getInstances(params);
+}
+
+std::vector<std::string> SlangServer::getModulesInFile(const std::string path) {
+    // just use the shallow compilation
+    return m_driver->getModulesInFile(path);
 }
 
 std::monostate SlangServer::addToWaveform(const waves::ItemToWaveform& params) {

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -36,7 +36,10 @@ int main(int argc, char** argv) {
     if (configSchema == true) {
         try {
             const std::string schema = rfl::json::to_schema<Config, rfl::DefaultIfMissing>(
-                rfl::json::pretty);
+                rfl::json::pretty | YYJSON_WRITE_PRETTY_TWO_SPACES
+                // Add this when comment support is added
+                // , "@generated from `include/Config.h`"
+            );
             OS::print(schema);
         }
         catch (const std::exception& e) {


### PR DESCRIPTION
### vaporview integration
  - In Vaporview, press 'e' on a selected signal, or use the buttons to open the corresponding filelist and go to that signal
  - In Slang's Hierarchy view, press 'w' or the buttons to open the corresponding waveform file and open in the waves
#### Button changes
  - Press `cmd+f` in the hierarchy or modules view to search for an instance in the design. Can also use the button to get to this command (magnifying glass)
  - Select buildfile button now looks like a folder
  - New 'Open buildfile' opens the current .f file. Saving this file will refresh a compilation. In the future this will also be generated for compilations set by top level, making it so that users can adjust the params and defines
  - "Copy Path" can be done now with either `cmd+c` or by right clicking on a signal
####  Backend fixes that apply to both vscode and neovim:
  - Type aliases and resolved types are shown in the hierarchy view
  - Macro defined symbols now show the proper locations of the macro usage that created them

