### PR TITLE
Fix hovers for invalid utf chars in parameter values.

### DIFF
--- a/include/util/Formatting.h
+++ b/include/util/Formatting.h
@@ -9,6 +9,10 @@
 
 #include "slang/syntax/SyntaxNode.h"
 
+namespace slang {
+class ConstantValue;
+} // namespace slang
+
 namespace slang::ast {
 class Type;
 class ValueSymbol;
@@ -51,6 +55,10 @@ lsp::MarkupContent svCodeBlock(const syntax::SyntaxNode& node);
 void ltrim(std::string& s);
 
 std::string toCamelCase(std::string_view str);
+
+/// @brief Format a ConstantValue for display in hovers
+/// For string values, shows escaped invalid UTF-8 characters
+std::string formatConstantValue(const slang::ConstantValue& value);
 
 // Print the canonical type nicely, if it's a type alias
 template<bool isMarkdown>

--- a/src/Hovers.cpp
+++ b/src/Hovers.cpp
@@ -70,7 +70,7 @@ lsp::MarkupContent getHover(const SourceManager& sm, const BufferID docBuffer,
             auto& param = info.symbol->as<ast::ParameterSymbol>();
             auto value = param.getValue();
             if (!value.bad()) {
-                infoPg.appendText("Value: ").appendCode(value.toString()).newLine();
+                infoPg.appendText("Value: ").appendCode(formatConstantValue(value)).newLine();
             }
         }
         else if (ast::Type::isKind(info.symbol->kind)) {


### PR DESCRIPTION
Stacked PRs:
 * #245
 * #244
 * #243
 * #242
 * __->__#239


--- --- ---

### Fix hovers for invalid utf chars in parameter values.


Shows string with escaped invalid chars now, instead of crashing on json serialization. Surprising I couldn't find a reflect-cpp option for handling these gracefully.
