### PR TITLE
Indexer: clean up and speed up

### DIFF
--- a/include/Indexer.h
+++ b/include/Indexer.h
@@ -7,217 +7,81 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include "lsp/LspTypes.h"
 #include "lsp/URI.h"
 #include <condition_variable>
 #include <map>
 #include <mutex>
-#include <tuple>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "slang/syntax/SyntaxTree.h"
+#include "slang/util/SmallVector.h"
 
 struct Indexer {
-    enum class IndexDataUpdateType : int { Added, Removed };
-    using IndexKeyType = std::string;
-
-    using SymbolIndexData = std::tuple<IndexKeyType, lsp::SymbolKind, std::string>;
-    using MacroIndexData = IndexKeyType;
+    // Data structures
+    struct GlobalSymbol {
+        std::string name;
+        slang::syntax::SyntaxKind kind;
+    };
 
     struct IndexedPath {
         std::string path;
-        std::vector<Indexer::SymbolIndexData> relevantSymbols;
-        std::vector<Indexer::MacroIndexData> relevantMacros;
+        std::vector<GlobalSymbol> symbols;
+        std::vector<std::string> macros;
     };
 
     Indexer();
 
-    template<typename T>
-    using IndexDataSet = slang::flat_hash_set<T>;
-    struct IndexMapEntry {
-        std::string toString(std::string_view name) const;
-        lsp::WorkspaceSymbol toWorkSpaceSymbol(std::string_view name) const;
-
-        // The ordering of these members is important. They should be sorted by location first.
-        URI uri;
-
-        lsp::SymbolKind kind{};
-        std::optional<std::string> containerName{};
-
-        // This should be enough to uniquely identify an entry
-        bool operator==(const IndexMapEntry& other) const { return uri == other.uri; }
-
-        inline static IndexMapEntry fromSymbolData(lsp::SymbolKind kind, std::string container,
-                                                   URI uri) {
-            IndexMapEntry out(uri);
-            out.kind = kind;
-            out.containerName = container.empty() ? std::optional<std::string>()
-                                                  : std::move(container);
-            return out;
-        }
-        inline static IndexMapEntry fromMacroData(URI uri) { return IndexMapEntry(uri); }
-        IndexMapEntry(URI uri) : uri{uri} {}
-        // Non-copyable
-        IndexMapEntry(IndexMapEntry&) = delete;
-        IndexMapEntry(IndexMapEntry&&) noexcept = default;
-    };
-
-    using IndexMap = std::multimap<IndexKeyType, IndexMapEntry>;
-    struct IndexStorage {
-        /// Returns range
-        auto getEntriesForKeyConst(const IndexKeyType& key) const {
-            return entries.equal_range(key);
-        }
-
-        auto getEntriesForKey(const IndexKeyType& key) { return entries.equal_range(key); }
-
-        void addEntry(IndexKeyType key, IndexMapEntry entry);
-
-        void removeEntry(IndexKeyType key, URI uri);
-
-        const IndexMap& getAllEntries() const { return entries; }
-
-        size_t sizeInBytes() const {
-            return entries.size() * sizeof(IndexMap::value_type) +
-                   entries.size() * sizeof(IndexMap::key_type);
-        }
-
-    private:
-        friend struct Indexer;
-        IndexMap entries;
-    };
-
-    /// Returns sorted (by symbol lexicographically) array of workspace symbols
-    std::vector<lsp::WorkspaceSymbol> getAllWorkspaceSymbols() const;
-
-    /// Index files/symbols/macros from the provided globs. Populate internal symbol ->
-    /// List<filenames> map.
+    // Primary indexing function, called on startup
     void startIndexing(const std::vector<std::string>& globs,
                        const std::vector<std::string>& excludeDirs, uint32_t numThreads = 0);
 
-    /// Add following documents to the index
+    // For workspace changes
     void addDocuments(const std::vector<std::filesystem::path>& paths, uint32_t numThreads = 0);
-
-    void indexTree(const slang::syntax::SyntaxTree& tree);
-
-    void indexPath(IndexedPath& indexedFile);
-
-    /// Remove these documents from the index's awareness. E.g. on file deletion
     void removeDocuments(const std::vector<std::filesystem::path>& paths, uint32_t numThreads = 0);
 
-    // for convenience/testing for now, could remove later
-    size_t sizeInBytes() const { return macroToFiles.sizeInBytes() + symbolToFiles.sizeInBytes(); }
+    // For open document lifecycle
+    void openDocument(const URI& uri, const slang::syntax::SyntaxTree& tree);
+    void updateDocument(const URI& uri, const slang::syntax::SyntaxTree& tree);
+    void closeDocument(const URI& uri);
 
-    const IndexStorage& symbolMap() const { return symbolToFiles; }
-    const IndexStorage& macroMap() const { return macroToFiles; }
-
-    struct DocSyntaxChange {
-        IndexDataSet<SymbolIndexData> newSymbols;
-        IndexDataSet<SymbolIndexData> oldSymbols;
-        IndexDataSet<MacroIndexData> newMacros;
-        IndexDataSet<MacroIndexData> oldMacros;
-
-        // Multiline, really just for debugging
-        std::string toString() const {
-            std::stringstream ss;
-
-            auto addSymbol = [&ss](const auto& data, const char* _name) {
-                ss << _name << ": \n";
-                for (const auto& [name, kind, container] : data) {
-                    ss << "\t[" << name << "]\n";
-                }
-            };
-
-            auto addMacro = [&ss](const auto& data, const char* _name) {
-                ss << _name << ": \n";
-                for (const auto& name : data) {
-                    ss << "\t[" << name << "]\n";
-                }
-            };
-
-            addSymbol(newSymbols, "newSymbols");
-            addSymbol(oldSymbols, "oldSymbols");
-            addMacro(newMacros, "newMacros");
-            addMacro(oldMacros, "oldMacros");
-
-            return ss.str();
-        }
-
-        DocSyntaxChange(DocSyntaxChange&) = delete;
-        DocSyntaxChange(DocSyntaxChange&&) = default;
-
-    protected:
-        DocSyntaxChange() = default;
+    // Threading API
+    void waitForIndexingCompletion() const;
+    struct GlobalSymbolLoc {
+        const URI* uri;
+        slang::syntax::SyntaxKind kind{};
     };
 
-    // void addSyntaxUpdate(const URI& uri, const slang::syntax::SyntaxTree* tree);
-    void consumeDocSyntaxChange(const URI& uri, DocSyntaxChange change) {
-        pendingUpdates[uri].consumeDocSyntaxChange(std::move(change));
-    }
+    // Index storage, public for querying
+    // Using SmallVector<2> to avoid heap allocations for the common case
+    std::unordered_map<std::string, slang::SmallVector<GlobalSymbolLoc, 2>> symbolToFiles;
+    std::unordered_map<std::string, slang::SmallVector<const URI*, 2>> macroToFiles;
 
-    void noteDocSaved(const URI& uri);
-
-    auto getEntriesForSymbol(std::string_view symbol) const {
-        return symbolToFiles.getEntriesForKeyConst(std::string(symbol));
-    }
-
-    auto getEntriesForMacro(std::string_view symbol) const {
-        return macroToFiles.getEntriesForKeyConst(std::string(symbol));
-    }
-
-    /// Signals when indexing is complete
-    void waitForIndexingCompletion() const {
-        std::unique_lock<std::mutex> lock(indexingMutex);
-        indexingCondition.wait(lock, [this] { return indexingComplete; });
-    }
-
-    void notifyIndexingComplete() {
-        {
-            std::lock_guard<std::mutex> lock(indexingMutex);
-            indexingComplete = true;
-        }
-        indexingCondition.notify_all();
-    }
-
-    void resetIndexingComplete() {
-        {
-            std::lock_guard<std::mutex> lock(indexingMutex);
-            indexingComplete = false;
-        }
-    }
+    // Storage for unique URIs (all pointers in the index point here)
+    std::unordered_set<URI> uniqueUris;
 
     std::vector<std::filesystem::path> getRelevantFilesForName(std::string_view name) const;
-
     std::vector<std::filesystem::path> getFilesForMacro(std::string_view name) const;
-
-    // Macro -> relevant files
-    IndexStorage macroToFiles;
-    // Modules/Interfaces/Packages -> relevant files
-    IndexStorage symbolToFiles;
 
     static const int MinFilesForThreading = 4;
 
 private:
+    friend struct IndexGuard;
+
+    void indexPath(IndexedPath& indexedFile);
+    void notifyIndexingComplete();
+    void resetIndexingComplete();
+
+    // Intern a URI to get a stable pointer
+    const URI* internUri(const URI& uri);
+
+    // Storage for open documents
+    std::unordered_map<URI, IndexedPath> openDocuments;
+
+    // Thread synchronization
     mutable std::condition_variable indexingCondition;
     mutable std::mutex indexingMutex;
     bool indexingComplete = false;
-
-    template<typename T>
-    using DataUpdate = std::pair<IndexDataUpdateType, T>;
-    struct UnsavedDocumentUpdate {
-        // These lists will always be mutually exclusive
-        slang::flat_hash_map<SymbolIndexData, IndexDataUpdateType> symbolUpdates;
-        slang::flat_hash_map<MacroIndexData, IndexDataUpdateType> macroUpdates;
-
-        void consumeDocSyntaxChange(DocSyntaxChange&& change);
-    };
-
-    /// Updates by document which are still unsaved
-    slang::flat_hash_map<URI, UnsavedDocumentUpdate> pendingUpdates;
-
-    void dumpIndex() const;
-
-    void indexDidChange() { workSpaceResultCached = false; }
-
-    mutable bool workSpaceResultCached = false;
 };

--- a/include/completions/Completions.h
+++ b/include/completions/Completions.h
@@ -30,7 +30,7 @@ void resolveMacro(const syntax::DefineDirectiveSyntax& macro, lsp::CompletionIte
 //------------------------------------------------------------------------------
 // Modules, Interfaces, Packages
 //------------------------------------------------------------------------------
-lsp::CompletionItem getModuleCompletion(std::string name, lsp::SymbolKind kind);
+lsp::CompletionItem getModuleCompletion(std::string name, const syntax::SyntaxKind& kind);
 
 void resolveModule(const slang::syntax::ModuleHeaderSyntax& header, lsp::CompletionItem& ret,
                    bool excludeName = false);

--- a/include/util/Converters.h
+++ b/include/util/Converters.h
@@ -35,6 +35,8 @@ lsp::Location toLocation(const SourceRange& range, const SourceManager& sourceMa
 
 lsp::Location toLocation(const SourceLocation& loc, const SourceManager& sourceManager);
 
+lsp::SymbolKind toSymbolKind(const slang::syntax::SyntaxKind& kind);
+
 lsp::MarkupContent markdown(std::string& md);
 
 std::string portString(ast::ArgumentDirection dir);

--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -27,6 +27,7 @@
 #include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/AllTypes.h"
+#include "slang/syntax/SyntaxKind.h"
 #include "slang/syntax/SyntaxNode.h"
 #include "slang/syntax/SyntaxPrinter.h"
 #include "slang/syntax/SyntaxTree.h"
@@ -80,25 +81,35 @@ void resolveMacro(const syntax::DefineDirectiveSyntax& macro, lsp::CompletionIte
 //------------------------------------------------------------------------------
 // Modules, Interfaces, Packages
 //------------------------------------------------------------------------------
-lsp::CompletionItem getModuleCompletion(std::string name, lsp::SymbolKind kind) {
-    auto kindStr = [kind]() -> std::string {
-        switch (kind) {
-            case lsp::SymbolKind::Module:
-                return " Module";
-            case lsp::SymbolKind::Package:
-                return " Package";
-            case lsp::SymbolKind::Interface:
-                return " Interface";
-            default:
-                return " Symbol";
-        }
-    }();
+lsp::CompletionItem getModuleCompletion(std::string name, const syntax::SyntaxKind& kind) {
+    // Convert SyntaxKind to user-friendly display string
+    std::string detail;
+    switch (kind) {
+        case syntax::SyntaxKind::ModuleDeclaration:
+            detail = " Module";
+            break;
+        case syntax::SyntaxKind::InterfaceDeclaration:
+            detail = " Interface";
+            break;
+        case syntax::SyntaxKind::PackageDeclaration:
+            detail = " Package";
+            break;
+        case syntax::SyntaxKind::ProgramDeclaration:
+            detail = " Program";
+            break;
+        case syntax::SyntaxKind::ClassDeclaration:
+            detail = " Class";
+            break;
+        default:
+            detail = std::string{toString(kind)};
+            break;
+    }
 
     return lsp::CompletionItem{
         .label = name,
         .labelDetails =
             lsp::CompletionItemLabelDetails{
-                .detail = kindStr,
+                .detail = detail,
             },
         .kind = lsp::CompletionItemKind::Module,
         .filterText = name,

--- a/src/util/Converters.cpp
+++ b/src/util/Converters.cpp
@@ -84,6 +84,26 @@ lsp::Location toLocation(const SourceLocation& loc, const SourceManager& sourceM
                                              .end = toPosition(loc + 1, sourceManager)}};
 }
 
+lsp::SymbolKind toSymbolKind(const syntax::SyntaxKind& kind) {
+    switch (kind) {
+        case syntax::SyntaxKind::InterfaceDeclaration:
+            return lsp::SymbolKind::Interface;
+        case syntax::SyntaxKind::ModuleDeclaration:
+        case syntax::SyntaxKind::CheckerDeclaration:
+        case syntax::SyntaxKind::ProgramDeclaration:
+            return lsp::SymbolKind::Module;
+        case syntax::SyntaxKind::PackageDeclaration:
+            return lsp::SymbolKind::Package;
+        case syntax::SyntaxKind::ClassDeclaration:
+            return lsp::SymbolKind::Class;
+        case syntax::SyntaxKind::FunctionDeclaration:
+        case syntax::SyntaxKind::TaskDeclaration:
+            return lsp::SymbolKind::Function;
+        default:
+            return lsp::SymbolKind::Null;
+    }
+}
+
 lsp::MarkupContent markdown(std::string& md) {
     return lsp::MarkupContent{.kind = lsp::MarkupKind::make<"markdown">(), .value = md};
 }

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -82,6 +82,9 @@ public:
     // For access to isWcpVariable
     // TODO -- remove once isWcpVariable is removed
     using SlangServer::m_driver;
+
+    // For access to indexer in tests
+    using SlangServer::m_indexer;
 };
 
 enum DocState {

--- a/tests/data/indexer_test/classes.sv
+++ b/tests/data/indexer_test/classes.sv
@@ -1,0 +1,6 @@
+class MyClass;
+    int x;
+endclass
+
+class AnotherClass;
+endclass

--- a/tests/data/indexer_test/macros.sv
+++ b/tests/data/indexer_test/macros.sv
@@ -1,0 +1,2 @@
+`define MY_MACRO value
+`define ANOTHER_MACRO

--- a/tests/data/indexer_test/macros_with_module.sv
+++ b/tests/data/indexer_test/macros_with_module.sv
@@ -1,0 +1,4 @@
+`define MY_MACRO value
+
+module m;
+endmodule

--- a/tests/data/indexer_test/modules.sv
+++ b/tests/data/indexer_test/modules.sv
@@ -1,0 +1,8 @@
+module m1;
+endmodule
+
+module m2;
+endmodule
+
+interface Iface;
+endinterface

--- a/tests/data/indexer_test/nested.sv
+++ b/tests/data/indexer_test/nested.sv
@@ -1,0 +1,4 @@
+module outer;
+    module inner;
+    endmodule
+endmodule


### PR DESCRIPTION
Stacked PRs:
 * #142
 * #141
 * #140
 * #139
 * #138
 * #132
 * __->__#131


--- --- ---

### Indexer: clean up and speed up

- Use unordered map of small vectors instead of multimap
- Thread-local source manager for less lock contention
- Set include limit to 0; this was expanding local `includes (not from incdirs), which wastes time and duplicates since we'll index those anyway. In the future we'll want to make note of these, and map all of those files to the same tree.
