### PR TITLE
Implement Inlayhints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,14 +44,15 @@ repos:
         files: (\.cmake|CMakeLists.txt)(.in)?$
         exclude: ^external/.*
 
-  # clang-format for cpp
+  # clang-format for cpp and json
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8
     hooks:
       - id: clang-format
+        types_or: [c++, c, json]
         exclude: ^external/.*
 
-  # Prettier for typescript, json, and yaml
+  # Prettier for typescript and yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ add_library(
   src/document/ShallowAnalysis.cpp
   src/document/SlangDoc.cpp
   src/document/SymbolIndexer.cpp
+  src/document/InlayHintCollector.cpp
   src/document/SymbolTreeVisitor.cpp
   src/document/SyntaxIndexer.cpp
   src/completions/Completions.cpp

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -693,7 +693,6 @@
     "eslint-plugin-unused-imports": "^4.2.0",
     "glob": "^11.0.0",
     "jiti": "^2.6.1",
-    "json-schema-to-typescript": "^15.0.4",
     "prettier-plugin-organize-imports": "^4.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3"

--- a/clients/vscode/pnpm-lock.yaml
+++ b/clients/vscode/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
-      json-schema-to-typescript:
-        specifier: ^15.0.4
-        version: 15.0.4
       prettier-plugin-organize-imports:
         specifier: ^4.1.0
         version: 4.1.0(prettier@3.6.2)(typescript@5.8.3)
@@ -80,10 +77,6 @@ importers:
         version: 5.8.3
 
 packages:
-
-  '@apidevtools/json-schema-ref-parser@11.9.3':
-    resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
-    engines: {node: '>= 16'}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -420,9 +413,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@jsdevtools/ono@7.1.3':
-    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -519,9 +509,6 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/lodash@4.17.20':
-    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
@@ -1121,14 +1108,6 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
-  fdir@6.4.6:
-    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1377,11 +1356,6 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-
-  json-schema-to-typescript@15.0.4:
-    resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1679,10 +1653,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
 
@@ -1952,10 +1922,6 @@ packages:
     resolution: {integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==}
     engines: {node: '>=4'}
 
-  tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
-    engines: {node: '>=12.0.0'}
-
   tmp@0.2.3:
     resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
     engines: {node: '>=14.14'}
@@ -2155,12 +2121,6 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
-
-  '@apidevtools/json-schema-ref-parser@11.9.3':
-    dependencies:
-      '@jsdevtools/ono': 7.1.3
-      '@types/json-schema': 7.0.15
-      js-yaml: 4.1.0
 
   '@azu/format-text@1.0.2': {}
 
@@ -2476,8 +2436,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
-  '@jsdevtools/ono@7.1.3': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2611,8 +2569,6 @@ snapshots:
       '@types/node': 20.11.30
 
   '@types/json-schema@7.0.15': {}
-
-  '@types/lodash@4.17.20': {}
 
   '@types/minimatch@3.0.5': {}
 
@@ -3335,10 +3291,6 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.4.6(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3592,18 +3544,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-to-typescript@15.0.4:
-    dependencies:
-      '@apidevtools/json-schema-ref-parser': 11.9.3
-      '@types/json-schema': 7.0.15
-      '@types/lodash': 4.17.20
-      is-glob: 4.0.3
-      js-yaml: 4.1.0
-      lodash: 4.17.21
-      minimist: 1.2.8
-      prettier: 3.6.2
-      tinyglobby: 0.2.14
-
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -3756,7 +3696,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  minimist@1.2.8: {}
+  minimist@1.2.8:
+    optional: true
 
   minipass@7.1.2: {}
 
@@ -3896,8 +3837,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.2: {}
 
   please-upgrade-node@3.2.0:
     dependencies:
@@ -4199,11 +4138,6 @@ snapshots:
   textextensions@6.11.0:
     dependencies:
       editions: 6.22.0
-
-  tinyglobby@0.2.14:
-    dependencies:
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
 
   tmp@0.2.3: {}
 

--- a/clients/vscode/resources/config.schema.json
+++ b/clients/vscode/resources/config.schema.json
@@ -74,6 +74,36 @@
               "type": "null"
             }
           ]
+        },
+        "inlayHints": {
+          "$ref": "#/$defs/Config__InlayHints",
+          "description": "Inline hints for things like ordered arguments, wildcard ports, and others"
+        }
+      },
+      "required": []
+    },
+    "Config__InlayHints": {
+      "type": "object",
+      "properties": {
+        "portTypes": {
+          "description": "Hints for port types",
+          "type": "boolean"
+        },
+        "orderedInstanceNames": {
+          "description": "Hints for names of ordered ports and params",
+          "type": "boolean"
+        },
+        "wildcardNames": {
+          "description": "Hints for port names in wildcard (.*) ports",
+          "type": "boolean"
+        },
+        "funcArgNames": {
+          "type": "integer",
+          "description": "Function argument hints: 0=off, N=only calls with >=N args"
+        },
+        "macroArgNames": {
+          "type": "integer",
+          "description": "Macro argument hints: 0=off, N=only calls with >=N args"
         }
       },
       "required": []

--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -1,15 +1,6 @@
 import * as vscode from 'vscode'
 
-import { ConfigSchema } from './config.gen'
-// enum class SlangKind {
-//   InstanceKind,
-//   ScopeKind,
-//   ParamKind,
-//   LogicKind,
-//   WireKind,
-// };
-
-export { ConfigSchema as Config }
+import { Config } from './config.gen'
 
 export enum SlangKind {
   Instance = 'Instance',

--- a/clients/vscode/src/config.gen.ts
+++ b/clients/vscode/src/config.gen.ts
@@ -25,4 +25,19 @@ export interface Config {
   wavesPattern?: string | null
   /** Waveform viewer command ({} will be replaced with the WCP port), used for direct wcp connection with neovim and surfer. */
   wcpCommand?: string | null
+  /** Inline hints for things like ordered arguments, wildcard ports, and others */
+  inlayHints?: Config__InlayHints
+}
+
+export interface Config__InlayHints {
+  /** Hints for port types */
+  portTypes?: boolean
+  /** Hints for names of ordered ports and params */
+  orderedInstanceNames?: boolean
+  /** Hints for port names in wildcard (.*) ports */
+  wildcardNames?: boolean
+  /** Function argument hints: 0=off, N=only calls with >=N args */
+  funcArgNames?: number
+  /** Macro argument hints: 0=off, N=only calls with >=N args */
+  macroArgNames?: number
 }

--- a/include/Config.h
+++ b/include/Config.h
@@ -11,9 +11,9 @@
 #include <rfl/Result.hpp>
 /// A singleton to hold global configuration options.
 class SlangLspClient;
-class Config {
+
+struct Config {
     /// generate json schema from this by running with --config-schema
-public:
     // all fields must be optional
     rfl::Description<"Flags to pass to slang", std::string> flags;
     rfl::Description<
@@ -51,6 +51,21 @@ public:
                      "direct wcp connection with neovim and surfer.",
                      std::optional<std::string>>
         wcpCommand;
+
+    struct InlayHints {
+        rfl::Description<"Hints for port types", bool> portTypes = false;
+        rfl::Description<"Hints for names of ordered ports and params", bool> orderedInstanceNames =
+            true;
+        rfl::Description<"Hints for port names in wildcard (.*) ports", bool> wildcardNames = true;
+        rfl::Description<"Function argument hints: 0=off, N=only calls with >=N args", int>
+            funcArgNames = 2;
+        rfl::Description<"Macro argument hints: 0=off, N=only calls with >=N args", int>
+            macroArgNames = 2;
+    };
+
+    rfl::Description<"Inline hints for things like ordered arguments, wildcard ports, and others",
+                     InlayHints>
+        inlayHints = InlayHints{};
 
     static Config fromFiles(std::vector<std::string> confPaths, SlangLspClient& m_client);
 };

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -185,6 +185,9 @@ public:
     rfl::Variant<std::vector<lsp::CompletionItem>, lsp::CompletionList, std::monostate>
     getDocCompletion(const lsp::CompletionParams&) override;
 
+    std::optional<std::vector<lsp::InlayHint>> getDocInlayHint(
+        const lsp::InlayHintParams&) override;
+
     /// Completions resolve (get docs and snippet string)
     lsp::CompletionItem getCompletionItemResolve(const lsp::CompletionItem&) override;
 

--- a/include/document/InlayHintCollector.h
+++ b/include/document/InlayHintCollector.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Config.h"
+#include "lsp/LspTypes.h"
+#include <vector>
+
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxFwd.h"
+
+namespace slang {
+class SourceManager;
+namespace syntax {
+struct NamedPortConnectionSyntax;
+struct WildcardPortConnectionSyntax;
+struct OrderedPortConnectionSyntax;
+struct OrderedParamAssignmentSyntax;
+struct InvocationExpressionSyntax;
+} // namespace syntax
+} // namespace slang
+
+namespace server {
+
+class ShallowAnalysis;
+
+/// Collects syntax nodes for inlay hints and generates hints on demand
+class InlayHintCollector {
+public:
+    InlayHintCollector(const ShallowAnalysis& analysis, lsp::Range range,
+                       const Config::InlayHints& config);
+    /// Get all inlay hints in the specified range
+    std::vector<lsp::InlayHint> result;
+
+    void collectHints();
+
+private:
+    const ShallowAnalysis& m_analysis;
+    lsp::Range m_range;
+
+    // Cached config values
+    bool m_portTypes;
+    bool m_orderedInstanceNames;
+    bool m_wildcardNames;
+    int m_funcArgNames;
+    int m_macroArgNames;
+
+    /// Handle instances- will show port/param names if ordered, names for wildcards, and types for
+    /// named ports
+    void handle(const slang::syntax::HierarchyInstantiationSyntax& syntax);
+
+    /// Handle function calls- will show argument names for calls with more than one arg
+    void handle(const slang::syntax::InvocationExpressionSyntax& syntax);
+
+    /// Handle macro usages- will show argument names for calls with more than one arg
+    void handle(const slang::syntax::MacroUsageSyntax& syntax);
+};
+
+} // namespace server

--- a/include/document/SymbolIndexer.h
+++ b/include/document/SymbolIndexer.h
@@ -18,6 +18,7 @@
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/syntax/SyntaxNode.h"
+#include "slang/text/SourceLocation.h"
 
 namespace server {
 
@@ -55,6 +56,9 @@ public:
     // These are not in the buffer, but should be visited
     void handle(const slang::ast::RootSymbol& sym);
     void handle(const slang::ast::CompilationUnitSymbol& sym);
+
+    // Index for inlay hints
+    void handle(const slang::ast::CallExpression& sym);
 
     /// Generic symbol handler with dispatch to specialized handlers
     template<typename T>

--- a/include/document/SyntaxIndexer.h
+++ b/include/document/SyntaxIndexer.h
@@ -16,7 +16,8 @@
 #include "slang/text/SourceLocation.h"
 #include "slang/util/FlatMap.h"
 namespace server {
-/// A visitor class that finds the syntax node at a given location.
+
+/// Indexes the syntax nodes and tokens for an Analysis
 class SyntaxIndexer {
 private:
     slang::BufferID m_buffer;
@@ -24,10 +25,14 @@ private:
 public:
     // collected declared tokens in order (tokens in the actual file)
     std::vector<const slang::parsing::Token*> collected;
+
     // Mapping of tokens to their parent syntax node
     // For macro usages, this will map the
     slang::flat_hash_map<const slang::parsing::Token*, const slang::syntax::SyntaxNode*>
         tokenToParent;
+
+    /// Map from offset to collected syntax nodes
+    std::map<uint32_t, slang::not_null<const slang::syntax::SyntaxNode*>> collectedHints;
 
     // Mapping of tokens to their parent syntax node
     // slang::flat_hash_map<const slang::parsing::Token*, const slang::syntax::Token*>

--- a/include/util/Formatting.h
+++ b/include/util/Formatting.h
@@ -10,7 +10,16 @@
 #include "slang/syntax/SyntaxNode.h"
 
 namespace server {
+/**
+ * @brief Utility functions for formatting SystemVerilog code snippets.
+ * These utility functions help with formatting code snippets for LSP responses, as well as
+ * formatting the SystemVeriog itself. Eventually the SV Formatting will be superseded by a full SV
+ * formatter, but for now these provide decent formatting utility.
+ */
+
 using namespace slang;
+
+static const size_t FORMATTING_INDENT = 4;
 
 /// @brief Strip whitespace leading up to the first line with a non-whitespace character
 void stripBlankLines(std::string& s);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -13,6 +13,7 @@
 #include "rfl/Result.hpp"
 #include "rfl/from_generic.hpp"
 #include "util/Logging.h"
+#include <rfl/DefaultIfMissing.hpp>
 
 static int CONFIG_READ_FLAGS = YYJSON_READ_ALLOW_COMMENTS | YYJSON_READ_ALLOW_TRAILING_COMMAS;
 
@@ -73,7 +74,7 @@ Config Config::fromFiles(std::vector<std::string> confPaths, SlangLspClient& m_c
         }
     }
 
-    auto finalConfig = rfl::from_generic<Config>(config);
+    auto finalConfig = rfl::from_generic<Config, rfl::DefaultIfMissing>(config);
     if (!finalConfig) {
         m_client.showError(fmt::format("Failed to convert final config to Config: {}",
                                        finalConfig.error().what()));

--- a/src/document/InlayHintCollector.cpp
+++ b/src/document/InlayHintCollector.cpp
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "document/InlayHintCollector.h"
+
+#include "document/ShallowAnalysis.h"
+#include "lsp/LspTypes.h"
+#include "util/Converters.h"
+#include "util/Formatting.h"
+#include "util/Logging.h"
+
+#include "slang/ast/Symbol.h"
+#include "slang/ast/symbols/MemberSymbols.h"
+#include "slang/ast/symbols/PortSymbols.h"
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxKind.h"
+
+using namespace slang;
+using namespace slang::syntax;
+
+namespace server {
+using namespace slang;
+
+InlayHintCollector::InlayHintCollector(const ShallowAnalysis& analysis, lsp::Range range,
+                                       const Config::InlayHints& config) :
+    m_analysis(analysis), m_range(range), m_portTypes(config.portTypes.value()),
+    m_orderedInstanceNames(config.orderedInstanceNames.value()),
+    m_wildcardNames(config.wildcardNames.value()), m_funcArgNames(config.funcArgNames.value()),
+    m_macroArgNames(config.macroArgNames.value()) {
+}
+
+void InlayHintCollector::handle(const HierarchyInstantiationSyntax& syntax) {
+    auto module = m_analysis.getSymbolAtToken(&syntax.type);
+    if (!module) {
+        return;
+    }
+
+    if (module->kind != ast::SymbolKind::Definition) {
+        // Primitive symbols- could maybe support this, but these are pretty rare nowadays
+        return;
+    }
+
+    auto& def = module->as<ast::DefinitionSymbol>();
+
+    // Do params
+    if (m_orderedInstanceNames && syntax.parameters) {
+        size_t paramIndex = 0;
+        for (auto paramSyntax : syntax.parameters->parameters) {
+            if (paramSyntax->kind == SyntaxKind::OrderedParamAssignment) {
+                result.push_back(lsp::InlayHint{
+                    .position = toPosition(paramSyntax->getFirstToken().location(),
+                                           m_analysis.m_sourceManager),
+                    .label = fmt::format("{}:", def.parameters[paramIndex++].name),
+                    .kind = lsp::InlayHintKind::Parameter,
+                    .paddingRight = true,
+                });
+            }
+        }
+    }
+
+    // Do ports on each instance
+    for (auto instanceSyntax : syntax.instances) {
+        if (instanceSyntax->kind != SyntaxKind::HierarchicalInstance) {
+            continue;
+        }
+
+        auto& hierInstSyntax = instanceSyntax->as<HierarchicalInstanceSyntax>();
+        auto inst = m_analysis.getSymbolAtToken(&hierInstSyntax.decl->name);
+        if (!inst) {
+            continue;
+        }
+        if (inst->kind != ast::SymbolKind::Instance) {
+            // TODO: handle instance arrays
+            continue;
+        }
+
+        auto& body = inst->as<ast::InstanceSymbol>().body;
+
+        // Collect named port hints for alignment
+        std::vector<lsp::InlayHint> namedPortHints;
+        size_t maxLabelLen = 0;
+        size_t portIndex = 0;
+        size_t lastPortLine = -1;
+        auto ports = body.getPortList();
+        for (auto portSyntax : hierInstSyntax.connections) {
+            switch (portSyntax->kind) {
+                case SyntaxKind::OrderedPortConnection: {
+                    if (!m_orderedInstanceNames) {
+                        continue;
+                    }
+                    result.push_back(lsp::InlayHint{
+                        .position = toPosition(portSyntax->getFirstToken().location(),
+                                               m_analysis.m_sourceManager),
+                        .label = fmt::format("{}:", ports[portIndex++]->name),
+                        .kind = lsp::InlayHintKind::Parameter,
+                        .paddingRight = true,
+                    });
+                } break;
+                case SyntaxKind::NamedPortConnection: {
+                    if (!m_portTypes) {
+                        continue;
+                    }
+                    auto& connection = portSyntax->as<NamedPortConnectionSyntax>();
+                    auto port = body.findPort(connection.name.valueText());
+                    if (!port) {
+                        continue;
+                    }
+
+                    std::string label;
+                    if (port->kind == ast::SymbolKind::Port) {
+                        auto& portSym = port->as<ast::PortSymbol>();
+                        label = fmt::format("{} {}", portString(portSym.direction),
+                                            portSym.getType().toString());
+                    }
+                    else if (port->kind == ast::SymbolKind::InterfacePort) {
+                        auto& portSym = port->as<ast::InterfacePortSymbol>();
+                        if (!portSym.interfaceDef) {
+                            WARN("invalid modport: {}", portSym.name);
+                            continue;
+                        }
+                        label = fmt::format("{}.{}", portSym.interfaceDef->name, portSym.modport);
+                    }
+                    else {
+                        WARN("Unknown port sym: {}", toString(port->kind));
+                        continue;
+                    }
+
+                    // Track max lengths to preserve alignment
+                    maxLabelLen = std::max(maxLabelLen, label.size());
+                    auto pos = toPosition(connection.name.location() +
+                                              connection.name.rawText().size(),
+                                          m_analysis.m_sourceManager);
+                    namedPortHints.push_back(lsp::InlayHint{
+                        .position = pos,
+                        .label = label,
+                        .kind = lsp::InlayHintKind::Type,
+                        .paddingLeft = true,
+                        .paddingRight = true,
+                    });
+
+                    // Don't show ports if types if theyr'e all on the same line
+                    if (pos.line == lastPortLine) {
+                        return;
+                    }
+                    lastPortLine = pos.line;
+                } break;
+                case SyntaxKind::WildcardPortConnection: {
+                    if (!m_wildcardNames) {
+                        continue;
+                    }
+                    std::string label;
+                    std::string replaceText = "";
+                    size_t indent = m_analysis.m_sourceManager.getColumnNumber(
+                                        syntax.type.location()) +
+                                    FORMATTING_INDENT - 1;
+
+                    auto getLine = [&](const auto& loc) {
+                        return m_analysis.m_sourceManager.getLineNumber(loc);
+                    };
+
+                    if (getLine(instanceSyntax->openParen.location()) ==
+                        getLine(portSyntax->sourceRange().start())) {
+                        // The lsp indent params are only specified in individual requests- so we
+                        // just have to guess for now. This config will go in formatting.json later.
+                        replaceText += "\n" + std::string(indent, ' ');
+                    }
+
+                    for (auto portSym : ports) {
+                        label += portSym->name;
+                        replaceText += fmt::format(".{}", portSym->name);
+
+                        if (portSym != ports.back()) {
+                            label += ", ";
+                            replaceText += ",\n" + std::string(indent, ' ');
+                        }
+                    }
+                    if (getLine(instanceSyntax->closeParen.location()) ==
+                        getLine(portSyntax->sourceRange().end())) {
+                        replaceText += "\n" + std::string(indent - FORMATTING_INDENT, ' ');
+                    }
+                    SLANG_ASSERT(body.getSyntax());
+                    auto portSyntaxList =
+                        body.getSyntax()->as<ModuleDeclarationSyntax>().header->ports;
+
+                    result.push_back(lsp::InlayHint{
+                        .position = toPosition(portSyntax->sourceRange().end(),
+                                               m_analysis.m_sourceManager),
+                        .label = label,
+                        .kind = lsp::InlayHintKind::Type,
+                        .textEdits =
+                            std::vector<lsp::TextEdit>{
+                                lsp::TextEdit{
+                                    .range = toRange(portSyntax->sourceRange(),
+                                                     m_analysis.m_sourceManager),
+                                    .newText = replaceText,
+                                },
+                            },
+                        .tooltip = portSyntaxList ? std::optional<lsp::MarkupContent>(
+                                                        svCodeBlock(*portSyntaxList))
+                                                  : std::nullopt,
+                        .paddingLeft = true,
+                        .paddingRight = true,
+                    });
+
+                } break;
+
+                default:
+                    WARN("Inlay Hints: Unknown port symbol kind: {}", toString(portSyntax->kind));
+                    break;
+            }
+        }
+
+        // align named port hints
+        for (auto& hint : namedPortHints) {
+            auto labelStr = rfl::get<std::string>(hint.label);
+            hint.label = labelStr + std::string(maxLabelLen - labelStr.size(), ' ');
+
+            result.push_back(std::move(hint));
+        }
+    }
+}
+
+void InlayHintCollector::handle(const MacroUsageSyntax& syntax) {
+    if (m_macroArgNames <= 0 || !syntax.args) {
+        return;
+    }
+
+    // TODO: maybe we should also use the index for these?
+    auto defInfo = m_analysis.macros.find(syntax.directive.valueText().substr(1));
+    if (defInfo == m_analysis.macros.end()) {
+        return;
+    }
+    if (!defInfo->second->formalArguments) {
+        return;
+    }
+    // Check if we should show hints based on arg count
+    if (syntax.args->args.size() < static_cast<size_t>(m_macroArgNames)) {
+        return;
+    }
+
+    size_t argIndex = 0;
+    for (auto param : syntax.args->args) {
+        result.push_back(lsp::InlayHint{
+            .position = toPosition(param->getFirstToken().location(), m_analysis.m_sourceManager),
+            .label = fmt::format(
+                "{}:", defInfo->second->formalArguments->args[argIndex++]->name.rawText()),
+            .kind = lsp::InlayHintKind::Parameter,
+            .paddingRight = true,
+        });
+    }
+}
+
+void InlayHintCollector::handle(const InvocationExpressionSyntax& syntax) {
+    if (m_funcArgNames <= 0 || !syntax.arguments)
+        return;
+    auto maybeSub = m_analysis.getSymbolAtToken(syntax.left->getLastTokenPtr());
+    if (!maybeSub || maybeSub->kind != ast::SymbolKind::Subroutine) {
+        // TODO: Implement for system names
+        return;
+    }
+
+    // Check if we should show hints based on arg count
+    if (syntax.arguments->parameters.size() < static_cast<size_t>(m_funcArgNames)) {
+        return;
+    }
+
+    auto argNames = maybeSub->as<ast::SubroutineSymbol>().getArguments();
+    size_t argIndex = 0;
+    for (auto arg : syntax.arguments->parameters) {
+        if (arg->kind != slang::syntax::SyntaxKind::OrderedArgument) {
+            break;
+        }
+        auto name = argNames[argIndex++]->name;
+        if (name.empty()) {
+            continue;
+        }
+        result.push_back(lsp::InlayHint{
+            .position = toPosition(arg->getFirstToken().location(), m_analysis.m_sourceManager),
+            .label = fmt::format("{}:", name),
+            .kind = lsp::InlayHintKind::Parameter,
+            .paddingRight = true,
+        });
+    }
+}
+
+void InlayHintCollector::collectHints() {
+
+    auto slangStart = m_analysis.m_sourceManager.getSourceLocation(m_analysis.m_buffer,
+                                                                   m_range.start.line,
+                                                                   m_range.start.character);
+
+    auto slangEnd = m_analysis.m_sourceManager.getSourceLocation(m_analysis.m_buffer,
+                                                                 m_range.end.line,
+                                                                 m_range.end.character);
+    if (!slangStart || !slangEnd) {
+        ERROR("Invalid range for inlay hints");
+        return;
+    }
+    auto start = m_analysis.syntaxes.collectedHints.lower_bound(slangStart->offset());
+    auto end = m_analysis.syntaxes.collectedHints.upper_bound(slangEnd->offset());
+
+    // Expand start backward to include nodes that begin before the range but extend into it
+    while (start != m_analysis.syntaxes.collectedHints.begin()) {
+        auto prev = std::prev(start);
+        if (prev->second->sourceRange().end().offset() <= slangStart->offset()) {
+            break;
+        }
+        start = prev;
+    }
+
+    for (auto it = start; it != end; ++it) {
+        switch (it->second->kind) {
+            case syntax::SyntaxKind::HierarchyInstantiation:
+                handle(it->second->as<HierarchyInstantiationSyntax>());
+                break;
+            case syntax::SyntaxKind::MacroUsage:
+                handle(it->second->as<MacroUsageSyntax>());
+                break;
+            case syntax::SyntaxKind::InvocationExpression:
+                handle(it->second->as<InvocationExpressionSyntax>());
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+} // namespace server

--- a/src/document/SymbolIndexer.cpp
+++ b/src/document/SymbolIndexer.cpp
@@ -14,6 +14,7 @@
 #include "slang/ast/Symbol.h"
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/PortSymbols.h"
 #include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxKind.h"
@@ -99,16 +100,18 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
             case slang::syntax::SyntaxKind::NamedPortConnection: {
                 auto& portSyntax = port->as<slang::syntax::NamedPortConnectionSyntax>();
                 auto name = portSyntax.name.valueText();
-                if (!name.empty()) {
-                    const slang::ast::Symbol* portSym = body.lookupName(
-                        portSyntax.name.valueText());
-                    if (portSym) {
-                        symdex[&portSyntax.name] = portSym;
-                    }
+                if (name.empty()) {
+                    continue;
                 }
+                const slang::ast::Symbol* maybePortSym = body.findPort(portSyntax.name.valueText());
+                if (!maybePortSym) {
+                    continue;
+                }
+
+                symdex[&portSyntax.name] = maybePortSym;
+
             } break;
             default:
-                WARN("Unknown port symbol kind: {}", toString(port->kind));
                 break;
         }
     }
@@ -145,7 +148,6 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
                 }
             } break;
             default:
-                WARN("Unknown parameter kind: {}", toString(param->kind));
                 break;
         }
     }

--- a/src/document/SyntaxIndexer.cpp
+++ b/src/document/SyntaxIndexer.cpp
@@ -12,6 +12,7 @@
 
 #include "slang/parsing/Token.h"
 #include "slang/parsing/TokenKind.h"
+#include "slang/syntax/SyntaxKind.h"
 #include "slang/syntax/SyntaxNode.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/SourceLocation.h"
@@ -27,6 +28,23 @@ SyntaxIndexer::SyntaxIndexer(const slang::syntax::SyntaxTree& tree) {
 }
 
 void SyntaxIndexer::visit(const slang::syntax::SyntaxNode& node) {
+    switch (node.kind) {
+        case syntax::SyntaxKind::MacroUsage: {
+            if (node.getFirstToken().location().buffer() == m_buffer) {
+                collectedHints.emplace(
+                    static_cast<uint32_t>(node.getFirstToken().location().offset()), &node);
+            }
+            break;
+        }
+        case syntax::SyntaxKind::InvocationExpression:
+        case syntax::SyntaxKind::HierarchyInstantiation:
+            collectedHints.emplace(static_cast<uint32_t>(node.getFirstToken().location().offset()),
+                                   &node);
+            break;
+        default:
+            break;
+    }
+
     for (uint32_t i = 0; i < node.getChildCount(); i++) {
         auto child = node.childNode(i);
         if (child)

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -52,6 +52,7 @@ int main(int argc, char** argv) {
                 // , "@generated from `include/Config.h`"
             );
             OS::print(schema);
+            OS::print("\n");
         }
         catch (const std::exception& e) {
             OS::print(fmt::format("Error generating config schema: {}\n", e.what()));

--- a/src/util/Converters.cpp
+++ b/src/util/Converters.cpp
@@ -9,6 +9,8 @@
 
 #include <fmt/format.h>
 
+#include "slang/text/SourceLocation.h"
+
 namespace server {
 
 using namespace slang;

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -5,8 +5,9 @@
 
 file(GLOB SERVER_TESTS "*.cpp")
 
-add_executable(server_unittests utils/ServerHarness.cpp main.cpp
-                                ${SERVER_TESTS})
+file(GLOB TEST_UTILS "utils/*.cpp")
+
+add_executable(server_unittests ${TEST_UTILS} main.cpp ${SERVER_TESTS})
 
 target_link_libraries(server_unittests PRIVATE slang_server_obj_lib)
 

--- a/tests/cpp/InlayHintTests.cpp
+++ b/tests/cpp/InlayHintTests.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "utils/GoldenTest.h"
+#include "utils/InlayHintScanner.h"
+#include "utils/ServerHarness.h"
+
+using namespace slang;
+
+TEST_CASE("InlayHintsAll") {
+    /// Test inlay hints on the comprehensive all.sv test file
+    ServerHarness server("");
+    auto hdl = server.openFile("all.sv");
+
+    InlayHintScanner scanner;
+    scanner.scanDocument(hdl);
+}
+
+TEST_CASE("InlayHintsFunction") {
+    /// Test inlay hints for function call arguments
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_function.sv", R"(
+module test;
+    function int add(int a, int b);
+        return a + b;
+    endfunction
+
+    initial begin
+        int x = add(5, 10);
+    end
+endmodule
+)");
+
+    InlayHintScanner scanner;
+    scanner.scanDocument(hdl);
+}
+
+TEST_CASE("InlayHintsModuleOrdered") {
+    /// Test inlay hints for module instantiation with ordered ports
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_module_ordered.sv", R"(
+module adder(
+    input logic clk,
+    input logic [7:0] a,
+    input logic [7:0] b,
+    output logic [8:0] sum
+);
+endmodule
+
+module top;
+    logic clk, a, b, sum;
+    adder u_adder(clk, a, b, sum);
+endmodule
+)");
+
+    InlayHintScanner scanner;
+    scanner.scanDocument(hdl);
+}
+
+TEST_CASE("InlayHintsModuleNamed") {
+    /// Test inlay hints for module instantiation with named ports
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_module_named.sv", R"(
+module counter(
+    input logic clk,
+    input logic rst,
+    output logic [7:0] count
+);
+endmodule
+
+module top;
+    logic clk, rst;
+    logic [7:0] cnt;
+    counter u_cnt(.clk(clk), .rst(rst), .count(cnt));
+
+    counter x_cnt(
+        .clk  (clk),
+        .rst  (rst),
+        .count(cnt)
+    );
+endmodule
+)");
+
+    InlayHintScanner scanner;
+    scanner.scanDocument(hdl);
+}
+
+TEST_CASE("InlayHintsWildcard") {
+    /// Test inlay hints for wildcard port connections
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_wildcard.sv", R"(
+module receiver(
+    input logic clk,
+    input logic [7:0] data
+);
+endmodule
+
+module top;
+    logic clk;
+    logic [7:0] data;
+    receiver u_rx(.*);
+endmodule
+)");
+
+    InlayHintScanner scanner;
+    scanner.scanDocument(hdl);
+}
+
+TEST_CASE("InlayHintsParameters") {
+    /// Test inlay hints for parameter assignments
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_params.sv", R"(
+module fifo #(
+    parameter int DEPTH = 16,
+    parameter int WIDTH = 8
+)(
+    input logic clk
+);
+endmodule
+
+module top;
+    logic clk;
+    fifo #(32, 16) u_fifo(clk);
+endmodule
+)");
+
+    InlayHintScanner scanner;
+    scanner.scanDocument(hdl);
+}
+
+TEST_CASE("InlayHintsWildcardExpansion") {
+    /// Test applying text edits from wildcard expansion
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_wildcard_expand.sv", R"(
+module receiver(
+    input logic clk,
+    input logic [7:0] data
+);
+endmodule
+
+module top;
+    logic clk;
+    logic [7:0] data;
+    receiver u_rx(.*);
+endmodule
+)");
+
+    auto hints = hdl.getAllInlayHints();
+
+    // Collect all text edits from hints
+    std::vector<lsp::TextEdit> edits;
+    for (const auto& hint : hints) {
+        if (hint.textEdits) {
+            for (const auto& edit : *hint.textEdits) {
+                edits.push_back(edit);
+            }
+        }
+    }
+
+    // Apply edits and check result
+    auto result = hdl.withTextEdits(edits);
+
+    GoldenTest test;
+    test.record(result);
+}
+
+TEST_CASE("InlayHintsWildcardMultiple") {
+    /// Test applying text edits from multiple wildcard expansions
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_wildcard_multi.sv", R"(
+module dut(
+    input logic clk,
+    input logic rst,
+    input logic [7:0] data_in,
+    output logic [7:0] data_out
+);
+endmodule
+
+module top;
+    logic clk, rst;
+    logic [7:0] data_in, data_out;
+
+    dut u_dut1(.*);
+
+    dut u_dut2(.*);
+
+    dut u_dut3(
+        .*
+    );
+endmodule
+)");
+
+    auto hints = hdl.getAllInlayHints();
+
+    // Collect all text edits from hints
+    std::vector<lsp::TextEdit> edits;
+    for (const auto& hint : hints) {
+        if (hint.textEdits) {
+            for (const auto& edit : *hint.textEdits) {
+                edits.push_back(edit);
+            }
+        }
+    }
+
+    // Apply edits and check result
+    auto result = hdl.withTextEdits(edits);
+
+    GoldenTest test;
+    test.record(result);
+}

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -228,6 +228,7 @@ macromodule m3;
            ^ Ref -> `I d(.a(), .b());`
 
         .e()
+         ^ Ref -> `// In m2`\n\\n\---\n\\n\`.e()`
 
     );
 

--- a/tests/cpp/golden/InlayHintsAll.out
+++ b/tests/cpp/golden/InlayHintsAll.out
@@ -1,0 +1,555 @@
+timeunit 1ns / 1ps;
+timeprecision 1ps;
+
+(* foo = 1 *) package static p;
+    timeunit 1ns;
+    parameter int x = 1;
+    parameter type y_t = logic[x:0];
+    parameter int x2 = x + 1;
+    parameter type y = logic[x:0];
+    parameter type y2 = logic[x2:0];
+    program; endprogram
+    export *::*;
+endpackage
+
+package pkg1;
+    typedef struct packed {
+        logic [7:0] data;
+        logic valid;
+    } packet_t;
+endpackage
+
+package pkg2;
+    import pkg1::packet_t;
+    export pkg1::packet_t;
+endpackage
+
+module automatic m1 import p::*; #(int i = 1)
+    (a, b, , .c({a, b[0]}));
+    input a;
+    output [1:0] b;
+    localparam int c = p::x;
+    localparam p::y d = {1'b0, 1'b1};
+endmodule
+
+module m2 #(
+    parameter i = 1,
+    localparam j = i,
+    parameter type x_t = bit
+)
+    (input int a[], (* bar = "asdf" *) output logic b = 1, ref c,
+    input p::y2 d2,
+     interface.mod d, .e());
+endmodule
+
+extern interface I(input a, output b);
+
+interface I(.*);
+    modport mod(input a);
+endinterface
+
+extern macromodule m3;
+
+macromodule m3;
+    wire b;
+    logic c;
+    I d(.a(), .b());
+
+    typedef p::y_t y_t;
+
+    m2 #(
+        .x_t(y_t)
+    ) m (, /*a:*/ b, /*b:*/ c, /*c:*/ d, );
+
+
+    typedef p::y2 y2;
+
+    m2 #(
+        .i(1),
+        .x_t(y2)
+    ) m2_inst (
+        .a /*input int$[]*/ ({1, 2}),
+        .b /*output logic*/ (b),
+        .c /*ref logic   */ (),
+        .d(d),
+        .e /*inout void  */ ()
+    );
+
+    $info("Hello %s", "world");
+
+    wor [1:0] w = 1;
+    assign (supply0, weak1) #(1:0:1, 2:1:0) w = 2;
+
+    wor u,v;
+    alias {u,v} = w;
+
+    logic f, z;
+    event ev;
+    initial begin
+        repeat (3) @(negedge b) f = #2 1;
+        wait (f) ++f;
+        wait fork;
+        wait_order (m3.ev) f++;
+
+        fork : fkb
+            static int i = 1;
+            disable fork;
+        join_none
+
+        disable m3.foo;
+
+        assign z = 1;
+        deassign z;
+
+        if (1) begin end else begin end
+
+        unique0 casex (w)
+            0, 1: ;
+            default ;
+        endcase
+
+        case (w) inside
+            [0: 3]: ;
+        endcase
+    end
+
+    always_ff @(posedge b iff f == 1) begin
+        forever break;
+        repeat (f + 2) continue;
+        while (1)
+            ;
+        for (int i = 0, j = i; i < 10; i += 2, j += i) begin end
+        foreach (w[q]) begin end
+    end
+
+    always @* begin : foo
+    end : foo
+
+    always_comb begin
+        typedef union tagged {
+            void Invalid;
+            int Valid;
+        } VInt;
+
+        typedef union tagged {
+            struct {
+                bit [4:0] reg1, reg2, regd;
+            } Add;
+            union tagged {
+                bit [9:0] JmpU;
+                struct {
+                    bit [1:0] cc;
+                    bit [9:0] addr;
+                } JmpC;
+            } Jmp;
+        } Instr;
+
+        VInt v;
+        Instr instr;
+        automatic int rf[] = new [3];
+        static longint pc = 'x;
+
+        case (v) matches
+            tagged Invalid &&& ~w : $display ("v is Invalid");
+            tagged Valid .n : $display ("v is Valid with value %d", n);
+        endcase
+
+        case (instr) matches
+            tagged Add .s: case (s) matches
+                            '{.*, .*, 0} : ; // no op
+                            '{.r1, .r2, .rd} : rf[rd] = rf[r1] + rf[r2];
+                          endcase
+            tagged Jmp .j: case (j) matches
+                            tagged JmpU .a : pc = pc + a;
+                            tagged JmpC '{.c, .a} : if (rf[c]) pc = a;
+                           endcase
+        endcase
+
+        if (instr matches (tagged Jmp .j) &&&
+            j matches (tagged JmpC '{cc:.c,addr:.a})) begin
+            pc = c[0] & a[0];
+            pc = instr matches (tagged Jmp .j) &&&
+                  j matches (tagged JmpC '{cc:.c,addr:.a}) ? c[0] & a[0] : 0;
+        end
+        else begin
+        end
+    end
+
+    always_latch begin
+    end
+
+    genvar j;
+    for (genvar i = 0; i < 10; i += 2)
+        if (i == 7) begin
+        end
+
+    ;
+
+    generate
+        case ($bits(w))
+            0, 1: begin end
+            2: begin end
+            default: begin end
+        endcase
+    endgenerate
+
+    assertion0: assert #0 (1 == 1) else $display("Hello!");
+    assertion1: assume final (2 != 1) else $display("Hello!");
+
+    if (1) begin
+        logic a,b,c,d,e,f;
+
+        property p1(x,y);
+            ##1 x |-> y;
+        endproperty
+
+        wire clk;
+        property p2;
+            @(posedge clk)
+            a ##1 (b || c)[->1] |->
+                if (b)
+                    p1(d,e)
+                else
+                    f;
+        endproperty
+        cover property (p2 and p2);
+    end
+
+    prim prim_inst(q, r);
+    rcmos #1step (q, r, s, t);
+
+    defparam m3.m.i = 1:1:1;
+
+    clocking cb @(r or s);
+        default input posedge #3ps;
+        input a = t;
+    endclocking
+
+    global clocking cb2 @t; endclocking
+
+    default clocking cb;
+    default disable iff 1 dist { [1:2] :/ 3, 2 };
+
+endmodule : m3
+
+extern program p(a, b);
+
+program p(a, b);
+    input a, b;
+endprogram : p
+
+extern primitive prim(output reg a, input b);
+
+primitive prim(output reg a, input b);
+    table
+        0 : ? : 1;
+        1 : 0 : x;
+    endtable
+endprimitive
+
+(* attr = 3.14 *) bind m3.m m1 #(/*i:*/ 1) bound(/*a:*/ 'x, , , );
+
+config cfg;
+    localparam i = 1;
+    design work.m3;
+    default liblist a b;
+    cell m3 use work.m3;
+endconfig
+
+module ALU (o1, i1, i2, opcode);
+    input [7:0] i1, i2;
+    input [2:1] opcode;
+    output [7:0] o1;
+
+    specify
+        specparam s1 = 2;
+        if (opcode == 2'b00) (i1,i2 *> o1) = (25.0, 25.0);
+        if (opcode == 2'b01) (i1 => o1) = (5.6, 8.0);
+        if (opcode == s1) (i2 => o1) = (5.6, 8.0);
+        (opcode *> o1) = (6.1, 6.5);
+    endspecify
+endmodule
+
+interface Iface;
+    extern function void foo(int i, real r);
+    extern forkjoin task t3();
+
+    modport m(export foo, function void bar(int, logic), task baz, export func);
+    modport n(import function void func(int), import task t2);
+    modport o(export t2);
+endinterface
+
+module n(Iface.m a);
+    initial begin
+        a.foo(/*i:*/ 42, /*r:*/ 3.14);
+        a.bar(1, 1);
+        a.baz();
+    end
+
+    function void a.bar(int i, logic l); endfunction
+    task a.baz; endtask
+    function void a.func(int i); endfunction
+
+    function void a.foo(int i, real r);
+    endfunction
+endmodule
+
+module m4;
+    Iface i1();
+    n n1(/*a:*/ i1);
+
+    Iface i2();
+    n n2(/*a:*/ i2.m);
+
+    localparam int baz = 3;
+    task i1.t2;
+        static int i = baz;
+    endtask
+
+    task i2.t2;
+        static int i = baz;
+    endtask
+endmodule
+
+typedef enum { cover_none, cover_all } coverage_level;
+checker assert_window1 (
+    logic test_expr,
+    untyped start_event,
+    untyped end_event,
+    event clock = $inferred_clock,
+    logic reset = $inferred_disable,
+    string error_msg = "violation",
+    coverage_level clevel = cover_all
+);
+    default clocking @clock; endclocking
+    default disable iff reset;
+    bit window = 1'b0, next_window = 1'b1;
+    rand bit q;
+
+    always_comb begin
+        if (reset || window && end_event)
+            next_window = 1'b0;
+        else if (!window && start_event)
+            next_window = 1'b1;
+        else
+            next_window = window;
+    end
+
+    always_ff @clock
+        window <= next_window;
+
+    property p_window;
+        start_event && !window |=> test_expr[+] ##0 end_event;
+    endproperty
+
+    a_window: assert property (p_window) else $error(error_msg);
+
+    generate if (clevel != cover_none) begin : cover_b
+        cover_window_open: cover property (start_event && !window)
+        $display("window_open covered");
+        cover_window: cover property (
+            start_event && !window
+            ##1 (!end_event && window) [*]
+            ##1 end_event && window
+        ) $display("window covered");
+    end : cover_b
+    endgenerate
+endchecker : assert_window1
+
+module m5;
+    logic a, b, c, d, e, clk;
+
+    default clocking @(posedge clk); endclocking
+
+    assert_window1 aw1(1 + 1, a, b);
+
+    initial begin
+        assert_window1 aw2(1 + 1, a, b);
+    end
+
+    sequence abc;
+        @(posedge clk) a ##1 b ##1 c;
+    endsequence
+
+    sequence de;
+        @(negedge clk) d ##[2:5] e;
+    endsequence
+
+    program check;
+        initial begin
+            wait( abc.triggered || de.triggered );
+            if( abc.triggered )
+                $display( "abc succeeded" );
+            if( de.triggered )
+                $display( "de succeeded" );
+        end
+    endprogram
+endmodule
+
+class C;
+    int i;
+    static int j;
+    extern function int foo(int bar, int baz = 1);
+endclass
+
+class D;
+    extern static function real foo;
+endclass
+
+localparam int k = 5;
+
+function int C::foo(int bar, int baz = 1);
+    i = j + k + bar + baz;
+endfunction
+
+function real D::foo;
+endfunction
+
+class G #(type T);
+    extern function T foo;
+endclass
+
+function G::T G::foo;
+    return 0;
+endfunction
+
+class H #(int p);
+    extern function int foo;
+endclass
+
+function int H::foo;
+endfunction
+
+module m7;
+    G #(real) g1;
+    G #(int) g2;
+
+    int i = g2.foo();
+    real r = D::foo();
+endmodule
+
+class A;
+    integer i = 1;
+    integer j = 2;
+    function integer f();
+        f = i;
+    endfunction
+endclass
+
+class B extends A;
+    integer i = 2;
+    function void f();
+        i = j;
+        super.i = super.j;
+        j = super.f();
+        j = this.super.f();
+    endfunction
+endclass
+
+class C2 extends B;
+    function void g();
+        f();
+        i = j + C::j + A::f();
+    endfunction
+
+    rand bit [63:0] value;
+    rand logic q;
+    constraint value_c {
+        value[63] dist {0 :/ 70, 1 :/ 30};
+        value[0] == 1'b0;
+        value[15:8] inside {
+            8'h0,
+            8'hF
+        };
+        solve value before q;
+        soft value[3:1] > 1;
+        q -> { value[4] == 0; }
+        if (q) { foreach (value[b]) { value[b] == 0; } } else { disable soft value; }
+    }
+endclass
+
+module m6;
+    A a = new;
+    A b1 = B::new;
+    B b2 = new;
+    C2 c = new;
+    int depth;
+    integer i = b1.f();
+    initial begin
+        b2.f();
+        a = b2;
+        c.i = c.j;
+
+        randsequence(main)
+            main : first second;
+            first : add | dec := (1 + 1);
+            second : repeat($urandom_range(2, 6)) first;
+            add : if (depth < 2) first else second;
+            dec : case (depth & 7)
+                0 : add;
+                1, 2 : dec;
+                default : first;
+            endcase;
+            third : rand join first second;
+            fourth(string s = "done") : { if (depth) break; };
+        endsequence
+    end
+endmodule
+
+class C3;
+    enum {red, green, blue} color;
+    bit [3:0] pixel_adr, pixel_offset, pixel_hue;
+    logic clk, x, y, c;
+
+    covergroup g2 (string instComment) @(posedge clk);
+        Offset: coverpoint pixel_offset;
+        Hue: coverpoint pixel_hue;
+        AxC: cross color, pixel_adr;
+        all: cross color, Hue, Offset;
+
+        option.comment = instComment;
+
+        e: coverpoint x iff (clk) {
+            option.weight = 2;
+            wildcard bins a = { [0:63],65 };
+            bins b[] = { [127:150],[148:191] }; // note overlapping values
+            bins c[] = { 200,201,202 };
+            bins d = { [1000:$] };
+            bins others[] = default;
+
+            bins sa = (4 => 5 => 6), ([7:9],10 => 11,12);
+            bins sb[] = (12 => 3 [* 1]);
+            bins sc = (12 => 3 [-> 1]);
+            bins sd = (12 => 3 [= 1:2]);
+        }
+        cross e, y {
+            option.weight = c;
+            bins one = '{ '{1,2}, '{3,4}, '{5,6} };
+            ignore_bins others = (!binsof(e.a) || !binsof(y) intersect {1}) with (e > 10);
+        }
+        b: cross y, x;
+    endgroup
+endclass
+
+module m9;
+    logic [3:0] a = {4 {1'b1}};
+endmodule
+
+module m10;
+    byte stream[$];
+    class Packet;
+        rand int header;
+        rand int len;
+        rand byte payload[];
+        int crc;
+        constraint G { len > 1; payload.size == len ; }
+        function void post_randomize; crc = payload.sum; endfunction
+    endclass
+
+    initial begin
+        byte q[$];
+        automatic Packet p = new;
+        {<< byte{ p.header, p.len, p.payload with [0 +: p.len], p.crc }} = stream;
+        stream = stream[ $bits(p) / 8 : $ ];
+    end
+endmodule

--- a/tests/cpp/golden/InlayHintsFunction.out
+++ b/tests/cpp/golden/InlayHintsFunction.out
@@ -1,0 +1,10 @@
+
+module test;
+    function int add(int a, int b);
+        return a + b;
+    endfunction
+
+    initial begin
+        int x = add(/*a:*/ 5, /*b:*/ 10);
+    end
+endmodule

--- a/tests/cpp/golden/InlayHintsModuleNamed.out
+++ b/tests/cpp/golden/InlayHintsModuleNamed.out
@@ -1,0 +1,19 @@
+
+module counter(
+    input logic clk,
+    input logic rst,
+    output logic [7:0] count
+);
+endmodule
+
+module top;
+    logic clk, rst;
+    logic [7:0] cnt;
+    counter u_cnt(.clk(clk), .rst(rst), .count(cnt));
+
+    counter x_cnt(
+        .clk /*input logic      */   (clk),
+        .rst /*input logic      */   (rst),
+        .count /*output logic[7:0]*/ (cnt)
+    );
+endmodule

--- a/tests/cpp/golden/InlayHintsModuleOrdered.out
+++ b/tests/cpp/golden/InlayHintsModuleOrdered.out
@@ -1,0 +1,13 @@
+
+module adder(
+    input logic clk,
+    input logic [7:0] a,
+    input logic [7:0] b,
+    output logic [8:0] sum
+);
+endmodule
+
+module top;
+    logic clk, a, b, sum;
+    adder u_adder(/*clk:*/ clk, /*a:*/ a, /*b:*/ b, /*sum:*/ sum);
+endmodule

--- a/tests/cpp/golden/InlayHintsParameters.out
+++ b/tests/cpp/golden/InlayHintsParameters.out
@@ -1,0 +1,13 @@
+
+module fifo #(
+    parameter int DEPTH = 16,
+    parameter int WIDTH = 8
+)(
+    input logic clk
+);
+endmodule
+
+module top;
+    logic clk;
+    fifo #(/*DEPTH:*/ 32, /*WIDTH:*/ 16) u_fifo(/*clk:*/ clk);
+endmodule

--- a/tests/cpp/golden/InlayHintsWildcard.out
+++ b/tests/cpp/golden/InlayHintsWildcard.out
@@ -1,0 +1,12 @@
+
+module receiver(
+    input logic clk,
+    input logic [7:0] data
+);
+endmodule
+
+module top;
+    logic clk;
+    logic [7:0] data;
+    receiver u_rx(.* /*clk, data*/ );
+endmodule

--- a/tests/cpp/golden/InlayHintsWildcardExpansion.out
+++ b/tests/cpp/golden/InlayHintsWildcardExpansion.out
@@ -1,0 +1,15 @@
+
+module receiver(
+    input logic clk,
+    input logic [7:0] data
+);
+endmodule
+
+module top;
+    logic clk;
+    logic [7:0] data;
+    receiver u_rx(
+        .clk,
+        .data
+    );
+endmodule

--- a/tests/cpp/golden/InlayHintsWildcardMultiple.out
+++ b/tests/cpp/golden/InlayHintsWildcardMultiple.out
@@ -1,0 +1,34 @@
+
+module dut(
+    input logic clk,
+    input logic rst,
+    input logic [7:0] data_in,
+    output logic [7:0] data_out
+);
+endmodule
+
+module top;
+    logic clk, rst;
+    logic [7:0] data_in, data_out;
+
+    dut u_dut1(
+        .clk,
+        .rst,
+        .data_in,
+        .data_out
+    );
+
+    dut u_dut2(
+        .clk,
+        .rst,
+        .data_in,
+        .data_out
+    );
+
+    dut u_dut3(
+        .clk,
+        .rst,
+        .data_in,
+        .data_out
+    );
+endmodule

--- a/tests/cpp/utils/InlayHintScanner.cpp
+++ b/tests/cpp/utils/InlayHintScanner.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "InlayHintScanner.h"
+
+#include "ServerHarness.h"
+#include "util/Converters.h"
+#include <catch2/catch_test_macros.hpp>
+
+void InlayHintScanner::scanDocument(DocumentHandle hdl) {
+    auto doc = hdl.doc;
+    if (!doc) {
+        FAIL("Failed to get SlangDoc");
+        return;
+    }
+
+    // Get inlay hints for the entire document
+    // In the future we may want to measure the performance of querying more normal ranges
+
+    std::string data = std::string{doc->getText()};
+    auto start = hdl.getLocation(0);
+    auto end = hdl.getLocation(data.size() - 1);
+    auto range = slang::SourceRange{*start, *end};
+    Config::InlayHints config{.portTypes = true};
+    auto hints = doc->getAnalysis().getInlayHints(server::toRange(range, doc->getSourceManager()),
+                                                  config);
+
+    // Insert hints into the document text
+    size_t size_added = 0;
+    for (auto& hint : hints) {
+        std::string label = rfl::get<std::string>(hint.label);
+
+        // Handle padding
+        std::string prefix = hint.paddingLeft.value_or(false) ? " " : "";
+        std::string suffix = hint.paddingRight.value_or(false) ? " " : "";
+
+        auto toAdd = fmt::format("{}/*{}*/{}", prefix, label, suffix);
+        auto insertPos = doc->getLocation(hint.position)->offset() + size_added;
+
+        REQUIRE(insertPos <= data.size());
+
+        data.insert(insertPos, toAdd);
+        size_added += toAdd.size();
+    }
+
+    // Trim trailing whitespace (including null bytes) and ensure exactly one newline at end
+    while (!data.empty() && (data.back() == ' ' || data.back() == '\t' || data.back() == '\n' ||
+                             data.back() == '\r' || data.back() == '\0')) {
+        data.pop_back();
+    }
+    test.record(data + "\n");
+}

--- a/tests/cpp/utils/InlayHintScanner.h
+++ b/tests/cpp/utils/InlayHintScanner.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "GoldenTest.h"
+#include "lsp/LspTypes.h"
+#include "rfl/visit.hpp"
+#include <map>
+#include <string>
+
+class DocumentHandle;
+
+class InlayHintScanner {
+public:
+    void scanDocument(DocumentHandle hdl);
+
+private:
+    GoldenTest test;
+};

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -143,6 +143,12 @@ public:
 
     std::optional<lsp::Hover> getHoverAt(lsp::uint offset);
 
+    /// @brief Get all inlay hints for the entire document
+    std::vector<lsp::InlayHint> getAllInlayHints();
+
+    /// @brief Apply text edits to the document and return the resulting text
+    std::string withTextEdits(std::vector<lsp::TextEdit> edits);
+
     std::string m_text;
     URI m_uri;
     ServerHarness& m_server;


### PR DESCRIPTION
Stacked PRs:
 * #132
 * #131
 * #130
 * #128
 * #125
 * #124
 * __->__#123


--- --- ---

### Implement Inlayhints

See config for descriptions:
```
struct InlayHints {
    rfl::Description<"Hints for port types", bool> portTypes = false;
    rfl::Description<"Hints for names of ordered ports and params", bool> orderedInstanceNames =
        true;
    rfl::Description<"Hints for port names in wildcard (.*) ports", bool> wildcardNames = true;
    rfl::Description<"Function argument hints: 0=off, N=only calls with >=N args",
                        int>
        funcArgNames = 2;
    rfl::Description<"Macro argument hints: 0=off, N=only calls with >=N args",
                        int>
        macroArgNames = 2;
};
```
- Use custom script for schema to TS generation- the package didn't seem to handle nested structs well
- Implements inlay replacements for wildcard ports.
