### PR TITLE
Neovim sync dry run mode

### DIFF
--- a/.github/workflows/neovim-sync.yml
+++ b/.github/workflows/neovim-sync.yml
@@ -23,12 +23,21 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
       - name: Mirror the subdirectory to the plugin repo
         env:
           GH_PAT: ${{ secrets.NEOVIM_PAT }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          RUNNING_REPO: ${{ github.repository }}
+          UPSTREAM_REPO: hudson-trading/slang-server
         run: |
           uv venv
           source .venv/bin/activate
           uv sync
-          scripts/ci/neovim-sync.py --event ${{ github.event_name }}
+          DRY_RUN="--dry-run"
+          if [ "$RUNNING_REPO" = "$UPSTREAM_REPO" ] && \
+             { [ "$EVENT_NAME" != "pull_request" ] || [ "$PR_HEAD_REPO" = "$RUNNING_REPO" ]; }; then
+            DRY_RUN=""
+          fi
+          scripts/ci/neovim-sync.py --event "$EVENT_NAME" $DRY_RUN

--- a/scripts/ci/neovim-sync.py
+++ b/scripts/ci/neovim-sync.py
@@ -41,11 +41,15 @@ https://github.com/hudson-trading/slang-server/commit/{this_commit}
     logging.warning(commit_message)
     author = Actor("Hudson River Trading", "opensource@hudson-trading.com")
 
+    gh_pat = os.environ.get("GH_PAT")
+    if not gh_pat and not args.dry_run:
+        sys.exit("GH_PAT is required for non-dry-run sync")
+
+    auth = f"x-access-token:{gh_pat}@" if gh_pat else ""
+    clone_url = f"https://{auth}github.com/hudson-trading/slang-server.nvim.git"
+
     temp_dir = TemporaryDirectory()
-    plugin_repo = Repo.clone_from(
-        f"https://x-access-token:{os.environ['GH_PAT']}@github.com/hudson-trading/slang-server.nvim.git",
-        temp_dir.name,
-    )
+    plugin_repo = Repo.clone_from(clone_url, temp_dir.name)
     plugin_remote = plugin_repo.remote()
     branch_ref = f"origin/{branch}"
     if branch == "main":


### PR DESCRIPTION
Forks and even PRs from forks won't have the `NEOVIM_PAT`.  Test syncing up to, but not including, the push in these cases.