### PR TITLE
[VSCode] Modify `onStart` function to not reveal the slang sidebar on startup

### DIFF
--- a/clients/vscode/src/sidebar/ProjectComponent.ts
+++ b/clients/vscode/src/sidebar/ProjectComponent.ts
@@ -477,7 +477,11 @@ export class ProjectComponent
   isRevalingFile: boolean = false
 
   async onStart(): Promise<void> {
-    await this.refreshSlangCompilation()
+    await this.refreshSlangCompilation({
+      revealHierarchy: false,
+      revealFile: false,
+      revealInstance: false,
+    })
   }
 
   //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Using the `buildFile` configuration option works great; it automatically sets my top module when VSCode is opened. 

However, what I find annoying is that it force-reveals the sidebar. I'd rather just look at my filesystem or whatever page VSCode opens by default.