### PR TITLE
[Neovim] Pass position encoding of the first client

### DIFF
--- a/clients/neovim/lua/slang-server/_commands/addToWaves.lua
+++ b/clients/neovim/lua/slang-server/_commands/addToWaves.lua
@@ -13,6 +13,9 @@ M.addToWaves = {
 
       local bufnr = vim.api.nvim_get_current_buf()
 
+      local first_client = vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })[1]
+      local position_encoding = first_client and first_client.offset_encoding or 'utf-16'
+
       client.getInstances(bufnr, {
          on_success = function(resp)
             if resp == nil or next(resp) == nil then
@@ -36,7 +39,7 @@ M.addToWaves = {
             end
          end,
          on_failure = handlers.defaultOnFailure,
-      }, { position = vim.lsp.util.make_position_params() })
+      }, { position = vim.lsp.util.make_position_params(0, position_encoding) })
    end,
 }
 


### PR DESCRIPTION
On newer Neovim versions (0.11.5 for example), `make_position_params()` function requires `position_encoding` argument. Currently no arguments are provided, that generates the following warning when using `addToWaves`: 

<img width="1878" height="260" alt="image" src="https://github.com/user-attachments/assets/f1887796-176b-416a-9b72-e742ca3916ec" />

After pressing enter, the signal is correctly added to the waveform, so the only thing needed is to get rid of a warning by passing `position_encoding` of the first client explicitly.

In order to do so, we get the first client for the current buffer and look for `offset_encoding` field. 
From the docs: offset_encoding is the same as position encoding in LSP spec.

First argument is 0, which stands for current window (default behavior).