### PR TITLE
Build/Release CI: Fix mac and linux releases; adjust build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,18 +40,18 @@ jobs:
         include:
           - preset: clang-release
             os: ubuntu-latest
+            container: rockylinux:8
             artifact_name: slang-server-linux-x64-clang
-          - preset: clang-release
+            extra_flags: -DCMAKE_CXX_COMPILER=clang++
+          - preset: gcc-release
             os: ubuntu-latest
             container: rockylinux:8
-            artifact_name: slang-server-rockylinux-x64
-            extra_flags: -DCMAKE_CXX_COMPILER=clang++-19
-          - preset: gcc-release
-            os: ubuntu-24.04-arm
-            artifact_name: slang-server-linux-arm64
+            artifact_name: slang-server-linux-x64-gcc
+            extra_flags: -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++
           - preset: macos-release
-            os: macos-latest
+            os: macos-15
             artifact_name: slang-server-macos
+            extra_flags: -DCMAKE_CXX_COMPILER=clang++
           - preset: win64-release
             os: windows-latest
             artifact_name: slang-server-windows-x64
@@ -72,19 +72,10 @@ jobs:
         ref: ${{ inputs.ref || github.ref }}
         submodules: true
         fetch-depth: 0
-    - name: Install dependencies (Ubuntu x64 Clang)
-      if: matrix.os == 'ubuntu-latest' && matrix.container != 'rockylinux:8'
-      run: |
-        # Add LLVM repository using modern method
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm.asc
-        echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update
-        sudo apt-get install -y g++-14 g++-11 clang-20 clang-tidy-20
     - uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
     - uses: maxim-lobanov/setup-xcode@v1
-      if: matrix.os == 'macos-latest'
+      if: runner.os == 'macOS'
       with:
         xcode-version: 'latest'
     - name: Configure
@@ -94,7 +85,7 @@ jobs:
     - name: Run ctest
       run: ctest --test-dir build/${{ matrix.preset }} --output-on-failure --no-tests=error -j8
       # Don't run tests on windows
-      if: matrix.os != 'windows-latest'
+      if: runner.os != 'Windows'
     - name: Set up uv
       uses: astral-sh/setup-uv@v6
     - name: Run pytest (not Windows)
@@ -114,8 +105,8 @@ jobs:
             #        pytest tests\system\ --binary build\${{ matrix.preset }}\bin\slang-server
 
     # Artifact creation for releases
-    - name: Strip binary (Linux/macOS)
-      if: inputs.upload_artifacts && runner.os != 'Windows'
+    - name: Strip binary (Linux)
+      if: inputs.upload_artifacts && runner.os == 'Linux'
       run: strip build/${{ matrix.preset }}/bin/slang-server
 
     - name: Create artifact directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,18 @@ project(
   HOMEPAGE_URL https://github.com/hudson-trading/slang-server
   DESCRIPTION "SystemVerilog language server based on slang")
 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  # This ensures that *all* targets (including slang and reflect-cpp) use the
+  # default Apple C++ runtime, preventing dynamic link conflicts.
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -stdlib=libc++"
+      CACHE STRING "" FORCE)
+  set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++"
+      CACHE STRING "" FORCE)
+  message(STATUS "macOS build: Forcing use of libc++ standard library.")
+endif()
+
 option(SLANG_SERVER_INCLUDE_TESTS "Include test targets in the build"
        ${SLANG_SERVER_MASTER_PROJECT})
 option(SLANG_SERVER_INCLUDE_INSTALL "Include installation targets"
@@ -136,14 +148,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options(-Wmissing-include-dirs)
 endif()
 
-# Configure static linking of C++ standard library if requested
+# Configure static linking of C++ standard library if requested Note: macOS uses
+# system libc++ which can't be statically linked and is generally compatible
+# across versions
 if(SLANG_SERVER_STATIC_LINK_STDLIB)
-  if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    # On macOS, statically link libc++ (compiler-rt is already static by
-    # default)
-    add_link_options(-static-libstdc++)
-    message(STATUS "Static linking enabled for C++ standard library (libc++)")
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT CMAKE_SYSTEM_NAME
+                                                   MATCHES "Darwin")
     # On Linux, statically link libstdc++/libc++ and libgcc for better
     # portability
     add_link_options(-static-libstdc++ -static-libgcc)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -199,7 +199,9 @@
       ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "SLANG_SERVER_STATIC_LINK_STDLIB": "ON"
+        "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.0",
+        "CMAKE_CXX_COMPILER": "clang++"
       }
     }
   ]

--- a/src/ast/WcpClient.cpp
+++ b/src/ast/WcpClient.cpp
@@ -8,13 +8,13 @@
 
 #include "ast/WcpClient.h"
 
+#include "fmt/format.h"
 #include "rfl/UnderlyingEnums.hpp"
 #include "rfl/to_generic.hpp"
 #include "wcp/WcpTypes.h"
 #include <chrono>
 #include <csignal>
 #include <cstdlib>
-#include <format>
 #include <sstream>
 
 #ifdef _WIN32
@@ -32,7 +32,7 @@ namespace fs = std::filesystem;
 
 void waves::WcpClient::runViewer() {
 #ifdef _WIN32
-    std::string cmdLine = std::vformat(m_command, std::make_format_args(m_port));
+    std::string cmdLine = fmt::format(fmt::runtime(m_command), m_port);
 
     auto stdoutLog = fs::temp_directory_path();
     stdoutLog /= "slang-server.wcp.stdout";
@@ -82,7 +82,7 @@ void waves::WcpClient::runViewer() {
         }
 
         std::vector<char*> args;
-        std::stringstream ss(std::vformat(m_command, std::make_format_args(m_port)));
+        std::stringstream ss(fmt::format(fmt::runtime(m_command), m_port));
         std::string token;
 
         while (ss >> token) {


### PR DESCRIPTION
Stacked PRs:
 * __->__#119


--- --- ---

### Build/Release CI: Fix mac and linux releases; adjust build CI


- Pin mac to 15 for stability
- Don't strip mac builds (causes segfaults)
- Run gcc and clang builds on rockylinux
- Use more consistent runner.os as opposed to our matrix.os, which we may change the version of
