### PR TITLE
Vscode highlights: Fix brackets configuration

### DIFF
--- a/clients/vscode/languages/sv/systemverilog.configuration.json
+++ b/clients/vscode/languages/sv/systemverilog.configuration.json
@@ -24,10 +24,6 @@
       "end"
     ],
     [
-      "randcase",
-      "endcase"
-    ],
-    [
       "casex",
       "endcase"
     ],
@@ -44,20 +40,12 @@
       "endchecker"
     ],
     [
-      "class",
-      "endclass"
-    ],
-    [
       "clocking",
       "endclocking"
     ],
     [
       "config",
       "endconfig"
-    ],
-    [
-      "coverage",
-      "endcoverage"
     ],
     [
       "covergroup",
@@ -76,16 +64,8 @@
       "join_none"
     ],
     [
-      "function",
-      "endfunction"
-    ],
-    [
       "generate",
       "endgenerate"
-    ],
-    [
-      "interface",
-      "endinterface"
     ],
     [
       "macromodule",
@@ -108,10 +88,6 @@
       "endprogram"
     ],
     [
-      "property",
-      "endproperty"
-    ],
-    [
       "randcase",
       "endcase"
     ],
@@ -120,16 +96,8 @@
       "endspecify"
     ],
     [
-      "sequence",
-      "endsequence"
-    ],
-    [
       "table",
       "endtable"
-    ],
-    [
-      "task",
-      "endtask"
     ]
   ],
   "autoClosingPairs": [
@@ -177,8 +145,8 @@
   ],
   "folding": {
     "markers": {
-      "start": "^[ \\t\\n]*(?://[ \\t\\n]*#?region|`(?:ifdef|ifndef|elsif|else)\\b|\\b(?:(?:macro)?module|class)\\b)",
-      "end": "^[ \\t\\n]*(?://[ \\t\\n]*#?endregion|`(?:elsif|else|endif)\\b|\\b(?:endmodule|endclass)\\b)"
+      "start": "^[ \\t\\n]*(?://[ \\t\\n]*#?region|`(?:ifdef|ifndef|elsif|else)\\b|\\b(?:(?:macro)?module|class|task|function|interface|property|sequence|package|program)\\b)",
+      "end": "^[ \\t\\n]*(?://[ \\t\\n]*#?endregion|`(?:elsif|else|endif)\\b|\\b(?:endmodule|endclass|endtask|endfunction|endinterface|endproperty|endsequence|endpackage|endprogram)\\b)"
     }
   }
 }

--- a/clients/vscode/languages/sv/systemverilog.snippets.json
+++ b/clients/vscode/languages/sv/systemverilog.snippets.json
@@ -58,15 +58,6 @@
     ],
     "description": "class name extends super; ... endclass"
   },
-  "task": {
-    "prefix": "task",
-    "body": [
-      "task ${1:automatic} ${2:taskName}(${3:arguments});",
-      "\t$0",
-      "endtask : $1"
-    ],
-    "description": "task name; ... endtask"
-  },
   "package": {
     "prefix": "package",
     "body": [
@@ -89,6 +80,24 @@
       "endinterface : $1"
     ],
     "description": "interface name; ... endinterface"
+  },
+  "property": {
+    "prefix": "property",
+    "body": [
+      "property ${1:propertyName};",
+      "\t$0",
+      "endproperty : $1"
+    ],
+    "description": "property name; ... endproperty"
+  },
+  "sequence": {
+    "prefix": "sequence",
+    "body": [
+      "sequence ${1:sequenceName};",
+      "\t$0",
+      "endsequence : $1"
+    ],
+    "description": "sequence name; ... endsequence"
   },
   "modport": {
     "prefix": "modport",

--- a/clients/vscode/languages/verilog/verilog.snippets.json
+++ b/clients/vscode/languages/verilog/verilog.snippets.json
@@ -282,12 +282,20 @@
   "function": {
     "prefix": "function",
     "body": [
-      "function $1;",
-      "\t$2;",
-      "\t$3",
-      "endfunction"
+      "function ${1:automatic} ${2:functionName}(${3:arguments});",
+      "\t$0",
+      "endfunction : $2"
     ],
-    "description": "function (...) ... endfunction"
+    "description": "function name(args); ... endfunction"
+  },
+  "task": {
+    "prefix": "task",
+    "body": [
+      "task ${1:automatic} ${2:taskName}(${3:arguments});",
+      "\t$0",
+      "endtask : $2"
+    ],
+    "description": "task name(args); ... endtask"
   },
   "generate": {
     "prefix": "generate",


### PR DESCRIPTION

- Removes function,task, and other keywords from 'brackets' language config, which are not always a begin/end pair.
    These were causing incorrect coloring when the end keyword was not there, yet still valid syntax
- Improves function, task, property and sequence snippets
