### PR TITLE
[VSCode] Add deprecation warning to `server.json` schema

### DIFF
--- a/clients/vscode/resources/config.schema.json
+++ b/clients/vscode/resources/config.schema.json
@@ -11,10 +11,12 @@
         },
         "indexGlobs": {
           "type": "array",
-          "description": "Deprecated: use 'index' instead. Globs of what to index. By default will index all sv and svh files in the workspace.",
+          "description": "Globs of what to index. By default will index all sv and svh files in the workspace.",
           "items": {
             "type": "string"
-          }
+          },
+          "deprecated": true,
+          "deprecationMessage": "Deprecated: use 'index' instead."
         },
         "index": {
           "type": "array",
@@ -25,10 +27,12 @@
         },
         "excludeDirs": {
           "type": "array",
-          "description": "Deprecated: use 'index' instead. Directories to exclude",
+          "description": "Directories to exclude",
           "items": {
             "type": "string"
-          }
+          },
+          "deprecated": true,
+          "deprecationMessage": "Deprecated: use 'index' instead."
         },
         "indexingThreads": {
           "type": "integer",


### PR DESCRIPTION
Been using indexGlob and I didn't even realize it was deprecated. Hopefully this will help future users from making the same mistake and allow it to eventually be phased out in a future release

Neovim may need to be changed as well