### PR TITLE
I have solved the path problem in windows, but it still doesn't get diagnostics

### DIFF
--- a/include/lsp/URI.h
+++ b/include/lsp/URI.h
@@ -46,6 +46,27 @@ public:
         return std::string_view(underlying_).substr(7);
     }
 
+    /// Decode URL-encoded path (e.g., "%3A" -> ":")
+    static std::string decodeURIComponent(std::string_view encoded) {
+        std::string decoded;
+        decoded.reserve(encoded.size());
+        for (size_t i = 0; i < encoded.size(); ++i) {
+            if (encoded[i] == '%' && i + 2 < encoded.size()) {
+                // Decode %XX hex sequence
+                char hex[3] = {encoded[i + 1], encoded[i + 2], 0};
+                char* end;
+                long value = std::strtol(hex, &end, 16);
+                if (end == hex + 2) {
+                    decoded += static_cast<char>(value);
+                    i += 2;
+                    continue;
+                }
+            }
+            decoded += encoded[i];
+        }
+        return decoded;
+    }
+
     static URI fromFile(const std::filesystem::path& file) { return URI("file", file.string()); }
 
     static URI fromWeb(std::string_view path) { return URI("https", std::string(path)); }


### PR DESCRIPTION
 _Originally posted by @AndrewNolte in [#115](https://github.com/hudson-trading/slang-server/issues/115#issuecomment-3533202370)_

https://github.com/hudson-trading/slang-server/issues/115#issuecomment-3532544650

Registered method: initialize
<--- initialize 0
Registered notification: textDocument/didOpen
Registered notification: textDocument/didChange
Registered notification: textDocument/didSave
Registered notification: textDocument/didClose
Registered method: textDocument/definition
Registered method: textDocument/hover
Registered method: textDocument/documentSymbol
Registered method: textDocument/documentLink
Registered method: textDocument/completion
Registered method: completionItem/resolve
Registered method: textDocument/prepareCallHierarchy
Registered method: callHierarchy/incomingCalls
Registered method: callHierarchy/outgoingCalls
Registered method: workspace/executeCommand
Registered method: workspace/symbol
Registered notification: initialized
INFO: Server started with pid: 34844
Registered command: slang.setTopLevel
Registered command: slang.setBuildFile
Registered command: slang.getInstances
Registered command: slang.getModulesInFile
Registered command: slang.addToWaveform
Registered command: slang.openWaveform
Registered command: slang.getScope
Registered command: slang.getFilesContainingModule
Registered command: slang.getScopesByModule
Registered command: slang.getInstancesOfModule
Registered command: slang.expandMacros
INFO: Using workspace folder: d:/temp/verilog
INFO: Layering config from d:/temp/verilog\.slang\server.json
WARN: Config file d:/temp/verilog\.slang\local\server.json does not exist, skipping
INFO: Creating ServerDriver with 0 trees
INFO: Updating index globs
INFO: Indexing with globs: ./.../*.sv*
INFO: Globbing ./.../*.sv*...
INFO: found 3 files 
INFO: Globbing ./.../*.sv* took 0.000s
Indexing 3 total files
INFO: Slang Indexing...
INFO: Slang Indexing took 0.003s
INFO: Indexing complete.
INFO: Total symbols: 3
INFO: Total Macros: 0
INFO: Approximate size: 528 Bytes
---> slang/setConfig
INFO: Initialize result: {"capabilities":{"textDocumentSync":{"openClose":true,"change":"Incremental","save":{"includeText":true}},"completionProvider":{"triggerCharacters":["`","#",".","(",":","["],"resolveProvider":true,"completionItem":{"labelDetailsSupport":true}},"hoverProvider":true,"definitionProvider":true,"documentSymbolProvider":true,"documentLinkProvider":{"resolveProvider":false,"workDoneProgress":false},"workspaceSymbolProvider":true,"executeCommandProvider":{"commands":["slang.openWaveform","slang.setTopLevel","slang.setBuildFile","slang.getInstances","slang.getModulesInFile","slang.getScope","slang.addToWaveform","slang.getFilesContainingModule","slang.getScopesByModule","slang.getInstancesOfModule","slang.expandMacros"]},"callHierarchyProvider":true},"serverInfo":{"name":"slang-server","version":"0.2.0+4605db4\n"}} 
---> initialize 0