### PR TITLE
Filter workspace/symbol results using query parameter

### DIFF
--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -17,6 +17,7 @@
 #include "util/Converters.h"
 #include "util/Logging.h"
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <fmt/base.h>
 #include <fmt/ranges.h>
@@ -644,13 +645,26 @@ void SlangServer::onWorkspaceDidChangeWatchedFiles(const lsp::DidChangeWatchedFi
     m_indexer.onWorkspaceDidChangeWatchedFiles(params);
 }
 
+static bool fuzzyMatch(std::string_view query, std::string_view candidate) {
+    auto qi = query.begin();
+    for (auto ci = candidate.begin(); qi != query.end() && ci != candidate.end(); ++ci) {
+        if (static_cast<char>(std::tolower(static_cast<unsigned char>(*qi))) ==
+            static_cast<char>(std::tolower(static_cast<unsigned char>(*ci)))) {
+            ++qi;
+        }
+    }
+    return qi == query.end();
+}
+
 rfl::Variant<std::vector<lsp::SymbolInformation>, std::vector<lsp::WorkspaceSymbol>, std::monostate>
-SlangServer::getWorkspaceSymbol(const lsp::WorkspaceSymbolParams&) {
+SlangServer::getWorkspaceSymbol(const lsp::WorkspaceSymbolParams& params) {
     slang::TimeTraceScope _timeScope("getWorkspaceSymbol", "");
 
     std::vector<lsp::WorkspaceSymbol> result;
 
     m_indexer.forEachSymbol([&](const std::string& name, const Indexer::GlobalSymbolLoc& entry) {
+        if (!params.query.empty() && !fuzzyMatch(params.query, name))
+            return;
         result.emplace_back(
             lsp::WorkspaceSymbol{.location = lsp::LocationUriOnly{URI::fromFile(*entry.uri)},
                                  .name = name,

--- a/tests/cpp/WorkspaceSymbolTests.cpp
+++ b/tests/cpp/WorkspaceSymbolTests.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "utils/ServerHarness.h"
+#include <set>
+#include <string>
+
+using namespace server;
+
+static std::set<std::string> getSymbolNames(ServerHarness& server, const std::string& query) {
+    auto result = server.getWorkspaceSymbol(lsp::WorkspaceSymbolParams{.query = query});
+    auto symbols = rfl::get<std::vector<lsp::WorkspaceSymbol>>(result);
+    std::set<std::string> names;
+    for (const auto& sym : symbols) {
+        names.insert(sym.name);
+    }
+    return names;
+}
+
+TEST_CASE("Workspace symbol - empty query returns all") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module Alpha;
+    logic a;
+endmodule
+
+module Beta;
+    logic b;
+endmodule
+)");
+    doc.save();
+
+    auto names = getSymbolNames(server, "");
+    CHECK(names.count("Alpha") == 1);
+    CHECK(names.count("Beta") == 1);
+
+    doc.close();
+}
+
+TEST_CASE("Workspace symbol - exact match") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module Alpha;
+    logic a;
+endmodule
+
+module Beta;
+    logic b;
+endmodule
+)");
+    doc.save();
+
+    auto names = getSymbolNames(server, "Alpha");
+    CHECK(names.count("Alpha") == 1);
+    CHECK(names.count("Beta") == 0);
+
+    doc.close();
+}
+
+TEST_CASE("Workspace symbol - case insensitive") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module TestModule;
+    logic a;
+endmodule
+)");
+    doc.save();
+
+    auto names = getSymbolNames(server, "testmodule");
+    CHECK(names.count("TestModule") == 1);
+
+    names = getSymbolNames(server, "TESTMODULE");
+    CHECK(names.count("TestModule") == 1);
+
+    doc.close();
+}
+
+TEST_CASE("Workspace symbol - subsequence match") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module TestModule;
+    logic a;
+endmodule
+
+module FooBar;
+    logic b;
+endmodule
+)");
+    doc.save();
+
+    auto names = getSymbolNames(server, "tml");
+    CHECK(names.count("TestModule") == 1);
+    CHECK(names.count("FooBar") == 0);
+
+    names = getSymbolNames(server, "fb");
+    CHECK(names.count("FooBar") == 1);
+    CHECK(names.count("TestModule") == 0);
+
+    doc.close();
+}
+
+TEST_CASE("Workspace symbol - no match returns empty") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module Alpha;
+    logic a;
+endmodule
+)");
+    doc.save();
+
+    auto names = getSymbolNames(server, "xyz");
+    CHECK(names.empty());
+
+    doc.close();
+}
+
+TEST_CASE("Workspace symbol - wrong order does not match") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module TestModule;
+    logic a;
+endmodule
+)");
+    doc.save();
+
+    auto names = getSymbolNames(server, "lmt");
+    CHECK(names.count("TestModule") == 0);
+
+    doc.close();
+}


### PR DESCRIPTION
Closes #272

`getWorkspaceSymbol` was ignoring `params.query` and returning every indexed symbol. This adds case-insensitive subsequence matching as described in the LSP spec (`LspTypes.h:4748-4752`) — the characters of the query must appear in order in the candidate symbol name. An empty query still returns everything.

I went with a simple subsequence matcher rather than pulling in rapidfuzz since the LSP spec explicitly describes this behavior and clients already apply their own scoring/highlighting on the results. Happy to switch to rapidfuzz if you'd prefer ranked results down the line.

### Changes
- `src/SlangServer.cpp` — named the `params` arg, added a `fuzzyMatch` helper, gated `emplace_back` on the match
- `tests/cpp/WorkspaceSymbolTests.cpp` — 6 test cases covering empty query, exact match, case-insensitive, subsequence, no match, and wrong character order

All 158 existing tests still pass.