### PR TITLE
No `\n` for completions of interface or module with no ports

### DIFF
--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -194,7 +194,7 @@ void resolveModuleInstance(const slang::syntax::ModuleHeaderSyntax& header,
 
     output.appendText(" ");
     output.appendPlaceholder(toCamelCase(header.name.valueText()));
-    output.appendText(" (\n");
+    output.appendText(" (");
 
     // get ports
     maxLen = 0;
@@ -206,18 +206,22 @@ void resolveModuleInstance(const slang::syntax::ModuleHeaderSyntax& header,
         maxLen = visitor.maxLen;
     }
 
-    // append ports
-    for (size_t i = 0; i < names.size(); ++i) {
-        auto name = std::string{names[i]};
-        auto nameFmt = name + std::string(maxLen - name.length(), ' ');
-        output.appendText("\t." + nameFmt + "(");
-        output.appendPlaceholder(name);
-        output.appendText(")");
-        if (i < names.size() - 1) {
-            output.appendText(",\n");
-        }
-        else {
-            output.appendText("\n");
+    if (names.size() != 0) {
+        output.appendText("\n");
+
+        // append ports
+        for (size_t i = 0; i < names.size(); ++i) {
+            auto name = std::string{names[i]};
+            auto nameFmt = name + std::string(maxLen - name.length(), ' ');
+            output.appendText("\t." + nameFmt + "(");
+            output.appendPlaceholder(name);
+            output.appendText(")");
+            if (i < names.size() - 1) {
+                output.appendText(",\n");
+            }
+            else {
+                output.appendText("\n");
+            }
         }
     }
 

--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -206,7 +206,7 @@ void resolveModuleInstance(const slang::syntax::ModuleHeaderSyntax& header,
         maxLen = visitor.maxLen;
     }
 
-    if (names.size() != 0) {
+    if (!names.empty()) {
         output.appendText("\n");
 
         // append ports

--- a/tests/cpp/golden/ModuleMemberCompletion.json
+++ b/tests/cpp/golden/ModuleMemberCompletion.json
@@ -52,7 +52,7 @@
           "value": "````systemverilog\nmodule cycle_test_module;\n````"
         },
         "filterText": "cycle_test_module",
-        "insertText": "cycle_test_module ${1:cycle_test_module} (\n);",
+        "insertText": "cycle_test_module ${1:cycle_test_module} ();",
         "insertTextFormat": "Snippet"
       },
       {
@@ -78,7 +78,7 @@
           "value": "````systemverilog\nmodule tb;\n````"
         },
         "filterText": "tb",
-        "insertText": "tb ${1:tb} (\n);",
+        "insertText": "tb ${1:tb} ();",
         "insertTextFormat": "Snippet"
       },
       {


### PR DESCRIPTION
This PR improves module-instantiation completions by avoiding an automatic newline after `(` and only switching to multi-line formatting when the module actually has ports. As a result, no-port modules now complete to a compact `foo ();` instead of an awkward multi-line stub. Ported modules still expand into a clean multi-line list. Example: `foo ();` (no ports) vs `foo (\n  .clk(clk),\n  .rst(rst)\n);` (with ports).

-Github Copilot description