### PR TITLE
Check workspace folders length in initialize

### DIFF
--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -123,7 +123,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     // File features
     registerCommand<ExpandMacroArgs, bool, &SlangServer::expandMacros>("slang.expandMacros");
 
-    if (params.workspaceFolders.has_value()) {
+    if (params.workspaceFolders.has_value() && !params.workspaceFolders->empty()) {
         auto folders = params.workspaceFolders.value();
         if (folders.size() > 1) {
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#172


--- --- ---

### Check workspace folders length in initialize

Most clients will pass null if there are no workspace folders, but helix doesn't.
