### PR TITLE
Trigger textDocument/didSave only on open docs

### DIFF
--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -78,6 +78,9 @@ public:
 
     void onDocDidChange(const lsp::DidChangeTextDocumentParams& params);
 
+    /// @brief Checks if a document is open
+    bool isDocumentOpen(const URI& uri);
+
     /// @brief Handle workspace file change notifications from the file watcher
     /// Reloads all changed buffers first, then updates open documents
     void onWorkspaceDidChangeWatchedFiles(const lsp::DidChangeWatchedFilesParams& params);

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -187,6 +187,10 @@ std::shared_ptr<SlangDoc> ServerDriver::getDocument(const URI& uri) {
     return doc;
 }
 
+bool ServerDriver::isDocumentOpen(const URI& uri) {
+    return m_openDocs.find(uri) != m_openDocs.end();
+}
+
 void ServerDriver::onDocDidChange(const lsp::DidChangeTextDocumentParams& params) {
     std::string_view path = params.textDocument.uri.getPath();
     auto doc = getDocument(params.textDocument.uri);

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -608,6 +608,11 @@ void SlangServer::onDocDidChange(const lsp::DidChangeTextDocumentParams& params)
 void SlangServer::onDocDidSave(const lsp::DidSaveTextDocumentParams& params) {
     m_indexer.waitForIndexingCompletion();
 
+    // Only process documents that have been explicitly opened by the client
+    if (!m_driver->isDocumentOpen(params.textDocument.uri)) {
+        return;
+    }
+
     auto doc = m_driver->getDocument(params.textDocument.uri);
     if (!doc) {
         throw std::runtime_error(


### PR DESCRIPTION
Some editors send `didSave` events for any saved document, and not only SystemVerilog files. See zed-industries/zed#37813. The LSP spec is not 100% clear on this, although an issue in the LSP repo (microsoft/language-server-protocol#2110) seems to say this is not allowed.

This results in `slang-server` getting `didSave` notifications for any type of document, which will load and issue diagnostics.

The proposed fix is to filter the URIs in `didSave`, allowing through only the ones that correspond to documents actually opened with `didOpen`. Maybe this can create issues if non-verilog files are included into verilog files, or if the editor can send `didSave` events to non-opened files (maybe when renaming a symbol?).