### PR TITLE
Support Non-ANSI style hovers

### DIFF
--- a/include/Hovers.h
+++ b/include/Hovers.h
@@ -9,7 +9,8 @@
 
 namespace server {
 
-lsp::MarkupContent getHover(const SourceManager& sm, const BufferID docBuffer,
-                            const DefinitionInfo& info, const Config::HoverConfig& hovers);
+lsp::MarkupContent getHover(const std::shared_ptr<ShallowAnalysis> sa, const SourceManager& sm,
+                            const BufferID docBuffer, const DefinitionInfo& info,
+                            const Config::HoverConfig& hovers);
 
 }

--- a/src/Hovers.cpp
+++ b/src/Hovers.cpp
@@ -20,8 +20,111 @@
 
 namespace server {
 
-lsp::MarkupContent getHover(const SourceManager& sm, const BufferID docBuffer,
-                            const DefinitionInfo& info, const Config::HoverConfig& hovers) {
+namespace {
+
+struct PortInfo {
+    std::string name;
+    std::string direction;
+    std::string type;
+    bool isAnsi = true;
+};
+
+struct PortsInfo {
+    std::vector<PortInfo> ports;
+    bool hasAnsiPorts;
+};
+
+std::string portDirectionToString(ast::ArgumentDirection dir) {
+    switch (dir) {
+        case ast::ArgumentDirection::In:
+            return "input";
+        case ast::ArgumentDirection::Out:
+            return "output";
+        case ast::ArgumentDirection::InOut:
+            return "inout";
+        case ast::ArgumentDirection::Ref:
+            return "ref";
+        default:
+            return "";
+    };
+};
+
+PortsInfo getPorts(std::shared_ptr<ShallowAnalysis> analysis, std::string_view moduleName) {
+    using namespace slang;
+    using namespace slang::ast;
+
+    PortsInfo result;
+
+    const Symbol* sym = analysis->getDefinition(moduleName);
+    if (!sym || sym->kind != SymbolKind::Definition)
+        return result;
+
+    const auto& def = sym->as<DefinitionSymbol>();
+    auto& comp = *analysis->getCompilation();
+    const auto& inst = InstanceSymbol::createDefault(comp, def);
+    const auto& body = inst.body;
+
+    result.hasAnsiPorts = !def.hasNonAnsiPorts;
+
+    for (const Symbol* s : body.getPortList()) {
+        switch (s->kind) {
+            case SymbolKind::Port: {
+                const auto& port = s->as<PortSymbol>();
+                result.ports.push_back({std::string(port.name),
+                                        std::string(portDirectionToString(port.direction)),
+                                        std::string(port.getType().toString()), port.isAnsiPort});
+                break;
+            }
+
+            case SymbolKind::MultiPort: {
+                const auto& mp = s->as<MultiPortSymbol>();
+                for (auto& port : mp.ports) {
+                    result.ports.push_back({std::string(port->name),
+                                            std::string(portDirectionToString(port->direction)),
+                                            std::string(port->getType().toString()),
+                                            port->isAnsiPort});
+                }
+                break;
+            }
+
+            case SymbolKind::InterfacePort: {
+                const auto& ip = s->as<InterfacePortSymbol>();
+                result.ports.push_back({std::string(ip.name), "interface", "", true});
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    return result;
+}
+
+std::string formatNonAnsiModulePorts(const PortsInfo& ports) {
+    fmt::memory_buffer out;
+
+    for (const auto& port : ports.ports) {
+        if (port.direction == "interface") {
+            fmt::format_to(fmt::appender(out), "   interface {};\n", port.name);
+        }
+        else if (!port.type.empty()) {
+            fmt::format_to(fmt::appender(out), "   {} {} {};\n", port.direction, port.type,
+                           port.name);
+        }
+        else {
+            fmt::format_to(fmt::appender(out), "   {} {};\n", port.direction, port.name);
+        }
+    }
+
+    return fmt::to_string(out);
+}
+
+} // namespace
+
+lsp::MarkupContent getHover(const std::shared_ptr<ShallowAnalysis> sa, const SourceManager& sm,
+                            const BufferID docBuffer, const DefinitionInfo& info,
+                            const Config::HoverConfig& hovers) {
     markup::Document doc;
 
     auto& infoPg = doc.addParagraph();
@@ -137,7 +240,22 @@ lsp::MarkupContent getHover(const SourceManager& sm, const BufferID docBuffer,
         const std::string docComments = getDocCommentForHover(display_node, docCommentFormat);
         if (!docComments.empty())
             doc.addParagraph().appendText(docComments).newLine();
-        doc.addParagraph().appendCodeBlock(formatCode(display_node));
+        std::string codeBlock = formatCode(display_node);
+
+        if (display_node.kind == syntax::SyntaxKind::ModuleHeader && info.symbol &&
+            info.symbol->kind == ast::SymbolKind::Definition) {
+            const auto ports = getPorts(sa, info.symbol->name);
+
+            if (!ports.hasAnsiPorts) {
+                const auto portSummary = formatNonAnsiModulePorts(ports);
+                if (!portSummary.empty()) {
+                    codeBlock += "\n" + portSummary +
+                                 "\n  endmodule : " + std::string(info.symbol->name);
+                }
+            }
+        }
+
+        doc.addParagraph().appendCodeBlock(codeBlock);
     }
 
     // Show what a macro expands to

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -657,7 +657,8 @@ std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::P
         return {};
     }
     const auto& info = *maybeInfo;
-    return lsp::Hover{.contents = getHover(sm, doc->getBuffer(), info, m_config.hovers.value())};
+    return lsp::Hover{.contents = getHover(doc->getAnalysis(), sm, doc->getBuffer(), info,
+                                           m_config.hovers.value())};
 }
 
 std::vector<lsp::LocationLink> ServerDriver::getDocDefinition(const URI& uri,

--- a/tests/cpp/PortsTests.cpp
+++ b/tests/cpp/PortsTests.cpp
@@ -1,0 +1,78 @@
+#include "document/SyntaxIndexer.h"
+#include "util/Converters.h"
+#include "utils/ServerHarness.h"
+#include <catch2/catch_test_macros.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/text/SourceManager.h"
+
+struct PortInfo {
+    std::string name;
+    std::string direction;
+};
+
+std::vector<PortInfo> getPorts(std::shared_ptr<hier::ShallowAnalysis> analysis,
+                               std::string_view moduleName) {
+    using namespace slang;
+    using namespace slang::ast;
+
+    std::vector<PortInfo> result;
+
+    const Symbol* sym = analysis->getDefinition(moduleName);
+    if (!sym || sym->kind != SymbolKind::Definition)
+        return result;
+
+    const auto& def = sym->as<DefinitionSymbol>();
+    auto& comp = *analysis->getCompilation();
+    const auto& inst = InstanceSymbol::createDefault(comp, def);
+    const auto& body = inst.body;
+
+    for (const Symbol* s : body.getPortList()) {
+        switch (s->kind) {
+            case SymbolKind::Port: {
+                const auto& port = s->as<PortSymbol>();
+                result.push_back({std::string(port.name), std::string(toString(port.direction))});
+                break;
+            }
+
+            case SymbolKind::MultiPort: {
+                const auto& mp = s->as<MultiPortSymbol>();
+                for (auto& port : mp.ports) {
+                    result.push_back(
+                        {std::string(port->name), std::string(toString(port->direction))});
+                }
+                break;
+            }
+
+            case SymbolKind::InterfacePort: {
+                const auto& ip = s->as<InterfacePortSymbol>();
+                result.push_back({std::string(ip.name), "interface"});
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    return result;
+}
+
+TEST_CASE("GetPortsNonAnsi") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module mymod(clk, rst, io, done);
+    input clk;
+    input rst;
+    inout io;
+    output done;
+endmodule
+)");
+
+    auto analysis = doc.doc->getAnalysis();
+    auto ports = getPorts(analysis, "mymod");
+
+    JsonGoldenTest golden;
+    golden.record(ports);
+}

--- a/tests/cpp/PortsTests.cpp
+++ b/tests/cpp/PortsTests.cpp
@@ -1,3 +1,4 @@
+#include "Hovers.h"
 #include "document/SyntaxIndexer.h"
 #include "util/Converters.h"
 #include "utils/ServerHarness.h"
@@ -9,14 +10,35 @@
 struct PortInfo {
     std::string name;
     std::string direction;
+    std::string type;
+    bool isAnsi = true;
 };
 
-std::vector<PortInfo> getPorts(std::shared_ptr<hier::ShallowAnalysis> analysis,
-                               std::string_view moduleName) {
+struct PortsInfo {
+    std::vector<PortInfo> ports;
+    bool hasAnsiPorts;
+};
+
+std::string portDirectionToString(ast::ArgumentDirection dir) {
+    switch (dir) {
+        case ast::ArgumentDirection::In:
+            return "input";
+        case ast::ArgumentDirection::Out:
+            return "output";
+        case ast::ArgumentDirection::InOut:
+            return "inout";
+        case ast::ArgumentDirection::Ref:
+            return "ref";
+        default:
+            return "";
+    };
+};
+
+PortsInfo getPorts(std::shared_ptr<hier::ShallowAnalysis> analysis, std::string_view moduleName) {
     using namespace slang;
     using namespace slang::ast;
 
-    std::vector<PortInfo> result;
+    PortsInfo result;
 
     const Symbol* sym = analysis->getDefinition(moduleName);
     if (!sym || sym->kind != SymbolKind::Definition)
@@ -27,26 +49,32 @@ std::vector<PortInfo> getPorts(std::shared_ptr<hier::ShallowAnalysis> analysis,
     const auto& inst = InstanceSymbol::createDefault(comp, def);
     const auto& body = inst.body;
 
+    result.hasAnsiPorts = !def.hasNonAnsiPorts;
+
     for (const Symbol* s : body.getPortList()) {
         switch (s->kind) {
             case SymbolKind::Port: {
                 const auto& port = s->as<PortSymbol>();
-                result.push_back({std::string(port.name), std::string(toString(port.direction))});
+                result.ports.push_back({std::string(port.name),
+                                        std::string(portDirectionToString(port.direction)),
+                                        std::string(port.getType().toString()), port.isAnsiPort});
                 break;
             }
 
             case SymbolKind::MultiPort: {
                 const auto& mp = s->as<MultiPortSymbol>();
                 for (auto& port : mp.ports) {
-                    result.push_back(
-                        {std::string(port->name), std::string(toString(port->direction))});
+                    result.ports.push_back({std::string(port->name),
+                                            std::string(portDirectionToString(port->direction)),
+                                            std::string(port->getType().toString()),
+                                            port->isAnsiPort});
                 }
                 break;
             }
 
             case SymbolKind::InterfacePort: {
                 const auto& ip = s->as<InterfacePortSymbol>();
-                result.push_back({std::string(ip.name), "interface"});
+                result.ports.push_back({std::string(ip.name), "interface", "", true});
                 break;
             }
 
@@ -63,10 +91,10 @@ TEST_CASE("GetPortsNonAnsi") {
 
     auto doc = server.openFile("test.sv", R"(
 module mymod(clk, rst, io, done);
-    input clk;
-    input rst;
-    inout io;
-    output done;
+    input logic clk;
+    input logic rst;
+    inout logic io;
+    output logic done;
 endmodule
 )");
 
@@ -75,4 +103,41 @@ endmodule
 
     JsonGoldenTest golden;
     golden.record(ports);
+}
+
+TEST_CASE("GetPortsAnsi") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module mymod(input logic clk, output logic done);
+endmodule
+)");
+
+    auto analysis = doc.doc->getAnalysis();
+    auto ports = getPorts(analysis, "mymod");
+
+    JsonGoldenTest golden;
+    golden.record(ports);
+}
+
+TEST_CASE("GetPortsNonAnsi_Hovers") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module mymod(clk, rst, io, done);
+    input logic clk;
+    input logic rst;
+    inout logic io;
+    output logic done;
+endmodule
+)");
+
+    auto analysis = doc.doc->getAnalysis();
+    auto ports = getPorts(analysis, "mymod");
+
+    auto cursor = doc.before("mymod");
+    auto s = doc.getHoverAt(cursor.m_offset);
+
+    JsonGoldenTest golden;
+    golden.record(s->contents);
 }

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -732,7 +732,7 @@ endprimitive
 
 (* attr = 3.14 *) bind m3.m m1 #(1) bound('x, , , );
                           ^ Ref -> **Instance** `m` in `m3`  \n\Type: m2  \n\\n\\n\---\n\\n\`m2 #(\n\    .x_t(y_t)\n\) m (, b, c, d, );`
-                            ^^ Ref -> **Definition** `m1`  \n\\n\\n\---\n\\n\`module automatic m1 import p::*; #(int i = 1)\n\(a, b, , .c({a, b[0]}));`
+                            ^^ Ref -> **Definition** `m1`  \n\\n\\n\---\n\\n\`module automatic m1 import p::*; #(int i = 1)\n\(a, b, , .c({a, b[0]}));\n\   input logic a;\n\   output logic[1:0] b;\n\   input void ;\n\   input logic a;\n\   output logic ;\n\\n\  endmodule : m1`
                                     ^^^^^ Sym bound : Instance
 
 

--- a/tests/cpp/golden/GetPortsAnsi.json
+++ b/tests/cpp/golden/GetPortsAnsi.json
@@ -1,0 +1,19 @@
+[
+  {
+    "ports": [
+      {
+        "name": "clk",
+        "direction": "input",
+        "type": "logic",
+        "isAnsi": true
+      },
+      {
+        "name": "done",
+        "direction": "output",
+        "type": "logic",
+        "isAnsi": true
+      }
+    ],
+    "hasAnsiPorts": true
+  }
+]

--- a/tests/cpp/golden/GetPortsNonAnsi.json
+++ b/tests/cpp/golden/GetPortsNonAnsi.json
@@ -1,0 +1,20 @@
+[
+  [
+    {
+      "name": "clk",
+      "direction": "In"
+    },
+    {
+      "name": "rst",
+      "direction": "In"
+    },
+    {
+      "name": "io",
+      "direction": "InOut"
+    },
+    {
+      "name": "done",
+      "direction": "Out"
+    }
+  ]
+]

--- a/tests/cpp/golden/GetPortsNonAnsi.json
+++ b/tests/cpp/golden/GetPortsNonAnsi.json
@@ -1,20 +1,31 @@
 [
-  [
-    {
-      "name": "clk",
-      "direction": "In"
-    },
-    {
-      "name": "rst",
-      "direction": "In"
-    },
-    {
-      "name": "io",
-      "direction": "InOut"
-    },
-    {
-      "name": "done",
-      "direction": "Out"
-    }
-  ]
+  {
+    "ports": [
+      {
+        "name": "clk",
+        "direction": "input",
+        "type": "logic",
+        "isAnsi": false
+      },
+      {
+        "name": "rst",
+        "direction": "input",
+        "type": "logic",
+        "isAnsi": false
+      },
+      {
+        "name": "io",
+        "direction": "inout",
+        "type": "logic",
+        "isAnsi": false
+      },
+      {
+        "name": "done",
+        "direction": "output",
+        "type": "logic",
+        "isAnsi": false
+      }
+    ],
+    "hasAnsiPorts": false
+  }
 ]

--- a/tests/cpp/golden/GetPortsNonAnsi_Hovers.json
+++ b/tests/cpp/golden/GetPortsNonAnsi_Hovers.json
@@ -1,0 +1,6 @@
+[
+  {
+    "kind": "markdown",
+    "value": "**Definition** `mymod`  \n\n\n---\n\n````systemverilog\nmodule mymod(clk, rst, io, done);\n   input logic clk;\n   input logic rst;\n   inout logic io;\n   output logic done;\n\n  endmodule : mymod\n````"
+  }
+]


### PR DESCRIPTION
~~Unfortunately~~ some people prefer the non-ANSI style of ports so this PR adds input/output declarations to the hovers to make it easier to see which ports to use.

See this reddit thread for the difference:

https://www.reddit.com/r/Verilog/comments/1jpz9w9/verilog_port_styles_ansi_vs_nonansi_which_one/