### PR TITLE
Fix compile commands database

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ project(
   DESCRIPTION "SystemVerilog language server based on slang")
 
 # Enable compile_commands.json for IDE/clangd tooling by default
-if(SLANG_SERVER_MASTER_PROJECT AND NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+if(SLANG_SERVER_MASTER_PROJECT)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 


### PR DESCRIPTION
#184 sets the compile commands when SLANG is the master project and `CMAKE_EXPORT_COMPILE_COMMANDS` does not exist, but it also inadvertently introduces a bug into the codebase. When another library defines `CMAKE_EXPORT_COMPILE_COMMANDS` but has it turned off, then `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` never executes. I believe it is `reflect-cpp` which defines the variable into existence (don't quote me though :) ).