### PR TITLE
[VSCode] don't reveal hierarchy on goto signal waveform

### DIFF
--- a/clients/vscode/src/sidebar/ProjectComponent.ts
+++ b/clients/vscode/src/sidebar/ProjectComponent.ts
@@ -1101,7 +1101,7 @@ export class ProjectComponent
         await this.openBuildFile({ name: basename, top: top })
       }
       await this.setInstance.func(fullpath, {
-        revealHierarchy: true,
+        revealHierarchy: false,
         revealFile: true,
         revealInstance: true,
         focus: 'editor',


### PR DESCRIPTION
If I'm in the vaporview tab, then I want to stay in the vaporview tab.