### PR TITLE
Filter out unused def diags; simplify nodemeta accesses

### DIFF
--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -252,8 +252,7 @@ std::vector<std::shared_ptr<SlangDoc>> ServerDriver::getDependentDocs(
                     docs[newdoc->getURI()] = newdoc;
 
                     // Only add packages to the queue for recursive processing
-                    for (auto& [n, _] : newdoc->getSyntaxTree()->getMetadata().nodeMeta) {
-                        auto decl = &n->as<syntax::ModuleDeclarationSyntax>();
+                    for (auto& [decl, _] : newdoc->getSyntaxTree()->getMetadata().nodeMeta) {
                         if (decl->kind == syntax::SyntaxKind::PackageDeclaration) {
                             treesToProcess.push(newdoc->getSyntaxTree());
                             break;

--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -241,21 +241,21 @@ void resolveModule(const slang::syntax::ModuleHeaderSyntax& header, lsp::Complet
 
 void resolveModule(const slang::syntax::SyntaxTree& tree, std::string_view moduleName,
                    lsp::CompletionItem& ret, bool excludeName) {
-    for (auto [syntax, node] : tree.getMetadata().nodeMeta) {
-        auto& module = syntax->as<slang::syntax::ModuleDeclarationSyntax>();
-        if (module.header->name.valueText() != moduleName)
+    for (auto [module, node] : tree.getMetadata().nodeMeta) {
+        auto& header = *module->header;
+        if (header.name.valueText() != moduleName)
             continue;
 
-        switch (syntax->kind) {
+        switch (module->kind) {
             case slang::syntax::SyntaxKind::InterfaceDeclaration:
             case slang::syntax::SyntaxKind::ModuleDeclaration: {
-                resolveModule(*module.header, ret, excludeName);
+                resolveModule(header, ret, excludeName);
             } break;
             default: {
                 // Packages and programs- just do the name. For packages we may want to
                 // automatically add the ::, but not sure if that will retrigger completions
-                ret.documentation = svCodeBlock(*module.header);
-                ret.insertText = module.header->name.valueText();
+                ret.documentation = svCodeBlock(header);
+                ret.insertText = header.name.valueText();
                 ret.insertTextFormat = lsp::InsertTextFormat::PlainText;
                 continue;
             }


### PR DESCRIPTION
Stacked PRs:
 * #193
 * #192
 * __->__#191


--- --- ---

### Filter out unused def diags; simplify nodemeta accesses

- Interfaces were getting flagged as unused definitions. The diag isn't really applicable to shallow compilations, since interfaces can be tops there.
- The nodemeta type is now ModuleDeclarationSyntax, so no need to cast
