### PR TITLE
Don't ignore neovim client for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
     branches: [main]
     paths-ignore:
       - 'docs/**'
-      - 'clients/**'
+      - 'clients/vscode/**'
       - '*.md'
       - 'mkdocs.yaml'
       - 'pyproject.toml'
@@ -26,7 +26,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - 'clients/**'
+      - 'clients/vscode/**'
       - '*.md'
       - 'mkdocs.yaml'
       - 'pyproject.toml'


### PR DESCRIPTION
`build.yml` is useful for neovim client changes since we have CI for it.