### PR TITLE
Vscode: Allow omitting 'dirs' and 'languageIds' in formatter config.

### DIFF
--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -289,7 +289,7 @@
                 "items": {
                   "type": "string"
                 },
-                "description": "Directories to format"
+                "description": "Directories to format. Relative to workspace root, and must not overlap. Formats all if omitted."
               },
               "languageIds": {
                 "type": "array",
@@ -302,6 +302,10 @@
                     "verilogheader"
                   ]
                 },
+                "default": [
+                  "verilog",
+                  "systemverilog"
+                ],
                 "description": "Language IDs to format (e.g., \"systemverilog\", \"verilog\")"
               }
             }
@@ -492,7 +496,7 @@
       "activitybar": [
         {
           "id": "slang",
-          "title": "Slang",
+          "title": "slang",
           "icon": "$(chip)"
         }
       ],

--- a/clients/vscode/src/utils.ts
+++ b/clients/vscode/src/utils.ts
@@ -108,6 +108,7 @@ export class FileDiagnostic extends vscode.Diagnostic {
 
 export const VerilogLanguages = ['verilog', 'verilogheader']
 export const SystemVerilogLanguages = ['systemverilog', 'systemverilogheader']
+export const HDLFiles = ['verilog', 'systemverilog']
 export const AnyVerilogLanguages = [
   'verilog',
   'systemverilog',


### PR DESCRIPTION
Stacked PRs:
 * #221
 * #220
 * __->__#219
 * #218
 * #215


--- --- ---

### Vscode: Allow omitting 'dirs' and 'languageIds' in formatter config.

