### PR TITLE
fix `vscode` linter not recoginizing `slang.Config`

### DIFF
--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { Config } from './config.gen'
 
-export type { Config };
+export type { Config }
 
 export enum SlangKind {
   Instance = 'Instance',


### PR DESCRIPTION
on vscode the typescript static analyzer raises an error that `slang.Config` does not exist in the file `extension.ts`. Although it works fine, this fix just gets rid of the error.