### PR TITLE
Fix for older clang versions' stricter -Wrange-loop-construct

### DIFF
--- a/include/ast/ConeTracer.h
+++ b/include/ast/ConeTracer.h
@@ -125,7 +125,7 @@ public:
             if (portSymbol) {
                 leaves.insert(portSymbol);
             }
-            for (const auto driver : drivers) {
+            for (const auto& driver : drivers) {
                 leaves.insert(driver);
             }
         }


### PR DESCRIPTION
On macOS with Xcode 16 (Apple clang 16), `cmake --build build/macos-release` fails with:

\`\`\`
include/ast/ConeTracer.h:128:29: error: loop variable 'driver' creates a copy from type 'const value_type' (aka 'const ConeLeaf') [-Werror,-Wrange-loop-construct]
    for (const auto driver : drivers) {
                    ^
\`\`\`

Apple clang 16's \`-Wrange-loop-construct\` is slightly stricter than the upstream Linux clang the CI uses (or the macos-15 runner was on a different version), so this currently slips through CI but breaks for any developer on a current Xcode.

Fix: use a const reference, which is what the code intends anyway — \`drivers\` is iterated only to insert each entry into another set, no copy is needed.

## Test plan
- \`cmake --preset macos-release && cmake --build build/macos-release -j8 --target server_unittests\` — builds clean (was failing before).
- \`build/macos-release/bin/server_unittests\` — 188 test cases / 58235 assertions, all pass.