### PR TITLE
Fix macro completion label formatting

### DIFF
--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -44,7 +44,7 @@ using namespace slang;
 
 lsp::CompletionItem getMacroCompletion(std::string name) {
     return lsp::CompletionItem{
-        .label = "`" + name,
+        .label = name,
         .labelDetails =
             lsp::CompletionItemLabelDetails{
                 .detail = " Macro",


### PR DESCRIPTION
Consider I have this:

```
`<cursor here>
```

Then list of macros pops up. This is great.

I select my macro.

```
``MY_MACRO<cursor here>
```

Uh oh. Now I need to go back and remove a backtick--well not anymore with this pr