### PR TITLE
Additional neovim compatibility tests

### DIFF
--- a/clients/neovim/lua/slang-server/_commands/addToWaves.lua
+++ b/clients/neovim/lua/slang-server/_commands/addToWaves.lua
@@ -5,13 +5,17 @@ local M = {}
 ---@type slang-server.ui.Subcommand
 M.addToWaves = {
    impl = function(args)
+      local capabilities = require("slang-server._lsp.capabilities")
+      local bufnr = vim.api.nvim_get_current_buf()
+      if not capabilities.check_or_notify(bufnr, { "slang.getInstances", "slang.addToWaveform" }) then
+         return
+      end
+
       local client = require("slang-server._lsp.client")
       local handlers = require("slang-server.handlers")
       local ui = require("slang-server._core.ui")
 
       local recursive = args[1] == "true"
-
-      local bufnr = vim.api.nvim_get_current_buf()
 
       local first_client = vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })[1]
       local position_encoding = first_client and first_client.offset_encoding or 'utf-16'

--- a/clients/neovim/lua/slang-server/_commands/hierarchy.lua
+++ b/clients/neovim/lua/slang-server/_commands/hierarchy.lua
@@ -5,6 +5,13 @@ local M = {}
 ---@type slang-server.ui.Subcommand
 M.hierarchy = {
    impl = function(args, opts)
+      local capabilities = require("slang-server._lsp.capabilities")
+      local bufnr = vim.api.nvim_get_current_buf()
+      local required = { "slang.getScope", "slang.getScopesByModule", "slang.getInstancesOfModule" }
+      if not capabilities.check_or_notify(bufnr, required) then
+         return
+      end
+
       local top = args[1]
       require("slang-server.navigation").show(top or "")
    end,

--- a/clients/neovim/lua/slang-server/_commands/openWaveform.lua
+++ b/clients/neovim/lua/slang-server/_commands/openWaveform.lua
@@ -5,11 +5,17 @@ local M = {}
 ---@type slang-server.ui.Subcommand
 M.openWaveform = {
    impl = function(args, opts)
+      local capabilities = require("slang-server._lsp.capabilities")
+      local bufnr = vim.api.nvim_get_current_buf()
+      if not capabilities.check_or_notify(bufnr, { "slang.openWaveform" }) then
+         return
+      end
+
       local client = require("slang-server._lsp.client")
       local handlers = require("slang-server.handlers")
 
       local file = args[1]
-      client.openWaveform(vim.api.nvim_get_current_buf(), handlers.defaultHandlers, { uri = file })
+      client.openWaveform(bufnr, handlers.defaultHandlers, { uri = file })
    end,
    complete = require("slang-server.util").complete_path,
 }

--- a/clients/neovim/lua/slang-server/_commands/setBuildFile.lua
+++ b/clients/neovim/lua/slang-server/_commands/setBuildFile.lua
@@ -5,11 +5,17 @@ local M = {}
 ---@type slang-server.ui.Subcommand
 M.setBuildFile = {
    impl = function(args, opts)
+      local capabilities = require("slang-server._lsp.capabilities")
+      local bufnr = vim.api.nvim_get_current_buf()
+      if not capabilities.check_or_notify(bufnr, { "slang.setBuildFile" }) then
+         return
+      end
+
       local client = require("slang-server._lsp.client")
       local handlers = require("slang-server.handlers")
 
       local file = args[1]
-      client.setBuildFile(vim.api.nvim_get_current_buf(), handlers.defaultHandlers, { uri = file })
+      client.setBuildFile(bufnr, handlers.defaultHandlers, { uri = file })
    end,
    complete = require("slang-server.util").complete_path,
 }

--- a/clients/neovim/lua/slang-server/_commands/setTopLevel.lua
+++ b/clients/neovim/lua/slang-server/_commands/setTopLevel.lua
@@ -5,10 +5,15 @@ local M = {}
 ---@type slang-server.ui.Subcommand
 M.setTopLevel = {
    impl = function(args, opts)
+      local capabilities = require("slang-server._lsp.capabilities")
+      local bufnr = vim.api.nvim_get_current_buf()
+      if not capabilities.check_or_notify(bufnr, { "slang.setTopLevel" }) then
+         return
+      end
+
       local client = require("slang-server._lsp.client")
       local handlers = require("slang-server.handlers")
 
-      local bufnr = vim.api.nvim_get_current_buf()
       local file = args[1] or vim.api.nvim_buf_get_name(bufnr)
       client.setTopLevel(bufnr, handlers.defaultHandlers, { uri = file })
    end,

--- a/clients/neovim/lua/slang-server/_lsp/capabilities.lua
+++ b/clients/neovim/lua/slang-server/_lsp/capabilities.lua
@@ -1,0 +1,130 @@
+local M = {}
+
+M.MIN_SERVER_VERSION = "0.2.2"
+
+local UPGRADE_HINT = "Please upgrade slang-server and possibly also this plugin."
+
+---@param v string
+---@return integer, integer, integer
+local function parse_version(v)
+   v = vim.trim(v):match("^[^+]+") or v
+   local major, minor, patch = v:match("^(%d+)%.(%d+)%.(%d+)")
+   return tonumber(major) or 0, tonumber(minor) or 0, tonumber(patch) or 0
+end
+
+---@param have string
+---@param want string
+---@return boolean
+local function version_at_least(have, want)
+   local hM, hm, hp = parse_version(have)
+   local wM, wm, wp = parse_version(want)
+   if hM ~= wM then
+      return hM > wM
+   end
+   if hm ~= wm then
+      return hm > wm
+   end
+   return hp >= wp
+end
+
+---@param bufnr integer
+---@return vim.lsp.Client?
+function M.get_client(bufnr)
+   for _, client in pairs(vim.lsp.get_clients({ bufnr = bufnr })) do
+      if client.server_info and client.server_info.name == "slang-server" then
+         return client
+      end
+   end
+   return nil
+end
+
+-- Per-client cached commands set. Keyed by client.id; populated lazily on the
+-- first successful static-check pass for that client and held for the client's
+-- lifetime (server_info and server_capabilities don't change after the LSP
+-- initialize handshake). Evicted by the LspDetach autocmd registered below.
+---@type table<integer, table<string, true>>
+local client_cache = {}
+
+vim.api.nvim_create_autocmd("LspDetach", {
+   group = vim.api.nvim_create_augroup("slang-server.capabilities", { clear = true }),
+   callback = function(args)
+      client_cache[args.data.client_id] = nil
+   end,
+})
+
+---Validate a client's static info and return its supported-command set.
+---@param client vim.lsp.Client
+---@return table<string, true>? commands, string? err_msg
+local function get_info(client)
+   local cmds = client_cache[client.id]
+   if cmds then
+      return cmds, nil
+   end
+
+   local version = client.server_info and client.server_info.version
+   if version and not version_at_least(version, M.MIN_SERVER_VERSION) then
+      return nil,
+         string.format(
+            "slang-server: server version %s is too old (need >= %s). Please upgrade slang-server.",
+            vim.trim(version),
+            M.MIN_SERVER_VERSION
+         )
+   end
+
+   local ecp = client.server_capabilities and client.server_capabilities.executeCommandProvider
+   if not (ecp and ecp.commands) then
+      return nil, "slang-server: server does not advertise executeCommandProvider. " .. UPGRADE_HINT
+   end
+
+   cmds = {}
+   for _, value in ipairs(ecp.commands) do
+      cmds[value] = true
+   end
+   client_cache[client.id] = cmds
+   return cmds, nil
+end
+
+---@param bufnr integer
+---@param required_commands string[]
+---@return boolean ok, string? err_msg
+function M.check(bufnr, required_commands)
+   local client = M.get_client(bufnr)
+   if not client then
+      return false, "slang-server: no slang-server LSP client attached. " .. UPGRADE_HINT
+   end
+
+   local cmds, err = get_info(client)
+   if not cmds then
+      return false, err
+   end
+
+   for _, command in ipairs(required_commands) do
+      if not cmds[command] then
+         return false,
+            string.format("slang-server: server does not support LSP command '%s'. %s", command, UPGRADE_HINT)
+      end
+   end
+
+   return true, nil
+end
+
+---@param bufnr integer
+---@param required_commands string[]
+---@return boolean
+function M.check_or_notify(bufnr, required_commands)
+   local ok, err = M.check(bufnr, required_commands)
+   if not ok then
+      vim.notify(err, vim.log.levels.ERROR)
+      return false
+   end
+   return true
+end
+
+---@param bufnr integer
+---@param command string
+---@return boolean ok, string? err_msg
+function M.command_supported(bufnr, command)
+   return M.check(bufnr, { command })
+end
+
+return M

--- a/clients/neovim/lua/slang-server/_lsp/client.lua
+++ b/clients/neovim/lua/slang-server/_lsp/client.lua
@@ -1,3 +1,5 @@
+local capabilities = require("slang-server._lsp.capabilities")
+
 local M = {}
 
 -- LSP commands
@@ -9,20 +11,9 @@ local lsp_execute = function(bufnr, params, handlers)
 
    local on_failure = handlers.on_failure or function() end
 
-   local client_found = false
-   for _, client in pairs(vim.lsp.get_clients({ bufnr = bufnr })) do
-      if client.server_capabilities.executeCommandProvider then
-         for _, value in ipairs(client.server_capabilities.executeCommandProvider.commands) do
-            if command == value then
-               client_found = true
-               break
-            end
-         end
-      end
-   end
-
-   if not client_found then
-      on_failure("No client found")
+   local ok, err = capabilities.command_supported(bufnr, command)
+   if not ok then
+      on_failure(err)
       return
    end
 


### PR DESCRIPTION
In addition to checking that the server handles commands immediately before dispatching them, plugin commands test for the entire set of necessary commands so as to prevent weird behavior in the case of incompatibility.  Also checks the semantic version (will need to be manually bumped).