### PR TITLE
Don't return untaken generate branches from getScope()

### DIFF
--- a/include/ast/HierarchicalView.h
+++ b/include/ast/HierarchicalView.h
@@ -259,6 +259,8 @@ static std::vector<HierItem_t> getScopeChildren(const slang::ast::Scope& scope,
                                                 const SourceManager& sm) {
     std::vector<HierItem_t> result;
     for (auto& sym : scope.members()) {
+        if (!sym.isInstantiated())
+            continue;
         if (auto inst = sym.as_if<slang::ast::InstanceSymbol>()) {
             handleInstance(result, *inst, sm);
         }

--- a/tests/cpp/HierarchyTests.cpp
+++ b/tests/cpp/HierarchyTests.cpp
@@ -56,6 +56,20 @@ TEST_CASE("GetScopeNested") {
     golden.record("mem_ctrl_scope", memCtrlScope);
 }
 
+TEST_CASE("GetScopeBranches") {
+    ServerHarness server("comp_repo");
+    JsonGoldenTest golden;
+
+    auto hdl = server.openFile("generate_branch.sv");
+
+    server.setTopLevel(std::string{hdl.m_uri.getPath()});
+
+    // Get only instantiated branches
+    auto children = server.getScope("top.the_sub");
+
+    golden.record("children", children);
+}
+
 TEST_CASE("GetScopesByModule") {
     ServerHarness server("comp_repo");
     JsonGoldenTest golden;

--- a/tests/cpp/golden/GetScopeBranches.json
+++ b/tests/cpp/golden/GetScopeBranches.json
@@ -1,0 +1,76 @@
+[
+  {
+    "children": [
+      {
+        "kind": "Param",
+        "instName": "condition",
+        "instLoc": {
+          "uri": "file://generate_branch.sv",
+          "range": {
+            "start": {
+              "line": 8,
+              "character": 18
+            },
+            "end": {
+              "line": 8,
+              "character": 27
+            }
+          }
+        },
+        "type": "bit",
+        "value": "1'b1"
+      },
+      {
+        "kind": "Scope",
+        "instName": "gen_yes",
+        "instLoc": {
+          "uri": "file://generate_branch.sv",
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 19
+            },
+            "end": {
+              "line": 12,
+              "character": 7
+            }
+          }
+        },
+        "children": [
+          {
+            "kind": "Instance",
+            "instName": "yes_sub_sub",
+            "instLoc": {
+              "uri": "file://generate_branch.sv",
+              "range": {
+                "start": {
+                  "line": 11,
+                  "character": 16
+                },
+                "end": {
+                  "line": 11,
+                  "character": 29
+                }
+              }
+            },
+            "declName": "sub_sub",
+            "declLoc": {
+              "uri": "file://generate_branch.sv",
+              "range": {
+                "start": {
+                  "line": 18,
+                  "character": 0
+                },
+                "end": {
+                  "line": 19,
+                  "character": 9
+                }
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/data/comp_repo/generate_branch.sv
+++ b/tests/data/comp_repo/generate_branch.sv
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+module top;
+    sub #(.condition ('1)) the_sub();
+endmodule
+
+module sub #(
+    parameter bit condition
+);
+    if (condition) begin: gen_yes
+        sub_sub yes_sub_sub();
+    end else begin: gen_no
+        logic some_logic;
+        sub_sub no_sub_sub();
+    end
+endmodule
+
+module sub_sub;
+endmodule


### PR DESCRIPTION
Unfortunately the test doesn't actually demonstrate the problem.  I haven't been able to find a simple reproducer yet, but the check prevents the un-taken generate branch in the larger design I'm looking at.