### PR TITLE
[Neovim] Semantic tokens -- inactive regions

### DIFF
--- a/clients/vscode/resources/config.schema.json
+++ b/clients/vscode/resources/config.schema.json
@@ -100,6 +100,10 @@
           "items": {
             "$ref": "#/$defs/Config__Build"
           }
+        },
+        "semanticTokens": {
+          "$ref": "#/$defs/Config__SemanticTokensConfig",
+          "description": "Configure semantic highlighting."
         }
       },
       "required": []
@@ -201,6 +205,26 @@
         "macroArgNames": {
           "type": "integer",
           "description": "Macro argument hints: 0=off, N=only calls with >=N args"
+        }
+      },
+      "required": []
+    },
+    "Config__SemanticTokensConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether semantic tokens should be provided by the server.",
+          "type": "boolean"
+        },
+        "disabledKinds": {
+          "type": "array",
+          "description": "Specify semantic token kinds that slang-server should not send to client.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "InactiveCode"
+            ]
+          }
         }
       },
       "required": []

--- a/clients/vscode/src/config.gen.ts
+++ b/clients/vscode/src/config.gen.ts
@@ -38,6 +38,8 @@ export interface Config {
   inlayHints?: Config__InlayHints
   /** Builds for direct .f selection or command-based .f generation */
   builds?: Config__Build[]
+  /** Configure semantic highlighting. */
+  semanticTokens?: Config__SemanticTokensConfig
 }
 
 export interface Config__Build {
@@ -72,4 +74,11 @@ export interface Config__InlayHints {
   funcArgNames?: number
   /** Macro argument hints: 0=off, N=only calls with >=N args */
   macroArgNames?: number
+}
+
+export interface Config__SemanticTokensConfig {
+  /** Whether semantic tokens should be provided by the server. */
+  enabled?: boolean
+  /** Specify semantic token kinds that slang-server should not send to client. */
+  disabledKinds?: "InactiveCode"[]
 }

--- a/include/Config.h
+++ b/include/Config.h
@@ -148,6 +148,20 @@ struct Config {
 
     /// Per-file flags with correct precedence. Skipped during serialization.
     rfl::Skip<std::vector<FlagSource>> flagsByFile;
+
+    struct SemanticTokensConfig {
+        enum class SemanticTokenKind { InactiveCode };
+
+        rfl::Description<"Whether semantic tokens should be provided by the server.", bool>
+            enabled = false;
+
+        rfl::Description<
+            "Specify semantic token kinds that slang-server should not send to client.",
+            std::vector<SemanticTokenKind>>
+            disabledKinds{};
+    };
+
+    rfl::Description<"Configure semantic highlighting.", SemanticTokensConfig> semanticTokens{};
 };
 
 template<>

--- a/include/SemanticToken.hpp
+++ b/include/SemanticToken.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "lsp/LspTypes.h"
+
+/// @brief Configuration for semantic tokens, defining token types and modifiers
+/// Currently just defines a single `comment` token type for inactive regions
+const lsp::SemanticTokensLegend SemanticTokensLegendConfig = {.tokenTypes = {"comment"}};

--- a/include/SlangLspClient.h
+++ b/include/SlangLspClient.h
@@ -15,8 +15,14 @@ class SlangLspClient : public lsp::LspClient {
 
 public:
     struct {
-        bool inactiveRegionsSupported = false;
-    } experimentalCapabilities;
+        struct {
+            bool multilineTokenSupport = false;
+        } semanticTokens;
+
+        struct {
+            bool inactiveRegionsSupported = false;
+        } experimental;
+    } clientCapabilities;
 
     virtual void setConfig(const Config& params) {
         lsp::sendNotification("slang/setConfig", rfl::to_generic(params));

--- a/include/SlangLspClient.h
+++ b/include/SlangLspClient.h
@@ -22,7 +22,7 @@ public:
         struct {
             bool inactiveRegionsSupported = false;
         } experimental;
-    } clientCapabilities;
+    } capabilities;
 
     virtual void setConfig(const Config& params) {
         lsp::sendNotification("slang/setConfig", rfl::to_generic(params));

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -201,6 +201,11 @@ public:
     std::optional<std::vector<lsp::DocumentHighlight>> getDocDocumentHighlight(
         const lsp::DocumentHighlightParams&) override;
 
+    /// Get semantic tokens for the document
+    /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_fullRequest
+    std::optional<lsp::SemanticTokens> getDocSemanticTokensFull(
+        const lsp::SemanticTokensParams&) override;
+
     ////////////////////////////////////////////////
     /// Cone tracing
     ////////////////////////////////////////////////

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -123,7 +123,8 @@ public:
     /// @brief Gets semantic tokens for the document
     /// @param inactiveRegionsSupported If inactive regions aren't supported, include them as tokens
     lsp::SemanticTokens getSemanticTokens(const bool inactiveRegionsSupported,
-                                          const Config::SemanticTokensConfig& cfg);
+                                          const Config::SemanticTokensConfig& cfg,
+                                          const bool multilineTokenSupport);
 
     /// Syntax finder for location->syntax mapping
     SyntaxIndexer syntaxes;

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -120,6 +120,10 @@ public:
     /// @brief Gets the AST symbol that a declared token refers to, if any
     const slang::ast::Symbol* getSymbolAtToken(const slang::parsing::Token* node) const;
 
+    /// @brief Gets semantic tokens for the document
+    /// @param inactiveRegionsSupported If inactive regions aren't supported, include them as tokens
+    lsp::SemanticTokens getSemanticTokens(bool inactiveRegionsSupported);
+
     /// Syntax finder for location->syntax mapping
     SyntaxIndexer syntaxes;
 
@@ -180,8 +184,8 @@ private:
     slang::analysis::AnalysisOptions m_analysisOptions;
 
     /// Symbol tree visitor for /documentSymbols
-    /// Currently this is relies on syntax, but we should switch it to use the shallow compilation
-    /// when symbols exist
+    /// Currently this is relies on syntax, but we should switch it to use the shallow
+    /// compilation when symbols exist
     SymbolTreeVisitor m_symbolTreeVisitor;
 
     /// Symbol indexer for syntax->symbol mappings of definitions; Used for lookups

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -122,7 +122,8 @@ public:
 
     /// @brief Gets semantic tokens for the document
     /// @param inactiveRegionsSupported If inactive regions aren't supported, include them as tokens
-    lsp::SemanticTokens getSemanticTokens(bool inactiveRegionsSupported);
+    lsp::SemanticTokens getSemanticTokens(const bool inactiveRegionsSupported,
+                                          const Config::SemanticTokensConfig& cfg);
 
     /// Syntax finder for location->syntax mapping
     SyntaxIndexer syntaxes;

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -983,7 +983,7 @@ std::optional<lsp::WorkspaceEdit> ServerDriver::getDocRename(const URI& uri,
 }
 
 void ServerDriver::publishInactiveRegions(SlangDoc& doc) {
-    if (!client.experimentalCapabilities.inactiveRegionsSupported)
+    if (!client.clientCapabilities.experimental.inactiveRegionsSupported)
         return;
 
     auto regions = doc.getInactiveRegions();

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -983,7 +983,7 @@ std::optional<lsp::WorkspaceEdit> ServerDriver::getDocRename(const URI& uri,
 }
 
 void ServerDriver::publishInactiveRegions(SlangDoc& doc) {
-    if (!client.clientCapabilities.experimental.inactiveRegionsSupported)
+    if (!client.capabilities.experimental.inactiveRegionsSupported)
         return;
 
     auto regions = doc.getInactiveRegions();

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -10,6 +10,7 @@
 #include "SlangServer.h"
 
 #include "Config.h"
+#include "SemanticToken.hpp"
 #include "ast/WcpClient.h"
 #include "completions/CompletionContext.h"
 #include "completions/CompletionDispatch.h"
@@ -78,6 +79,8 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     registerDocReferences();
     registerDocRename();
     registerDocCodeAction();
+
+    registerDocSemanticTokensFull();
 
     // Cone tracing (drivers/loads)
     registerDocPrepareCallHierarchy();
@@ -216,6 +219,9 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
                             .commands = getCommandList(),
                         },
                     .callHierarchyProvider = true,
+                    .semanticTokensProvider =
+                        lsp::SemanticTokensOptions{.legend = SemanticTokensLegendConfig,
+                                                   .full = true},
                     .inlayHintProvider =
                         lsp::InlayHintOptions{
                             .resolveProvider = false,
@@ -833,6 +839,26 @@ std::optional<std::vector<lsp::Location>> SlangServer::getDocReferences(
 
 std::optional<lsp::WorkspaceEdit> SlangServer::getDocRename(const lsp::RenameParams& params) {
     return m_driver->getDocRename(params.textDocument.uri, params.position, params.newName);
+}
+
+std::optional<lsp::SemanticTokens> SlangServer::getDocSemanticTokensFull(
+    const lsp::SemanticTokensParams& params) {
+
+    const auto doc = m_driver->getDocument(params.textDocument.uri);
+    if (!doc) {
+        return lsp::SemanticTokens{
+            .data = {},
+        };
+    }
+
+    const auto analysis = doc->getAnalysis();
+    if (!analysis) {
+        return lsp::SemanticTokens{
+            .data = {},
+        };
+    }
+
+    return analysis->getSemanticTokens(m_client.experimentalCapabilities.inactiveRegionsSupported);
 }
 
 SourceManager& SlangServer::sourceManager() {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -163,7 +163,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     loadConfig();
 
     if (params.capabilities.textDocument && params.capabilities.textDocument->semanticTokens) {
-        m_client.clientCapabilities.semanticTokens.multilineTokenSupport =
+        m_client.capabilities.semanticTokens.multilineTokenSupport =
             params.capabilities.textDocument->semanticTokens->multilineTokenSupport.value_or(false);
     }
 
@@ -172,7 +172,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
             *params.capabilities.experimental);
 
         if (exp && exp->inactiveRegions && exp->inactiveRegions->inactiveRegions.value_or(false)) {
-            m_client.clientCapabilities.experimental.inactiveRegionsSupported = true;
+            m_client.capabilities.experimental.inactiveRegionsSupported = true;
         }
     }
 
@@ -864,9 +864,9 @@ std::optional<lsp::SemanticTokens> SlangServer::getDocSemanticTokensFull(
     }
 
     return analysis->getSemanticTokens(
-        m_client.clientCapabilities.experimental.inactiveRegionsSupported,
+        m_client.capabilities.experimental.inactiveRegionsSupported,
         m_config.semanticTokens.value(),
-        m_client.clientCapabilities.semanticTokens.multilineTokenSupport);
+        m_client.capabilities.semanticTokens.multilineTokenSupport);
 }
 
 SourceManager& SlangServer::sourceManager() {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -858,7 +858,8 @@ std::optional<lsp::SemanticTokens> SlangServer::getDocSemanticTokensFull(
         };
     }
 
-    return analysis->getSemanticTokens(m_client.experimentalCapabilities.inactiveRegionsSupported);
+    return analysis->getSemanticTokens(m_client.experimentalCapabilities.inactiveRegionsSupported,
+                                       m_config.semanticTokens.value());
 }
 
 SourceManager& SlangServer::sourceManager() {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -863,10 +863,9 @@ std::optional<lsp::SemanticTokens> SlangServer::getDocSemanticTokensFull(
         };
     }
 
-    return analysis->getSemanticTokens(
-        m_client.capabilities.experimental.inactiveRegionsSupported,
-        m_config.semanticTokens.value(),
-        m_client.capabilities.semanticTokens.multilineTokenSupport);
+    return analysis->getSemanticTokens(m_client.capabilities.experimental.inactiveRegionsSupported,
+                                       m_config.semanticTokens.value(),
+                                       m_client.capabilities.semanticTokens.multilineTokenSupport);
 }
 
 SourceManager& SlangServer::sourceManager() {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -162,12 +162,17 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
 
     loadConfig();
 
+    if (params.capabilities.textDocument && params.capabilities.textDocument->semanticTokens) {
+        m_client.clientCapabilities.semanticTokens.multilineTokenSupport =
+            params.capabilities.textDocument->semanticTokens->multilineTokenSupport.value_or(false);
+    }
+
     if (params.capabilities.experimental) {
-        auto exp = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
+        const auto exp = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
             *params.capabilities.experimental);
 
         if (exp && exp->inactiveRegions && exp->inactiveRegions->inactiveRegions.value_or(false)) {
-            m_client.experimentalCapabilities.inactiveRegionsSupported = true;
+            m_client.clientCapabilities.experimental.inactiveRegionsSupported = true;
         }
     }
 
@@ -858,8 +863,10 @@ std::optional<lsp::SemanticTokens> SlangServer::getDocSemanticTokensFull(
         };
     }
 
-    return analysis->getSemanticTokens(m_client.experimentalCapabilities.inactiveRegionsSupported,
-                                       m_config.semanticTokens.value());
+    return analysis->getSemanticTokens(
+        m_client.clientCapabilities.experimental.inactiveRegionsSupported,
+        m_config.semanticTokens.value(),
+        m_client.clientCapabilities.semanticTokens.multilineTokenSupport);
 }
 
 SourceManager& SlangServer::sourceManager() {

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -659,7 +659,12 @@ std::vector<const slang::analysis::ValueDriver*> ShallowAnalysis::getDrivers(
     return manager->getDrivers(symbol);
 }
 
-lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(bool inactiveRegionsSupported) {
+lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(const bool inactiveRegionsSupported,
+                                                       const Config::SemanticTokensConfig& cfg) {
+    if (!cfg.enabled.value()) {
+        return lsp::SemanticTokens{.data = {}};
+    }
+
     struct SemanticTokenInfo {
         lsp::uint line;
         lsp::uint character;
@@ -670,7 +675,17 @@ lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(bool inactiveRegionsSuppo
 
     std::vector<SemanticTokenInfo> tokens;
 
-    if (!inactiveRegionsSupported) {
+    // In the future if/when more semantic tokens are added then this can be made a lot more
+    // efficient
+    bool inactiveDisabled = inactiveRegionsSupported;
+    for (auto kind : cfg.disabledKinds.value()) {
+        if (kind == Config::SemanticTokensConfig::SemanticTokenKind::InactiveCode) {
+            inactiveDisabled = true;
+            break;
+        }
+    }
+
+    if (!inactiveDisabled) {
         for (const auto& region : syntaxes.disabledRegions) {
             const auto range = toRange(region, m_sourceManager);
 

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -39,11 +39,12 @@
 namespace server {
 using namespace slang;
 
+namespace {
 // Helper to check if two symbols represent the same semantic entity.
 // After normalization in getSymbolAtToken, most symbols should have pointer equality.
 // This fallback handles edge cases where different instance bodies create different
 // symbol objects for the same source-level declaration (e.g., parameters).
-static bool symbolsMatch(const ast::Symbol* a, const ast::Symbol* b) {
+bool symbolsMatch(const ast::Symbol* a, const ast::Symbol* b) {
     if (!a || !b) {
         return false;
     }
@@ -56,6 +57,37 @@ static bool symbolsMatch(const ast::Symbol* a, const ast::Symbol* b) {
     }
     return false;
 }
+
+/// Returns the raw buffer offset where an inactive-code token should end
+size_t inactiveRegionEndOffset(const SourceManager& sourceManager, const SourceRange region,
+                               const bool includeNextDirective) {
+    if (!includeNextDirective) {
+        return region.end().offset();
+    }
+
+    const auto text = sourceManager.getSourceText(region.end().buffer());
+    auto offset = region.end().offset();
+    if (offset >= text.size()) {
+        return offset;
+    }
+
+    auto endOffset = offset;
+    if (text[offset] == '\r') {
+        endOffset++;
+        offset++;
+    }
+    if (offset < text.size() && text[offset] == '\n') {
+        endOffset++;
+        offset++;
+    }
+
+    if (endOffset != region.end().offset() && offset < text.size() && text[offset] == '`') {
+        return offset + 1;
+    }
+    return region.end().offset();
+}
+} // namespace
+
 ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID buffer,
                                  std::shared_ptr<SyntaxTree> tree, slang::Bag options,
                                  const std::vector<std::shared_ptr<SyntaxTree>>& allTrees) :
@@ -691,64 +723,57 @@ lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(const bool inactiveRegion
     if (!inactiveDisabled) {
         for (const auto& region : syntaxes.disabledRegions) {
             const auto range = toRange(region, m_sourceManager);
+            const auto text = m_sourceManager.getSourceText(region.start().buffer());
+            const auto startOffset = region.start().offset();
+            const auto endOffset = inactiveRegionEndOffset(m_sourceManager, region,
+                                                           multilineTokenSupport);
 
-            if (multilineTokenSupport) {
-                lsp::uint length = 0;
-
-                for (lsp::uint line = range.start.line; line <= range.end.line; line++) {
-                    const lsp::uint startChar = line == range.start.line ? range.start.character
-                                                                         : 0;
-
-                    lsp::uint endChar;
-                    if (line == range.end.line) {
-                        endChar = range.end.character;
-                    }
-
-                    else {
-                        endChar = static_cast<lsp::uint>(
-                            m_sourceManager.getLine(m_buffer, line + 1).size());
-                    }
-
-                    if (endChar > startChar) {
-                        length += endChar - startChar;
-                    }
-
-                    if (line != range.end.line) {
-                        length += 1; // account for '\n'
-                    }
-                }
-
-                if (length > 0) {
-                    tokens.push_back({
-                        range.start.line,
-                        range.start.character,
-                        length,
-                        0,
-                        0,
-                    });
-                }
-
+            if (endOffset <= startOffset || startOffset >= text.size()) {
                 continue;
             }
 
-            for (lsp::uint line = range.start.line; line <= range.end.line; line++) {
-                const lsp::uint startChar = line == range.start.line ? range.start.character : 0;
-                lsp::uint endChar = range.end.character;
+            if (multilineTokenSupport) {
+                tokens.push_back({
+                    range.start.line,
+                    range.start.character,
+                    static_cast<lsp::uint>(endOffset - startOffset),
+                    0,
+                    0,
+                });
+                continue;
+            }
 
-                if (line != range.end.line) {
-                    const auto text = m_sourceManager.getLine(m_buffer, line + 1);
-                    endChar = static_cast<lsp::uint>(text.size());
+            auto offset = startOffset;
+            auto line = range.start.line;
+            auto startChar = range.start.character;
+            while (offset < endOffset) {
+                auto lineEnd = text.find('\n', offset);
+                if (lineEnd == std::string_view::npos || lineEnd > endOffset) {
+                    lineEnd = endOffset;
                 }
 
-                if (endChar > startChar) {
+                auto tokenEnd = lineEnd;
+                if (tokenEnd > offset && text[tokenEnd - 1] == '\r') {
+                    tokenEnd--;
+                }
+
+                if (tokenEnd > offset) {
                     tokens.push_back({
                         line,
                         startChar,
-                        endChar - startChar,
+                        static_cast<lsp::uint>(tokenEnd - offset),
                         0,
                         0,
                     });
                 }
+
+                if (lineEnd >= endOffset || lineEnd >= text.size() || text[lineEnd] != '\n') {
+                    break;
+                }
+
+                offset = lineEnd + 1;
+                line++;
+                startChar = 0;
             }
         }
     }

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -659,4 +659,87 @@ std::vector<const slang::analysis::ValueDriver*> ShallowAnalysis::getDrivers(
     return manager->getDrivers(symbol);
 }
 
+lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(bool inactiveRegionsSupported) {
+    struct SemanticTokenInfo {
+        lsp::uint line;
+        lsp::uint character;
+        lsp::uint length;
+        lsp::uint tokenType;
+        lsp::uint tokenModifiers;
+    };
+
+    std::vector<SemanticTokenInfo> tokens;
+
+    if (!inactiveRegionsSupported) {
+        for (const auto& region : syntaxes.disabledRegions) {
+            const auto range = toRange(region, m_sourceManager);
+
+            for (lsp::uint line = range.start.line; line <= range.end.line; line++) {
+                const lsp::uint startChar = line == range.start.line ? range.start.character : 0;
+                lsp::uint endChar = range.end.character;
+
+                if (line != range.end.line) {
+                    const auto text = m_sourceManager.getLine(m_buffer, line + 1);
+                    endChar = static_cast<lsp::uint>(text.size());
+                }
+
+                if (endChar > startChar) {
+                    tokens.push_back({
+                        line,
+                        startChar,
+                        endChar - startChar,
+                        0,
+                        0,
+                    });
+                }
+            }
+        }
+    }
+
+    std::sort(tokens.begin(), tokens.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.line != rhs.line) {
+            return lhs.line < rhs.line;
+        }
+
+        return lhs.character < rhs.character;
+    });
+
+    std::vector<lsp::uint> data;
+    data.reserve(tokens.size() * 5);
+
+    lsp::uint prevLine = 0;
+    lsp::uint prevChar = 0;
+    bool first = true;
+
+    for (const auto& token : tokens) {
+        /// From
+        /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens
+        // A specific token i in the file consists of the following array indices:
+        //  * at index 5*i - deltaLine: token line number, relative to the start of the previous
+        //  token
+        //  * at index 5*i+1 - deltaStart: token start character, relative to the start of the
+        //  previous token (relative to 0 or the previous token’s start if they are on the same
+        //  line)
+        //  * at index 5*i+2 - length: the length of the token. at index 5*i+3 - tokenType: will be
+        //  looked up in SemanticTokensLegend.tokenTypes. We currently ask that tokenType < 65536.
+        //  * at index 5*i+4 - tokenModifiers: each set bit will be looked up in
+        //  SemanticTokensLegend.tokenModifiers
+
+        const lsp::uint deltaLine = first ? token.line : token.line - prevLine;
+        const lsp::uint deltaChar = deltaLine == 0 ? token.character - prevChar : token.character;
+
+        data.push_back(deltaLine);
+        data.push_back(deltaChar);
+        data.push_back(token.length);
+        data.push_back(token.tokenType);
+        data.push_back(token.tokenModifiers);
+
+        prevLine = token.line;
+        prevChar = token.character;
+        first = false;
+    }
+
+    return lsp::SemanticTokens{.data = data};
+}
+
 } // namespace server

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -659,6 +659,8 @@ std::vector<const slang::analysis::ValueDriver*> ShallowAnalysis::getDrivers(
     return manager->getDrivers(symbol);
 }
 
+/// TODO: When more tokens are added we need to ensure that they aren't overlapping unless the
+/// client supports `overlappingTokenSupport`
 lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(const bool inactiveRegionsSupported,
                                                        const Config::SemanticTokensConfig& cfg) {
     if (!cfg.enabled.value()) {

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -662,7 +662,8 @@ std::vector<const slang::analysis::ValueDriver*> ShallowAnalysis::getDrivers(
 /// TODO: When more tokens are added we need to ensure that they aren't overlapping unless the
 /// client supports `overlappingTokenSupport`
 lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(const bool inactiveRegionsSupported,
-                                                       const Config::SemanticTokensConfig& cfg) {
+                                                       const Config::SemanticTokensConfig& cfg,
+                                                       const bool multilineTokenSupport) {
     if (!cfg.enabled.value()) {
         return lsp::SemanticTokens{.data = {}};
     }
@@ -690,6 +691,41 @@ lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(const bool inactiveRegion
     if (!inactiveDisabled) {
         for (const auto& region : syntaxes.disabledRegions) {
             const auto range = toRange(region, m_sourceManager);
+
+            if (multilineTokenSupport) {
+                lsp::uint length = 0;
+
+                for (lsp::uint line = range.start.line; line <= range.end.line; line++) {
+                    const lsp::uint startChar = line == range.start.line ? range.start.character
+                                                                         : 0;
+
+                    lsp::uint endChar;
+                    if (line == range.end.line) {
+                        endChar = range.end.character;
+                    }
+
+                    else {
+                        endChar = static_cast<lsp::uint>(
+                            m_sourceManager.getLine(m_buffer, line + 1).size());
+                    }
+
+                    if (endChar > startChar) {
+                        length += endChar - startChar;
+                    }
+                }
+
+                if (length > 0) {
+                    tokens.push_back({
+                        range.start.line,
+                        range.start.character,
+                        length,
+                        0,
+                        0,
+                    });
+                }
+
+                continue;
+            }
 
             for (lsp::uint line = range.start.line; line <= range.end.line; line++) {
                 const lsp::uint startChar = line == range.start.line ? range.start.character : 0;

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -58,7 +58,7 @@ bool symbolsMatch(const ast::Symbol* a, const ast::Symbol* b) {
     return false;
 }
 
-/// Returns the raw buffer offset where an inactive-code token should end
+// Returns the raw buffer offset where an inactive-code token should end.
 size_t inactiveRegionEndOffset(const SourceManager& sourceManager, const SourceRange region,
                                const bool includeNextDirective) {
     if (!includeNextDirective) {

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -712,6 +712,10 @@ lsp::SemanticTokens ShallowAnalysis::getSemanticTokens(const bool inactiveRegion
                     if (endChar > startChar) {
                         length += endChar - startChar;
                     }
+
+                    if (line != range.end.line) {
+                        length += 1; // account for '\n'
+                    }
                 }
 
                 if (length > 0) {

--- a/tests/cpp/SemanticTokensTests.cpp
+++ b/tests/cpp/SemanticTokensTests.cpp
@@ -1,0 +1,152 @@
+#include "utils/ServerHarness.h"
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+struct DecodedSemanticToken {
+    uint32_t line;
+    uint32_t startChar;
+    uint32_t length;
+    uint32_t tokenType;
+    uint32_t tokenModifiers;
+    std::string text;
+};
+
+static size_t offsetForLineChar(std::string_view text, uint32_t targetLine, uint32_t targetChar) {
+    size_t offset = 0;
+
+    for (uint32_t line = 0; line < targetLine; line++) {
+        offset = text.find('\n', offset);
+        if (offset == std::string_view::npos)
+            return text.size();
+
+        offset++; // move past '\n'
+    }
+
+    return std::min(offset + static_cast<size_t>(targetChar), text.size());
+}
+
+static std::string_view sliceTokenText(std::string_view sourceText, uint32_t line,
+                                       uint32_t startChar, uint32_t length) {
+
+    const size_t startOffset = offsetForLineChar(sourceText, line, startChar);
+    const size_t endOffset = std::min(startOffset + static_cast<size_t>(length), sourceText.size());
+
+    if (startOffset >= sourceText.size() || endOffset < startOffset)
+        return {};
+
+    return sourceText.substr(startOffset, endOffset - startOffset);
+}
+
+static std::vector<DecodedSemanticToken> decodeSemanticTokens(const std::vector<uint32_t>& data,
+                                                              std::string_view sourceText) {
+
+    std::vector<DecodedSemanticToken> decoded;
+
+    uint32_t line = 0;
+    uint32_t startChar = 0;
+
+    for (size_t i = 0; i + 4 < data.size(); i += 5) {
+        const uint32_t deltaLine = data[i + 0];
+        const uint32_t deltaStart = data[i + 1];
+        const uint32_t length = data[i + 2];
+        const uint32_t tokenType = data[i + 3];
+        const uint32_t tokenModifiers = data[i + 4];
+
+        line += deltaLine;
+
+        if (deltaLine == 0)
+            startChar += deltaStart;
+        else
+            startChar = deltaStart;
+
+        decoded.push_back({
+            .line = line,
+            .startChar = startChar,
+            .length = length,
+            .tokenType = tokenType,
+            .tokenModifiers = tokenModifiers,
+            .text = std::string(sliceTokenText(sourceText, line, startChar, length)),
+        });
+    }
+
+    return decoded;
+}
+} // namespace
+
+TEST_CASE("SemanticTokens_InactiveRegions") {
+    ServerHarness server;
+    JsonGoldenTest golden;
+
+    auto header = server.openFile("foo.svh", "`define FOO\n");
+
+    const std::string source = R"(
+module top;
+`ifdef FOO
+    logic[2:0] a;
+`else
+    logic b;
+`endif
+
+`define BAR
+`define BAZ
+
+`ifndef BAR
+    bit[2:0] c[13];
+`elsif BAZ
+    int d;
+`else
+    int e;
+`endif
+endmodule
+
+`ifdef A logic foo; `else logic bar; `endif
+
+`include "foo.svh"
+
+`ifdef FOO
+    logic[7:0] foot;
+`else
+    logic[7:0] bart;
+`endif
+)";
+
+    auto doc = server.openFile("test.sv", source);
+
+    Config::SemanticTokensConfig cfg{.enabled = true};
+
+    const auto result = doc.doc->getAnalysis()->getSemanticTokens(false, cfg, false);
+
+    const auto decoded = decodeSemanticTokens(result.data, source);
+
+    golden.record(decoded);
+}
+
+TEST_CASE("SemanticTokens_InactiveRegions_Multiline") {
+    ServerHarness server;
+    JsonGoldenTest golden;
+
+    const std::string source = R"(
+module top;
+`ifdef MISSING
+    logic[2:0] inactive_a;
+    logic inactive_b;
+    int inactive_c;
+`else
+    logic active;
+`endif
+endmodule
+)";
+
+    auto doc = server.openFile("test.sv", source);
+
+    Config::SemanticTokensConfig cfg{.enabled = true};
+
+    const auto result = doc.doc->getAnalysis()->getSemanticTokens(false, cfg, true);
+
+    const auto decoded = decodeSemanticTokens(result.data, source);
+
+    golden.record(decoded);
+}

--- a/tests/cpp/SemanticTokensTests.cpp
+++ b/tests/cpp/SemanticTokensTests.cpp
@@ -134,10 +134,19 @@ module top;
     logic[2:0] inactive_a;
     logic inactive_b;
     int inactive_c;
+    logic inactive_d;
 `else
     logic active;
 `endif
+
+`ifdef FOO
+    logic[2:0] a;
+`else
+    logic b;
+`endif
 endmodule
+
+`ifdef A logic foo; `else logic bar; `endif
 )";
 
     auto doc = server.openFile("test.sv", source);

--- a/tests/cpp/golden/SemanticTokens_InactiveRegions.json
+++ b/tests/cpp/golden/SemanticTokens_InactiveRegions.json
@@ -1,0 +1,44 @@
+[
+  [
+    {
+      "line": 3,
+      "startChar": 4,
+      "length": 13,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "logic[2:0] a;"
+    },
+    {
+      "line": 12,
+      "startChar": 4,
+      "length": 15,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "bit[2:0] c[13];"
+    },
+    {
+      "line": 16,
+      "startChar": 4,
+      "length": 6,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "int e;"
+    },
+    {
+      "line": 20,
+      "startChar": 9,
+      "length": 10,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "logic foo;"
+    },
+    {
+      "line": 27,
+      "startChar": 4,
+      "length": 16,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "logic[7:0] bart;"
+    }
+  ]
+]

--- a/tests/cpp/golden/SemanticTokens_InactiveRegions_Multiline.json
+++ b/tests/cpp/golden/SemanticTokens_InactiveRegions_Multiline.json
@@ -1,0 +1,12 @@
+[
+  [
+    {
+      "line": 3,
+      "startChar": 4,
+      "length": 66,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "logic[2:0] inactive_a;\n    logic inactive_b;\n    int inactive_c;\n`"
+    }
+  ]
+]

--- a/tests/cpp/golden/SemanticTokens_InactiveRegions_Multiline.json
+++ b/tests/cpp/golden/SemanticTokens_InactiveRegions_Multiline.json
@@ -3,10 +3,26 @@
     {
       "line": 3,
       "startChar": 4,
-      "length": 66,
+      "length": 88,
       "tokenType": 0,
       "tokenModifiers": 0,
-      "text": "logic[2:0] inactive_a;\n    logic inactive_b;\n    int inactive_c;\n`"
+      "text": "logic[2:0] inactive_a;\n    logic inactive_b;\n    int inactive_c;\n    logic inactive_d;\n`"
+    },
+    {
+      "line": 12,
+      "startChar": 4,
+      "length": 15,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "logic[2:0] a;\n`"
+    },
+    {
+      "line": 18,
+      "startChar": 9,
+      "length": 10,
+      "tokenType": 0,
+      "tokenModifiers": 0,
+      "text": "logic foo;"
     }
   ]
 ]


### PR DESCRIPTION
Semantic tokens (#350) is a lot more work than I'm willing to put in (for now!), but we can still leverage them to provide inactive region support to editors that don't easily support `textDocument/inactiveRegions` (ie: neovim). This is what clangd does see

https://clangd.llvm.org/features#kinds

NEOVIM for reference:

<img width="2224" height="968" alt="image" src="https://github.com/user-attachments/assets/005fd8ef-5ad4-48a4-8b6d-9ef8579c5a88" />

In a future PR I'll add the ability to disable certain semantic tokens from appearing ala:

https://clangd.llvm.org/config.html#semantic-tokens