### PR TITLE
Add linux release with newer libc version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
   push:
-    branches: [main]
+    branches: [main, ci-test]
     paths-ignore:
       - 'docs/**'
       - 'clients/**'
@@ -48,6 +48,13 @@ jobs:
             container: rockylinux:8
             artifact_name: slang-server-linux-x64-gcc
             extra_flags: -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++
+          - preset: clang-release
+            os: ubuntu-latest
+            artifact_name: slang-server-newer-linux-x64-clang
+            extra_flags: -DCMAKE_CXX_COMPILER=clang++
+          - preset: gcc-release
+            os: ubuntu-latest
+            artifact_name: slang-server-newer-linux-x64-gcc
           - preset: macos-release
             os: macos-15
             artifact_name: slang-server-macos


### PR DESCRIPTION
Replaces #207.  Adds Ubuntu to the build matrix so we can run CI on linux.

Also adds `ci-test` so we can test on forks before creating a PR.