### PR TITLE
Fix excessive threading after unused-diags addition; configure analysis options properly when design is set.

### DIFF
--- a/include/ast/ServerCompilationAnalysis.h
+++ b/include/ast/ServerCompilationAnalysis.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <vector>
 
+#include "slang/analysis/AnalysisOptions.h"
 #include "slang/util/Bag.h"
 
 namespace server {
@@ -75,7 +76,8 @@ private:
     /// Retained buffer data to prevent deallocation while this compilation exists
     std::vector<std::shared_ptr<void>> m_retainedBuffers;
 
-    slang::analysis::AnalysisManager m_driverAnalysis;
+    /// Analysis options from the bag, used for driver analysis
+    slang::analysis::AnalysisOptions m_analysisOptions;
 
     /// Index of value symbol -> uses (e.g. processes or continuous assignments)
     std::optional<ReferenceIndexer> m_references = std::nullopt;

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -18,7 +18,7 @@
 #include <string_view>
 #include <vector>
 
-#include "slang/analysis/AnalysisManager.h"
+#include "slang/analysis/AnalysisOptions.h"
 #include "slang/ast/ASTContext.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/Lookup.h"
@@ -167,8 +167,8 @@ private:
     /// Compilation context for symbol resolution
     std::unique_ptr<slang::ast::Compilation> m_compilation;
 
-    /// Analysis manager for running driver and unused checks
-    slang::analysis::AnalysisManager m_driverAnalysis;
+    /// Analysis options for driver analysis (numThreads=1 to avoid persistent threads)
+    slang::analysis::AnalysisOptions m_analysisOptions;
 
     /// Symbol tree visitor for /documentSymbols
     /// Currently this is relies on syntax, but we should switch it to use the shallow compilation

--- a/tests/cpp/golden/CompilationDiagnostics.json
+++ b/tests/cpp/golden/CompilationDiagnostics.json
@@ -128,6 +128,60 @@
       {
         "range": {
           "start": {
+            "line": 11,
+            "character": 35
+          },
+          "end": {
+            "line": 11,
+            "character": 44
+          }
+        },
+        "severity": "Warning",
+        "code": "undriven-port",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#undriven-port"
+        },
+        "message": "undriven output port 'mem_wdata'"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 13,
+            "character": 36
+          },
+          "end": {
+            "line": 13,
+            "character": 42
+          }
+        },
+        "severity": "Warning",
+        "code": "undriven-port",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#undriven-port"
+        },
+        "message": "undriven output port 'mem_we'"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 25,
+            "character": 27
+          },
+          "end": {
+            "line": 25,
+            "character": 40
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'register_file' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
             "line": 48,
             "character": 19
           },
@@ -188,6 +242,321 @@
             "message": "declared here"
           }
         ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 54,
+            "character": 27
+          },
+          "end": {
+            "line": 54,
+            "character": 37
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-variable"
+        },
+        "message": "unused variable 'alu_result'",
+        "tags": [
+          "Unnecessary"
+        ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 55,
+            "character": 10
+          },
+          "end": {
+            "line": 55,
+            "character": 18
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-variable"
+        },
+        "message": "unused variable 'alu_zero'",
+        "tags": [
+          "Unnecessary"
+        ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 55,
+            "character": 20
+          },
+          "end": {
+            "line": 55,
+            "character": 32
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-variable"
+        },
+        "message": "unused variable 'alu_overflow'",
+        "tags": [
+          "Unnecessary"
+        ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 58,
+            "character": 27
+          },
+          "end": {
+            "line": 58,
+            "character": 38
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'alu_array_a' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 59,
+            "character": 27
+          },
+          "end": {
+            "line": 59,
+            "character": 38
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'alu_array_b' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 60,
+            "character": 27
+          },
+          "end": {
+            "line": 60,
+            "character": 43
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'alu_array_result' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 61,
+            "character": 13
+          },
+          "end": {
+            "line": 61,
+            "character": 25
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'alu_array_op' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 62,
+            "character": 10
+          },
+          "end": {
+            "line": 62,
+            "character": 24
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'alu_array_zero' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 63,
+            "character": 10
+          },
+          "end": {
+            "line": 63,
+            "character": 28
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'alu_array_overflow' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 77,
+            "character": 10
+          },
+          "end": {
+            "line": 77,
+            "character": 24
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'counter_enable' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 78,
+            "character": 16
+          },
+          "end": {
+            "line": 78,
+            "character": 29
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'counter_count' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 93,
+            "character": 35
+          },
+          "end": {
+            "line": 93,
+            "character": 44
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'gen_alu_a' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 93,
+            "character": 46
+          },
+          "end": {
+            "line": 93,
+            "character": 55
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'gen_alu_b' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 93,
+            "character": 57
+          },
+          "end": {
+            "line": 93,
+            "character": 71
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'gen_alu_result' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 94,
+            "character": 21
+          },
+          "end": {
+            "line": 94,
+            "character": 31
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'gen_alu_op' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 95,
+            "character": 18
+          },
+          "end": {
+            "line": 95,
+            "character": 30
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'gen_alu_zero' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 95,
+            "character": 32
+          },
+          "end": {
+            "line": 95,
+            "character": 48
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'gen_alu_overflow' is assigned but its value is never used"
       }
     ]
   },
@@ -320,6 +689,60 @@
       {
         "range": {
           "start": {
+            "line": 11,
+            "character": 35
+          },
+          "end": {
+            "line": 11,
+            "character": 44
+          }
+        },
+        "severity": "Warning",
+        "code": "undriven-port",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#undriven-port"
+        },
+        "message": "undriven output port 'mem_wdata'"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 13,
+            "character": 36
+          },
+          "end": {
+            "line": 13,
+            "character": 42
+          }
+        },
+        "severity": "Warning",
+        "code": "undriven-port",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#undriven-port"
+        },
+        "message": "undriven output port 'mem_we'"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 25,
+            "character": 27
+          },
+          "end": {
+            "line": 25,
+            "character": 40
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'register_file' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
             "line": 48,
             "character": 19
           },
@@ -380,6 +803,321 @@
             "message": "declared here"
           }
         ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 54,
+            "character": 27
+          },
+          "end": {
+            "line": 54,
+            "character": 37
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-variable"
+        },
+        "message": "unused variable 'alu_result'",
+        "tags": [
+          "Unnecessary"
+        ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 55,
+            "character": 10
+          },
+          "end": {
+            "line": 55,
+            "character": 18
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-variable"
+        },
+        "message": "unused variable 'alu_zero'",
+        "tags": [
+          "Unnecessary"
+        ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 55,
+            "character": 20
+          },
+          "end": {
+            "line": 55,
+            "character": 32
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-variable"
+        },
+        "message": "unused variable 'alu_overflow'",
+        "tags": [
+          "Unnecessary"
+        ]
+      },
+      {
+        "range": {
+          "start": {
+            "line": 58,
+            "character": 27
+          },
+          "end": {
+            "line": 58,
+            "character": 38
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'alu_array_a' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 59,
+            "character": 27
+          },
+          "end": {
+            "line": 59,
+            "character": 38
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'alu_array_b' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 60,
+            "character": 27
+          },
+          "end": {
+            "line": 60,
+            "character": 43
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'alu_array_result' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 61,
+            "character": 13
+          },
+          "end": {
+            "line": 61,
+            "character": 25
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'alu_array_op' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 62,
+            "character": 10
+          },
+          "end": {
+            "line": 62,
+            "character": 24
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'alu_array_zero' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 63,
+            "character": 10
+          },
+          "end": {
+            "line": 63,
+            "character": 28
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'alu_array_overflow' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 77,
+            "character": 10
+          },
+          "end": {
+            "line": 77,
+            "character": 24
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'counter_enable' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 78,
+            "character": 16
+          },
+          "end": {
+            "line": 78,
+            "character": 29
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'counter_count' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 93,
+            "character": 35
+          },
+          "end": {
+            "line": 93,
+            "character": 44
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'gen_alu_a' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 93,
+            "character": 46
+          },
+          "end": {
+            "line": 93,
+            "character": 55
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'gen_alu_b' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 93,
+            "character": 57
+          },
+          "end": {
+            "line": 93,
+            "character": 71
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'gen_alu_result' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 94,
+            "character": 21
+          },
+          "end": {
+            "line": 94,
+            "character": 31
+          }
+        },
+        "severity": "Warning",
+        "code": "unassigned-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unassigned-variable"
+        },
+        "message": "variable 'gen_alu_op' is never assigned a value"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 95,
+            "character": 18
+          },
+          "end": {
+            "line": 95,
+            "character": 30
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'gen_alu_zero' is assigned but its value is never used"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 95,
+            "character": 32
+          },
+          "end": {
+            "line": 95,
+            "character": 48
+          }
+        },
+        "severity": "Warning",
+        "code": "unused-but-set-variable",
+        "codeDescription": {
+          "href": "https://sv-lang.com/warning-ref.html#unused-but-set-variable"
+        },
+        "message": "variable 'gen_alu_overflow' is assigned but its value is never used"
       }
     ]
   }


### PR DESCRIPTION
Stacked PRs:
 * __->__#222


--- --- ---

### Fix excessive threading after unused-diags addition; configure analysis options properly when design is set.


Analysis managers contain a thread pool, so should be destroyed right after usage. The default analysis options were being passed the server comp's manager, so was not getting the flags from the config.