### PR TITLE
Fix VS Code grammar to highlight nested structs properly (#238)

### DIFF
--- a/clients/vscode/languages/sv/systemverilog.tmLanguage.json
+++ b/clients/vscode/languages/sv/systemverilog.tmLanguage.json
@@ -220,7 +220,7 @@
       "name": "meta.typedef.systemverilog"
     },
     "typedef-enum-struct-union": {
-      "begin": "[ \\t\\r\\n]*\\b(typedef)[ \\t\\r\\n]+(enum|struct|union(?:[ \\t\\r\\n]+tagged)?|class|interface[ \\t\\r\\n]+class)(?:[ \\t\\r\\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?))?(?:[ \\t\\r\\n]+(packed))?(?:[ \\t\\r\\n]+(signed|unsigned))?(?=[ \\t\\r\\n]*(?:{|$))",
+      "begin": "[ \\t\\r\\n]*\\b(typedef)[ \\t\\r\\n]+(enum|struct|union(?:[ \\t\\r\\n]+tagged)?|class|interface[ \\t\\r\\n]+class)(?:[ \\t\\r\\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?))?(?:[ \\t\\r\\n]+(packed))?(?:[ \\t\\r\\n]+(signed|unsigned))?(?=[ \\t\\r\\n]*(?:\\{|$))(?:[ \\t\\r\\n]*(\\{))?",
       "beginCaptures": {
         "1": {
           "name": "keyword.control.systemverilog"
@@ -247,14 +247,20 @@
         },
         "6": {
           "name": "storage.modifier.systemverilog"
+        },
+        "7": {
+          "name": "punctuation.section.block.begin.systemverilog"
         }
       },
-      "end": "(?<=})[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \\t\\r\\n])\\\\[!-~]+(?=$|[ \\t\\r\\n]))(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?)[ \\t\\r\\n]*[,;]",
+      "end": "(})[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \\t\\r\\n])\\\\[!-~]+(?=$|[ \\t\\r\\n]))(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?)[ \\t\\r\\n]*[,;]",
       "endCaptures": {
         "1": {
-          "name": "storage.type.systemverilog"
+          "name": "punctuation.section.block.end.systemverilog"
         },
         "2": {
+          "name": "storage.type.systemverilog"
+        },
+        "3": {
           "patterns": [
             {
               "include": "#selects"
@@ -263,6 +269,9 @@
         }
       },
       "patterns": [
+        {
+          "include": "#enum-struct-union"
+        },
         {
           "include": "#port-net-parameter"
         },
@@ -279,7 +288,7 @@
       "name": "meta.typedef-enum-struct-union.systemverilog"
     },
     "enum-struct-union": {
-      "begin": "[ \\t\\r\\n]*\\b(enum|struct|union(?:[ \\t\\r\\n]+tagged)?|class|interface[ \\t\\r\\n]+class)(?:[ \\t\\r\\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?))?(?:[ \\t\\r\\n]+(packed))?(?:[ \\t\\r\\n]+(signed|unsigned))?(?=[ \\t\\r\\n]*(?:{|$))",
+      "begin": "[ \\t\\r\\n]*\\b(enum|struct|union(?:[ \\t\\r\\n]+tagged)?|class|interface[ \\t\\r\\n]+class)(?:[ \\t\\r\\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?))?(?:[ \\t\\r\\n]+(packed))?(?:[ \\t\\r\\n]+(signed|unsigned))?(?=[ \\t\\r\\n]*(?:\\{|$))(?:[ \\t\\r\\n]*(\\{))?",
       "beginCaptures": {
         "1": {
           "name": "keyword.control.systemverilog"
@@ -303,18 +312,24 @@
         },
         "5": {
           "name": "storage.modifier.systemverilog"
+        },
+        "6": {
+          "name": "punctuation.section.block.begin.systemverilog"
         }
       },
-      "end": "(?<=})[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \\t\\r\\n])\\\\[!-~]+(?=$|[ \\t\\r\\n]))(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?)[ \\t\\r\\n]*[,;]",
+      "end": "(})[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \\t\\r\\n])\\\\[!-~]+(?=$|[ \\t\\r\\n]))(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?)[ \\t\\r\\n]*[,;]",
       "endCaptures": {
         "1": {
+          "name": "punctuation.section.block.end.systemverilog"
+        },
+        "2": {
           "patterns": [
             {
               "include": "#identifiers"
             }
           ]
         },
-        "2": {
+        "3": {
           "patterns": [
             {
               "include": "#selects"

--- a/clients/vscode/languages/sv/systemverilog.tmLanguage.yaml
+++ b/clients/vscode/languages/sv/systemverilog.tmLanguage.yaml
@@ -102,7 +102,7 @@ repository:
     name: meta.typedef.systemverilog
   typedef-enum-struct-union:
     begin: >-
-      [ \t\r\n]*\b(typedef)[ \t\r\n]+(enum|struct|union(?:[ \t\r\n]+tagged)?|class|interface[ \t\r\n]+class)(?:[ \t\r\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?))?(?:[ \t\r\n]+(packed))?(?:[ \t\r\n]+(signed|unsigned))?(?=[ \t\r\n]*(?:{|$))
+      [ \t\r\n]*\b(typedef)[ \t\r\n]+(enum|struct|union(?:[ \t\r\n]+tagged)?|class|interface[ \t\r\n]+class)(?:[ \t\r\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?))?(?:[ \t\r\n]+(packed))?(?:[ \t\r\n]+(signed|unsigned))?(?=[ \t\r\n]*(?:\{|$))(?:[ \t\r\n]*(\{))?
     beginCaptures:
       '1':
         name: keyword.control.systemverilog
@@ -118,14 +118,19 @@ repository:
         name: storage.modifier.systemverilog
       '6':
         name: storage.modifier.systemverilog
-    end: (?<=})[ \t\r\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \t\r\n])\\[!-~]+(?=$|[ \t\r\n]))(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?)[ \t\r\n]*[,;]
+      '7':
+        name: punctuation.section.block.begin.systemverilog
+    end: (})[ \t\r\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \t\r\n])\\[!-~]+(?=$|[ \t\r\n]))(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?)[ \t\r\n]*[,;]
     endCaptures:
       '1':
-        name: storage.type.systemverilog
+        name: punctuation.section.block.end.systemverilog
       '2':
+        name: storage.type.systemverilog
+      '3':
         patterns:
           - include: '#selects'
     patterns:
+      - include: '#enum-struct-union'
       - include: '#port-net-parameter'
       - include: '#keywords'
       - include: '#base-grammar'
@@ -133,7 +138,7 @@ repository:
     name: meta.typedef-enum-struct-union.systemverilog
   enum-struct-union:
     begin: >-
-      [ \t\r\n]*\b(enum|struct|union(?:[ \t\r\n]+tagged)?|class|interface[ \t\r\n]+class)(?:[ \t\r\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?))?(?:[ \t\r\n]+(packed))?(?:[ \t\r\n]+(signed|unsigned))?(?=[ \t\r\n]*(?:{|$))
+      [ \t\r\n]*\b(enum|struct|union(?:[ \t\r\n]+tagged)?|class|interface[ \t\r\n]+class)(?:[ \t\r\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?))?(?:[ \t\r\n]+(packed))?(?:[ \t\r\n]+(signed|unsigned))?(?=[ \t\r\n]*(?:\{|$))(?:[ \t\r\n]*(\{))?
     beginCaptures:
       '1':
         name: keyword.control.systemverilog
@@ -147,12 +152,16 @@ repository:
         name: storage.modifier.systemverilog
       '5':
         name: storage.modifier.systemverilog
-    end: (?<=})[ \t\r\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \t\r\n])\\[!-~]+(?=$|[ \t\r\n]))(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?)[ \t\r\n]*[,;]
+      '6':
+        name: punctuation.section.block.begin.systemverilog
+    end: (})[ \t\r\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \t\r\n])\\[!-~]+(?=$|[ \t\r\n]))(?:[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?)[ \t\r\n]*[,;]
     endCaptures:
       '1':
+        name: punctuation.section.block.end.systemverilog
+      '2':
         patterns:
           - include: '#identifiers'
-      '2':
+      '3':
         patterns:
           - include: '#selects'
     patterns:


### PR DESCRIPTION
Fixes #238

The issue: The VS Code TextMate grammar was dropping syntax highlighting for nested structs inside typedef union packed blocks after the first struct.

The root cause: The typedef-enum-struct-union rule was prematurely matching the closing } of the first inner struct, mistakenly thinking the entire outer typedef block had ended.

The fix:
- Updated the YAML grammar to properly capture { and } as punctuation scopes.
- Allowed the typedef rule to recurse into #enum-struct-union so the inner struct consumes its own braces, preventing the outer rule from terminating early.
- Regenerated `systemverilog.tmLanguage.json` directly from the YAML via pnpm syntax.

Validation: Verified this works correctly in the VS Code Extension Development Host using the repro snippet from the issue thread:

```
typedef union packed {
  struct packed {logic val;} s1;
  struct packed {logic val;} s1;
} u_t;

```

