### PR TITLE
TCP_QUICKACK for WCP

### DIFF
--- a/src/ast/WcpClient.cpp
+++ b/src/ast/WcpClient.cpp
@@ -144,6 +144,11 @@ void waves::WcpClient::greet() {
         return;
     }
 
+#ifdef __linux__
+    int flag = 1;
+    setsockopt(m_clientFd, IPPROTO_TCP, TCP_QUICKACK, (char*)&flag, sizeof(int));
+#endif
+
     std::cerr << "WCP connection established" << std::endl;
 
     // Send greeting


### PR DESCRIPTION
Ran into some TCP deadlock with Surfer.  I think we can / should prevent this on the Surfer side too, but this is defensive against arbitrary WCP server wonkiness.