### PR TITLE
Fix missing diags

### DIFF
--- a/src/ServerDiagClient.cpp
+++ b/src/ServerDiagClient.cpp
@@ -257,6 +257,11 @@ void ServerDiagClient::pushDiags(const URI& priorityUri) {
         m_client.onDocPublishDiagnostics(
             lsp::PublishDiagnosticsParams{.uri = priorityUri, .diagnostics = it->second});
     }
+    else if (m_dirtyUris.contains(priorityUri)) {
+        m_client.onDocPublishDiagnostics(
+            lsp::PublishDiagnosticsParams{.uri = priorityUri, .diagnostics = {}});
+    }
+    m_dirtyUris.erase(priorityUri);
     pushDiags();
 }
 


### PR DESCRIPTION
Fixes `test_diags_update` which was failing because dirty URIs were not being republished on `textDocument/publishDiagnostics`.