### PR TITLE
neovim: uri_to_fname()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         # unfortunately that uncovers the fact that the neovim builds from that
         # GH action require a newer GLIBC version than rockylinux provides.
         # Not going down that rabbit hole right now
-        if: runner.os != 'Windows' && matrix.container == ''
+        if: matrix.container == ''
         uses: nvim-neorocks/nvim-busted-action@v1
         env:
           SLANG_SERVER_BIN: ../../build/${{ matrix.preset }}/bin/slang-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         # unfortunately that uncovers the fact that the neovim builds from that
         # GH action require a newer GLIBC version than rockylinux provides.
         # Not going down that rabbit hole right now
-        if: matrix.container == ''
+        if: runner.os != 'Windows' && matrix.container == ''
         uses: nvim-neorocks/nvim-busted-action@v1
         env:
           SLANG_SERVER_BIN: ../../build/${{ matrix.preset }}/bin/slang-server

--- a/clients/neovim/lua/slang-server/navigation/hierarchy.lua
+++ b/clients/neovim/lua/slang-server/navigation/hierarchy.lua
@@ -44,8 +44,7 @@ local function map_keys(split, tree)
       ["yf"] = {
          impl = function(node)
             if node and node.instLoc and node.instLoc.uri then
-               local uri = string.gsub(node.instLoc.uri, "^file://", "")
-               util.yank_and_notify(uri)
+               util.yank_and_notify(vim.uri_to_fname(node.instLoc.uri))
             end
          end,
          opts = { noremap = true },

--- a/clients/neovim/lua/slang-server/util.lua
+++ b/clients/neovim/lua/slang-server/util.lua
@@ -130,7 +130,7 @@ function M.jump_loc(loc, winnr)
 
    local win = vim.fn.win_getid(winnr)
    vim.api.nvim_set_current_win(win)
-   vim.cmd.edit(loc.uri)
+   vim.cmd.edit(vim.uri_to_fname(loc.uri))
 
    local start = loc.range.start
    vim.api.nvim_win_set_cursor(win, { start.line + 1, start.character })


### PR DESCRIPTION
Direct URI to File path conversion does not work on windows.