### PR TITLE
handle inst arrays

### DIFF
--- a/include/document/SymbolIndexer.h
+++ b/include/document/SymbolIndexer.h
@@ -46,6 +46,7 @@ public:
     const slang::ast::Scope* getScopeForSyntax(const slang::syntax::SyntaxNode& syntax) const;
 
     /// Module instances- module name, parameters, ports
+    void handle(const slang::ast::InstanceArraySymbol& sym);
     void handle(const slang::ast::InstanceSymbol& sym);
 
     /// Index ValueSymbol names
@@ -80,6 +81,12 @@ public:
         // Index symbol name for other symbol types
         visitDefault(astNode);
     }
+
+private:
+    /// Helper to index instance syntax (shared by InstanceSymbol and InstanceArraySymbol)
+    void indexInstanceSyntax(const slang::syntax::HierarchicalInstanceSyntax& instSyntax,
+                             const slang::ast::InstanceBodySymbol& instanceSymbol,
+                             const slang::ast::DefinitionSymbol& definition);
 };
 
 } // namespace server

--- a/tests/cpp/golden/FindSymbolRefHdl.out
+++ b/tests/cpp/golden/FindSymbolRefHdl.out
@@ -347,20 +347,25 @@ module TestModule #(
 
     Sub #(.WIDTH(16)) sub_inst [NUM_SUBS] (
     ^^^ Ref -> `module Sub #(\n\    parameter int WIDTH = 16\n\)(\n\    input logic clk,\n\    input logic rst,\n\    input logic [WIDTH-1:0] data_in,\n\    output logic [WIDTH-1:0] data_out\n\);`
+           ^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`parameter int WIDTH = 16`
                       ^^^^^^^^ Sym sub_inst : HierarchicalInstance
-                                ^^^^^^^^ Ref -> `// In TestModule`\n\\n\---\n\\n\`parameter int NUM_SUBS = 4`
+                                ^^^^^^^^ Ref -> `parameter int NUM_SUBS = 4`
 
         .clk(clk),
-             ^^^ Ref -> `// In TestModule`\n\\n\---\n\\n\`input logic clk`
+         ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic clk`
+             ^^^ Ref -> `input logic clk`
 
         .rst(rst),
-             ^^^ Ref -> `// In TestModule`\n\\n\---\n\\n\`input logic rst`
+         ^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic rst`
+             ^^^ Ref -> `input logic rst`
 
         .data_in(sub_data_in),
-                 ^^^^^^^^^^^ Ref -> `// In TestModule`\n\\n\---\n\\n\`// Instance array that depends on NUM_SUBS parameter\n\logic [15:0] sub_data_in [NUM_SUBS];`
+         ^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+                 ^^^^^^^^^^^ Ref -> `// Instance array that depends on NUM_SUBS parameter\n\logic [15:0] sub_data_in [NUM_SUBS];`
 
         .data_out(sub_data_out)
-                  ^^^^^^^^^^^^ Ref -> `// In TestModule`\n\\n\---\n\\n\`logic [15:0] sub_data_out [NUM_SUBS];`
+         ^^^^^^^^ Ref -> `// In Sub`\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+                  ^^^^^^^^^^^^ Ref -> `logic [15:0] sub_data_out [NUM_SUBS];`
 
     );
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#99
 * #98
 * #97


--- --- ---

### Handle instance arrays

Since parameters are invalid in some compilations, those symbols weren't being indexed. We can instead create a default instance, and use that for indexing the parameter and port maps.

