### PR TITLE
Improve LazyVim install instructions

### DIFF
--- a/docs/start/installing.md
+++ b/docs/start/installing.md
@@ -82,7 +82,7 @@ return {
 }
 ```
 
-The above assumes that a slang-server config has been added to `nvim-lspconfig` using one of the preceding steps.
+The above assumes that a slang-server config has been added to `vim.lsp.config` or `nvim-lspconfig` using one of the preceding steps.
 
 Optionally, run `:LspInfo` to make sure the LSP was correctly installed.
 

--- a/docs/start/installing.md
+++ b/docs/start/installing.md
@@ -1,6 +1,5 @@
 # Installing
 
-
 ### Vscode
 
 Install the extension [here](https://marketplace.visualstudio.com/items?itemName=Hudson-River-Trading.vscode-slang). Then, it will prompt you to allow the extension to autoinstall the server binary from the [releases](https://github.com/hudson-trading/slang-server/releases) page. Alternatively, you can set `slang.path` to you built slang-server binary.
@@ -13,8 +12,8 @@ Install from your editor, or download from the [OpenVSX Marketplace](https://ope
 
 > `slang-server` will eventually be added to [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) and [mason.nvim](https://github.com/mason-org/mason.nvim) so that no additional configuration will be required. Until then, follow one of the methods below to manually add the server configuration.
 
+For newer versions of Neovim (≥ v0.11), the new [vim.lsp API](<https://neovim.io/doc/user/lsp.html#vim.lsp.start()>) is the preferred, simpler way to configure language servers:
 
-For newer versions of Neovim (≥ v0.11), the new [vim.lsp API](https://neovim.io/doc/user/lsp.html#vim.lsp.start()) is the preferred, simpler way to configure language servers:
 ```lua
 vim.lsp.config("slang-server", {
   cmd = { "slang-server" },
@@ -29,6 +28,7 @@ vim.lsp.enable("slang-server")
 ```
 
 For older versions of Neovim (< v0.11) with `nvim-lspconfig`, the server can be configured with:
+
 ```lua
 local configs = require("lspconfig.configs")
 local util = require("lspconfig.util")
@@ -52,49 +52,42 @@ if not configs.slang_server then
 end
 ```
 
-For users of lazy.nvim, the above could be added to their `nvim-lspconfig` spec at `~/.config/nvim/lua/plugins/nvim-lspconfig.lua` like this:
+For users of lazy.nvim, add the `nvim-lspconfig` config to `<runtimepath>/lsp/slang.lua`:
+
+```lua
+---@type vim.lsp.Config
+return {
+  cmd = { "slang-server" },
+  root_markers = { ".git", ".slang" },
+  filetypes = {
+    "systemverilog",
+    "verilog",
+  },
+}
+```
+
+Then enable the config in LazyVim by adding the following to `<runtimepath>/lua/plugins/slang.lua`:
+
 ```lua
 return {
   "neovim/nvim-lspconfig",
   opts = {
-    setup = {
-      slang_server = function(_, opts)
-        local configs = require("lspconfig.configs")
-        local util = require("lspconfig.util")
-
-        if not configs.slang_server then
-          configs.slang_server = {
-            default_config = {
-              cmd = {
-                "slang-server",
-              },
-              filetypes = {
-                "systemverilog",
-                "verilog",
-              },
-              single_file_support = true,
-              root_dir = function(fname)
-                return util.root_pattern(".git", ".slang")(fname)
-              end,
-            },
-          }
-        end
-      end,
-    },
     servers = {
-      slang_server = {
-        enabled = true,
+      slang = {
+        -- Tell LazyVim that Mason isn't needed since this is a manual config
         mason = false,
       },
     },
   },
 }
+
+Optionally, run `:LspInfo` to make sure the LSP was correctly installed.
 ```
 
 Pointing at the binary is all you need for standard language features, however a plugin is provided to enable some client-side features which extend the LSP (e.g. the hierarchy view, waveform integration). The plugin can be found in `clients/neovim/` and is also mirrored in [slang-server.nvim](https://github.com/hudson-trading/slang-server.nvim) for ease of use with Neovim plugin managers.
 
 ### Other editors
 
-Most modern editors can at least point to a language server binary for specific file types. This will provide standard LSP features, but not HDL specific  features.
+Most modern editors can at least point to a language server binary for specific file types. This will provide standard LSP features, but not HDL specific features.
 
 If the editor also allows for executing LSP commands, HDL features like setting a compilation should be available.

--- a/docs/start/installing.md
+++ b/docs/start/installing.md
@@ -27,6 +27,20 @@ vim.lsp.config("slang-server", {
 vim.lsp.enable("slang-server")
 ```
 
+Alternatively, adding the below to `<runtimepath>/lsp/slang_server.lua` will automatically be picked up by `vim.lsp`:
+
+```lua
+---@type vim.lsp.Config
+return {
+  cmd = { "slang-server" },
+  root_markers = { ".git", ".slang" },
+  filetypes = {
+    "systemverilog",
+    "verilog",
+  },
+}
+```
+
 For older versions of Neovim (< v0.11) with `nvim-lspconfig`, the server can be configured with:
 
 ```lua
@@ -52,37 +66,25 @@ if not configs.slang_server then
 end
 ```
 
-For users of lazy.nvim, add the `nvim-lspconfig` config to `<runtimepath>/lsp/slang.lua`:
-
-```lua
----@type vim.lsp.Config
-return {
-  cmd = { "slang-server" },
-  root_markers = { ".git", ".slang" },
-  filetypes = {
-    "systemverilog",
-    "verilog",
-  },
-}
-```
-
-Then enable the config in LazyVim by adding the following to `<runtimepath>/lua/plugins/slang.lua`:
+For users of lazy.nvim, natively enable the server by adding the following to `<runtimepath>/lua/plugins/slang_server.lua`:
 
 ```lua
 return {
   "neovim/nvim-lspconfig",
   opts = {
     servers = {
-      slang = {
+      slang_server = {
         -- Tell LazyVim that Mason isn't needed since this is a manual config
         mason = false,
       },
     },
   },
 }
+```
+
+The above assumes that a slang-server config has been added to `nvim-lspconfig` using one of the preceding steps.
 
 Optionally, run `:LspInfo` to make sure the LSP was correctly installed.
-```
 
 Pointing at the binary is all you need for standard language features, however a plugin is provided to enable some client-side features which extend the LSP (e.g. the hierarchy view, waveform integration). The plugin can be found in `clients/neovim/` and is also mirrored in [slang-server.nvim](https://github.com/hudson-trading/slang-server.nvim) for ease of use with Neovim plugin managers.
 


### PR DESCRIPTION
Hi there!

Many thanks for the excellent LSP server, I've found this a pleasure to use in my daily use. I run LazyVim and noticed that the installation instructions could be made a bit more idiomatic to match the existing Lazy plugin system.

The idea is to separate the nvim-lspconfig spec, which I presume will eventually make its way into the registry, from the plugin being enabled on LazyVim startup. When `slang-server` gets added to the Mason registry we can even get rid of the `mason = false`. While there are now two files, the line count is much lower and overall the setup is cleaner.

Thanks!