### PR TITLE
Add `addModuleMemberKwCompletions` back

### DIFF
--- a/src/completions/CompletionDispatch.cpp
+++ b/src/completions/CompletionDispatch.cpp
@@ -57,6 +57,8 @@ void CompletionDispatch::getInvokedCompletions(std::vector<lsp::CompletionItem>&
         completions::addMemberCompletions(results, scope, ctx.kind, scope);
     }
 
+    completions::addModuleMemberKwCompletions(results);
+
     INFO("Returning {} completions in {} context", results.size(), toString(ctx.kind));
 }
 


### PR DESCRIPTION
At some point the primary function from #152 was removed.

There should've been a test to catch this.

This also fixes `always_comb`, `always_ff`, etc.