### PR TITLE
[VSCode] modules should not expand when a module is clicked in the hierarchy

### DIFF
--- a/clients/vscode/src/sidebar/InstancesView.ts
+++ b/clients/vscode/src/sidebar/InstancesView.ts
@@ -171,6 +171,10 @@ export class InstancesView
   }
 
   revealPath(module: string, path: string | undefined = undefined, focus: boolean = false) {
+    if (!this.treeView?.visible) {
+      return
+    }
+
     const moduleItem = this.modules.get(module)
     if (moduleItem === undefined) {
       return


### PR DESCRIPTION
small little nitpick; see following:

Click a module here:

<img width="589" height="1425" alt="image" src="https://github.com/user-attachments/assets/58bf2394-ecc1-4b8b-bce7-f58a7df2baec" />

And the module pops up:

<img width="598" height="1403" alt="image" src="https://github.com/user-attachments/assets/cf98fbc1-0537-4f98-9ce0-0d0e51445daf" />

This PR makes it so that it only selects the corresponding item in modules, if its visible (ie: not compressed). However perhaps the popping up is the intended behavior, in which case I can just keep this as a patch on my own fork.