### PR TITLE
Fix hover markdown rendering for SystemVerilog backticks

### DIFF
--- a/src/util/Markdown.cpp
+++ b/src/util/Markdown.cpp
@@ -69,7 +69,14 @@ Paragraph& Paragraph::appendCode(std::string_view code) {
     size_t delimiterCount = maxBackticks + 1;
     std::string delimiter(delimiterCount, '`');
 
-    fmt::format_to(std::back_inserter(buffer), "{} {} {}", delimiter, code, delimiter);
+    // Add spaces only if content contains backticks (required by CommonMark spec)
+    bool needsSpaces = maxBackticks > 0;
+    if (needsSpaces) {
+        fmt::format_to(std::back_inserter(buffer), "{} {} {}", delimiter, code, delimiter);
+    }
+    else {
+        fmt::format_to(std::back_inserter(buffer), "{}{}{}", delimiter, code, delimiter);
+    }
     return *this;
 }
 

--- a/src/util/Markdown.cpp
+++ b/src/util/Markdown.cpp
@@ -51,7 +51,25 @@ Paragraph& Paragraph::appendText(std::string_view text) {
 }
 
 Paragraph& Paragraph::appendCode(std::string_view code) {
-    fmt::format_to(std::back_inserter(buffer), "`` {} ``", code);
+    // Find the longest run of consecutive backticks in the content
+    size_t maxBackticks = 0;
+    size_t currentRun = 0;
+    for (char c : code) {
+        if (c == '`') {
+            currentRun++;
+            maxBackticks = std::max(maxBackticks, currentRun);
+        }
+        else {
+            currentRun = 0;
+        }
+    }
+
+    // Use one more backtick than the longest run in the content
+    // Minimum of 1 backtick (for content with no backticks)
+    size_t delimiterCount = maxBackticks + 1;
+    std::string delimiter(delimiterCount, '`');
+
+    fmt::format_to(std::back_inserter(buffer), "{} {} {}", delimiter, code, delimiter);
     return *this;
 }
 

--- a/src/util/Markdown.cpp
+++ b/src/util/Markdown.cpp
@@ -51,7 +51,7 @@ Paragraph& Paragraph::appendText(std::string_view text) {
 }
 
 Paragraph& Paragraph::appendCode(std::string_view code) {
-    fmt::format_to(std::back_inserter(buffer), "`{}`", code);
+    fmt::format_to(std::back_inserter(buffer), "`` {} ``", code);
     return *this;
 }
 

--- a/tests/cpp/MarkupTests.cpp
+++ b/tests/cpp/MarkupTests.cpp
@@ -48,25 +48,40 @@ TEST_CASE("AppendCode_BacktickWrapping") {
     using namespace server::markup;
 
     // Test case from issue #310: SystemVerilog macros with backticks
-    // should be wrapped with double backticks to prevent markdown rendering issues
+    // should be wrapped with dynamic delimiter (one more than longest run)
     Paragraph para;
     para.appendCode("`define MACRO_A 10");
 
-    std::string result = para.asMarkdown();
+    std::string result{para.asMarkdown()};
 
     // Should use double backticks with spaces: `` code ``
+    // (single backtick in content requires 2-backtick delimiter)
     CHECK(result == "`` `define MACRO_A 10 ``");
 }
 
 TEST_CASE("AppendCode_TripleBacktickTokenPaste") {
     using namespace server::markup;
 
-    // Test case from issue #310: macro token-paste operators with triple backticks
+    // Test case: macro token-paste operators with triple backticks (```)
+    // Dynamic delimiter must use 4 backticks to wrap content with 3
     Paragraph para;
     para.appendCode("`define JOIN_MACRO(name) name```MACRO_A");
 
-    std::string result = para.asMarkdown();
+    std::string result{para.asMarkdown()};
 
-    // Double backtick wrapping should handle triple backticks in content
-    CHECK(result == "`` `define JOIN_MACRO(name) name```MACRO_A ``");
+    // Should use quad backticks (4) to wrap triple backticks (3) in content
+    CHECK(result == "```` `define JOIN_MACRO(name) name```MACRO_A ````");
+}
+
+TEST_CASE("AppendCode_NoBackticks") {
+    using namespace server::markup;
+
+    // Content with no backticks should use single backtick delimiter
+    Paragraph para;
+    para.appendCode("int variable = 42");
+
+    std::string result{para.asMarkdown()};
+
+    // Should use single backticks (minimum)
+    CHECK(result == "` int variable = 42 `");
 }

--- a/tests/cpp/MarkupTests.cpp
+++ b/tests/cpp/MarkupTests.cpp
@@ -82,6 +82,6 @@ TEST_CASE("AppendCode_NoBackticks") {
 
     std::string result{para.asMarkdown()};
 
-    // Should use single backticks (minimum)
-    CHECK(result == "` int variable = 42 `");
+    // Should use single backticks without spaces (no backticks in content)
+    CHECK(result == "`int variable = 42`");
 }

--- a/tests/cpp/MarkupTests.cpp
+++ b/tests/cpp/MarkupTests.cpp
@@ -43,3 +43,30 @@ TEST_CASE("EscapeMarkdown") {
 
     CHECK(escapeMultilineMarkdown("1. item\n2) item\n<tag/>") == "1\\. item\n2\\) item\n\\<tag/>");
 }
+
+TEST_CASE("AppendCode_BacktickWrapping") {
+    using namespace server::markup;
+
+    // Test case from issue #310: SystemVerilog macros with backticks
+    // should be wrapped with double backticks to prevent markdown rendering issues
+    Paragraph para;
+    para.appendCode("`define MACRO_A 10");
+
+    std::string result = para.asMarkdown();
+
+    // Should use double backticks with spaces: `` code ``
+    CHECK(result == "`` `define MACRO_A 10 ``");
+}
+
+TEST_CASE("AppendCode_TripleBacktickTokenPaste") {
+    using namespace server::markup;
+
+    // Test case from issue #310: macro token-paste operators with triple backticks
+    Paragraph para;
+    para.appendCode("`define JOIN_MACRO(name) name```MACRO_A");
+
+    std::string result = para.asMarkdown();
+
+    // Double backtick wrapping should handle triple backticks in content
+    CHECK(result == "`` `define JOIN_MACRO(name) name```MACRO_A ``");
+}


### PR DESCRIPTION
SystemVerilog uses backticks for preprocessor directives (`` `define ``) and the token-paste operator (`` `` ``). When hovering over these constructs, the single-backtick wrap in `Paragraph::appendCode` breaks markdown rendering because the content itself contains backticks — CommonMark requires the code-span delimiter run to not appear inside the content.

This rewrites `appendCode` to scan the content for the longest run of consecutive backticks (N) and wrap with N+1 backticks, padding with one space on each side when the content contains any backticks (per CommonMark). This handles every valid SystemVerilog construct, including the triple-backtick token-paste case (`` `define JOIN(a,b) a```b ``) from the issue.

Tests cover:
- single-backtick content (`` `define MACRO_A 10 ``) → wrapped with `` `` `` ``
- triple-backtick content (`` name```MACRO_A ``) → wrapped with `` ```` ````
- backtick-free content → wrapped with single backticks, no padding

Fixes #310