### PR TITLE
Add new builds/releases for mason; Clean up build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,33 +38,53 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - preset: clang-release
+          - name: linux-x64-clang
+            preset: clang-release
             os: ubuntu-latest
             container: rockylinux:8
-            artifact_name: slang-server-linux-x64-clang
             extra_flags: -DCMAKE_CXX_COMPILER=clang++
-          - preset: gcc-release
+          - name: linux-arm64-clang
+            preset: clang-release
+            os: ubuntu-24.04-arm
+            container: rockylinux:8
+            extra_flags: -DCMAKE_CXX_COMPILER=clang++
+          - name: linux-x64-gcc
+            preset: gcc-release
             os: ubuntu-latest
             container: rockylinux:8
-            artifact_name: slang-server-linux-x64-gcc
             extra_flags: -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++
-          - preset: clang-release
+          - name: newer-linux-x64-clang
+            preset: clang-release
             os: ubuntu-latest
-            artifact_name: slang-server-newer-linux-x64-clang
             extra_flags: -DCMAKE_CXX_COMPILER=clang++
-          - preset: gcc-release
+          - name: newer-linux-x64-gcc
+            preset: gcc-release
             os: ubuntu-latest
-            artifact_name: slang-server-newer-linux-x64-gcc
-          - preset: macos-release
+          - name: linux-arm64-gcc
+            preset: gcc-release
+            os: ubuntu-24.04-arm
+            container: rockylinux:8
+            extra_flags: -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++
+          # Not very available/used
+          # - name: macos-x64
+          #   preset: macos-release
+          #   os: macos-15-intel
+          #   extra_flags: -DCMAKE_CXX_COMPILER=clang++
+          - name: macos-arm64
+            preset: macos-release
             os: macos-15
-            artifact_name: slang-server-macos
             extra_flags: -DCMAKE_CXX_COMPILER=clang++
-          - preset: win64-release
+          - name: windows-x64
+            preset: win64-release
             os: windows-latest
-            artifact_name: slang-server-windows-x64
+          - name: windows-arm64
+            preset: winarm64-release
+            os: windows-11-arm
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    env:
+      SLANG_SERVER_ARTIFACT_NAME: slang-server-${{ matrix.name }}
     steps:
       - name: Install dependencies (Rocky Linux 8)
         if: matrix.container == 'rockylinux:8'
@@ -81,6 +101,8 @@ jobs:
           fetch-depth: 0
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
+        with:
+          arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
       - uses: maxim-lobanov/setup-xcode@v1
         if: runner.os == 'macOS'
         with:
@@ -153,7 +175,7 @@ jobs:
         if: inputs.upload_artifacts
         shell: bash
         run: |
-          cat > release-artifacts/README.txt << 'EOF'
+          cat > release-artifacts/README.txt << EOF
           Slang Server - SystemVerilog Language Server
 
           This is a pre-built binary of slang-server.
@@ -166,7 +188,7 @@ jobs:
           For more information, visit:
           https://github.com/hudson-trading/slang-server
 
-          Platform: ${{ matrix.artifact_name }}
+          Platform: ${{ env.SLANG_SERVER_ARTIFACT_NAME }}
           Build date: $(date -u +%Y-%m-%d)
           EOF
 
@@ -174,7 +196,7 @@ jobs:
         if: inputs.upload_artifacts && runner.os != 'Windows'
         run: |
           cd release-artifacts
-          tar -czf ../${{ matrix.artifact_name }}.tar.gz *
+          tar -czf ../${{ env.SLANG_SERVER_ARTIFACT_NAME }}.tar.gz *
           cd ..
 
       - name: Create zip (Windows)
@@ -182,17 +204,17 @@ jobs:
         shell: bash
         run: |
           cd release-artifacts
-          7z a ../${{ matrix.artifact_name }}.zip *
+          7z a ../${{ env.SLANG_SERVER_ARTIFACT_NAME }}.zip *
           cd ..
 
       - name: Upload artifact
         if: inputs.upload_artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact_name }}
+          name: ${{ env.SLANG_SERVER_ARTIFACT_NAME }}
           path: |
-            ${{ matrix.artifact_name }}.tar.gz
-            ${{ matrix.artifact_name }}.zip
+            ${{ env.SLANG_SERVER_ARTIFACT_NAME }}.tar.gz
+            ${{ env.SLANG_SERVER_ARTIFACT_NAME }}.zip
           retention-days: 7
 
   clang-debug:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -70,6 +70,19 @@
       }
     },
     {
+      "name": "winarm64-release",
+      "displayName": "WinARM64 Release",
+      "inherits": "windows-release",
+      "architecture": {
+        "value": "arm64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "SLANG_INCLUDE_THREADTEST": "ON",
+        "SLANG_SERVER_STATIC_LINK_STDLIB": "ON"
+      }
+    },
+    {
       "name": "gcc-flags",
       "hidden": true,
       "cacheVariables": {


### PR DESCRIPTION
- Names build entries so it's easier to read in github (release binary names should be unchanged)
- Adds arm builds for all platforms (other than mac)
- Decided against adding intel mac since it's on the way out