### PR TITLE
Disable ctest from VSCode test explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,4 +29,6 @@
   "[cpp]": {
     "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
   },
+  // Disables ctest from popping up in the VSCode explorer. Use C++ TestMate instead.
+  "cmake.ctest.testExplorerIntegrationEnabled": false,
 }


### PR DESCRIPTION
Disable ctest integration in VSCode settings.