### PR TITLE
Fix enum values in macro args

### DIFF
--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -56,7 +56,7 @@ public:
     /// @param tree The syntax tree for the main document
     /// @param options Compilation options bag for semantic analysis
     /// @param trees Additional syntax trees that this document depends on
-    ShallowAnalysis(const SourceManager& sourceManager, slang::BufferID buffer,
+    ShallowAnalysis(SourceManager& sourceManager, slang::BufferID buffer,
                     std::shared_ptr<slang::syntax::SyntaxTree> tree, slang::Bag options,
                     const std::vector<std::shared_ptr<slang::syntax::SyntaxTree>>& trees = {});
 
@@ -125,8 +125,8 @@ public:
     static const slang::ast::Scope* getScopeFromSym(const slang::ast::Symbol* symbol);
 
 private:
-    /// Reference to the source manager
-    const SourceManager& m_sourceManager;
+    /// Reference to the source manager. Not const because we may need to parse macro args.
+    SourceManager& m_sourceManager;
 
     /// Buffer ID for this document
     slang::BufferID m_buffer;

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -24,10 +24,11 @@
 #include "slang/syntax/SyntaxKind.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/SourceLocation.h"
+#include "slang/text/SourceManager.h"
 #include "slang/util/Util.h"
 namespace server {
 using namespace slang;
-ShallowAnalysis::ShallowAnalysis(const SourceManager& sourceManager, slang::BufferID buffer,
+ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID buffer,
                                  std::shared_ptr<SyntaxTree> tree, slang::Bag options,
                                  const std::vector<std::shared_ptr<SyntaxTree>>& dependentTrees) :
     syntaxes(*tree), m_sourceManager(sourceManager), m_buffer(buffer), m_tree(tree),
@@ -257,7 +258,9 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
 
         std::string_view macroArg{firstToken.rawText().data(), endOffset - startOffset};
 
-        tokTree = SyntaxTree::fromText(macroArg);
+        // These will overwrite the same assigned source, but it's ok since they are temporary,
+        // and the source manager should be thread safe (for when we do threaded async)
+        tokTree = SyntaxTree::fromText(macroArg, m_sourceManager);
         tokTree->root().parent = macroArgSyntax.parent;
         OffsetFinder visitor(declTok->location().offset() -
                              macroArgSyntax.getFirstToken().location().offset());

--- a/tests/cpp/golden/FindSymbolRefMacro.out
+++ b/tests/cpp/golden/FindSymbolRefMacro.out
@@ -195,12 +195,12 @@ module test;
     `DECLARE_INT(initial_state, STATE_IDLE)
     ^^^^^^^^^^^^ Ref -> ``define DECLARE_INT(name, val) localparam int name = val;`
                  ^^^^^^^^^^^^^ Ref -> `localparam int initial_state = STATE_IDLE`\n\ Expanded from\n\ ``DECLARE_INT(initial_state, STATE_IDLE)`
-                                ^^^^^^^^^^Exception occurred
+                                ^^^^^^^^^^ Ref -> `// In test.state_t`\n\\n\---\n\\n\`// Enum for testing macro with enum values\n\typedef enum {\n\    STATE_IDLE = 0,\n\    STATE_ACTIVE = 1,\n\    STATE_WAIT = 2,\n\    STATE_DONE = 3\n\} state_t;`
 
     `DECLARE_INT(active_state, STATE_ACTIVE)
     ^^^^^^^^^^^^ Ref -> ``define DECLARE_INT(name, val) localparam int name = val;`
                  ^^^^^^^^^^^^ Ref -> `localparam int active_state = STATE_ACTIVE`\n\ Expanded from\n\ ``DECLARE_INT(active_state, STATE_ACTIVE)`
-                               ^^^^^^^^^^^^Exception occurred
+                               ^^^^^^^^^^^^ Ref -> `// In test.state_t`\n\\n\---\n\\n\`// Enum for testing macro with enum values\n\typedef enum {\n\    STATE_IDLE = 0,\n\    STATE_ACTIVE = 1,\n\    STATE_WAIT = 2,\n\    STATE_DONE = 3\n\} state_t;`
 
 
 


### PR DESCRIPTION
Stacked PRs:
 * #125
 * #124
 * #123
 * __->__#122
 * #121


--- --- ---

### Fix enum values in macro args


The upstream change ended up being different, requiring changes in the lookup logic to pass the source mananger.
