### PR TITLE
Expand location-only diagnostic ranges over identifiers

### DIFF
--- a/src/ServerDiagClient.cpp
+++ b/src/ServerDiagClient.cpp
@@ -26,6 +26,60 @@
 #include "slang/text/SourceManager.h"
 namespace server {
 
+bool isSimpleIdentifierChar(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+           c == '_' || c == '$';
+}
+
+bool isTokenWhitespace(char c) {
+    return c == '\0' || c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+           c == '\v';
+}
+
+lsp::Location toDiagnosticLocation(SourceLocation loc, const SourceManager& sourceManager) {
+    if (!sourceManager.isFileLoc(loc)) {
+        return toLocation(loc, sourceManager);
+    }
+
+    auto text = sourceManager.getSourceText(loc.buffer());
+    auto offset = loc.offset();
+    if (offset >= text.size() || isTokenWhitespace(text[offset])) {
+        return toLocation(loc, sourceManager);
+    }
+
+    auto escapedStart = offset;
+    while (escapedStart > 0 && !isTokenWhitespace(text[escapedStart - 1])) {
+        escapedStart--;
+    }
+    if (text[escapedStart] == '\\') {
+        auto end = offset + 1;
+        while (end < text.size() && !isTokenWhitespace(text[end])) {
+            end++;
+        }
+        return toLocation(SourceRange{SourceLocation{loc.buffer(), escapedStart},
+                                      SourceLocation{loc.buffer(), end}},
+                          sourceManager);
+    }
+
+    auto start = offset;
+    while (start > 0 && isSimpleIdentifierChar(text[start - 1])) {
+        start--;
+    }
+
+    if (!isSimpleIdentifierChar(text[offset])) {
+        return toLocation(loc, sourceManager);
+    }
+
+    auto end = offset + 1;
+    while (end < text.size() && isSimpleIdentifierChar(text[end])) {
+        end++;
+    }
+
+    return toLocation(SourceRange{SourceLocation{loc.buffer(), start},
+                                  SourceLocation{loc.buffer(), end}},
+                      sourceManager);
+}
+
 lsp::DiagnosticSeverity convertSeverity(slang::DiagnosticSeverity severity) {
     switch (severity) {
         case slang::DiagnosticSeverity::Ignored:
@@ -120,7 +174,7 @@ void ServerDiagClient::report(const slang::ReportedDiagnostic& diag) {
         bool hasLocation = loc.buffer() != SourceLocation::NoLocation.buffer();
         if (ranges.empty()) {
             if (hasLocation) {
-                return toLocation(loc, m_sourceManager);
+                return toDiagnosticLocation(loc, m_sourceManager);
             }
             else {
                 ERROR("Diagnostic has no ranges and no location: {}", message);
@@ -195,11 +249,16 @@ void ServerDiagClient::report(const slang::ReportedDiagnostic& diag) {
             }
             continue;
         }
-        auto noteLoc = toLocation(note.location, m_sourceManager);
-        related.emplace_back(lsp::DiagnosticRelatedInformation{
-            .location = noteLoc,
-            .message = engine->formatMessage(note),
-        });
+        auto noteMessage = engine->formatMessage(note);
+        SmallVector<SourceRange> noteRanges;
+        engine->mapSourceRanges(note.location, note.ranges, noteRanges);
+        auto noteLoc = getLocation(note.location, noteRanges, noteMessage);
+        if (noteLoc) {
+            related.emplace_back(lsp::DiagnosticRelatedInformation{
+                .location = *noteLoc,
+                .message = noteMessage,
+            });
+        }
     }
 
     m_diagnostics[uri].push_back(lsp::Diagnostic{

--- a/tests/cpp/DiagTests.cpp
+++ b/tests/cpp/DiagTests.cpp
@@ -37,6 +37,36 @@ endmodule
     golden.record(doc.getDiagnostics());
 }
 
+TEST_CASE("LocationOnlyDiagnosticCoversIdentifier") {
+    ServerHarness server;
+
+    auto doc = server.openFile("redefinition.sv", R"(
+module top;
+    logic foo;
+    logic foo;
+endmodule
+)");
+
+    auto expectedStart = doc.after("logic foo;\n    logic ").getPosition();
+    auto expectedEnd = expectedStart;
+    expectedEnd.character += 3;
+
+    bool foundRedefinition = false;
+    for (const auto& diag : doc.getDiagnostics()) {
+        if (diag.message.find("redefinition of 'foo'") == std::string::npos) {
+            continue;
+        }
+
+        foundRedefinition = true;
+        CHECK(diag.range.start.line == expectedStart.line);
+        CHECK(diag.range.start.character == expectedStart.character);
+        CHECK(diag.range.end.line == expectedEnd.line);
+        CHECK(diag.range.end.character == expectedEnd.character);
+    }
+
+    CHECK(foundRedefinition);
+}
+
 TEST_CASE("DiagsPublishedOnOpenCachedDoc") {
     ServerHarness server("cached_dep");
 

--- a/tests/cpp/golden/CompilationDiagnostics.json
+++ b/tests/cpp/golden/CompilationDiagnostics.json
@@ -35,7 +35,7 @@
               "range": {
                 "start": {
                   "line": 54,
-                  "character": 27
+                  "character": 37
                 },
                 "end": {
                   "line": 54,
@@ -67,7 +67,7 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 10
+                  "character": 18
                 },
                 "end": {
                   "line": 55,
@@ -99,7 +99,7 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 20
+                  "character": 32
                 },
                 "end": {
                   "line": 55,
@@ -199,7 +199,7 @@
               "range": {
                 "start": {
                   "line": 12,
-                  "character": 35
+                  "character": 44
                 },
                 "end": {
                   "line": 12,
@@ -231,7 +231,7 @@
               "range": {
                 "start": {
                   "line": 15,
-                  "character": 36
+                  "character": 43
                 },
                 "end": {
                   "line": 15,
@@ -596,7 +596,7 @@
               "range": {
                 "start": {
                   "line": 54,
-                  "character": 27
+                  "character": 37
                 },
                 "end": {
                   "line": 54,
@@ -628,7 +628,7 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 10
+                  "character": 18
                 },
                 "end": {
                   "line": 55,
@@ -660,7 +660,7 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 20
+                  "character": 32
                 },
                 "end": {
                   "line": 55,
@@ -760,7 +760,7 @@
               "range": {
                 "start": {
                   "line": 12,
-                  "character": 35
+                  "character": 44
                 },
                 "end": {
                   "line": 12,
@@ -792,7 +792,7 @@
               "range": {
                 "start": {
                   "line": 15,
-                  "character": 36
+                  "character": 43
                 },
                 "end": {
                   "line": 15,

--- a/tests/cpp/golden/CompilationDiagnostics.json
+++ b/tests/cpp/golden/CompilationDiagnostics.json
@@ -35,11 +35,11 @@
               "range": {
                 "start": {
                   "line": 54,
-                  "character": 37
+                  "character": 27
                 },
                 "end": {
                   "line": 54,
-                  "character": 27
+                  "character": 37
                 }
               }
             },
@@ -67,11 +67,11 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 18
+                  "character": 10
                 },
                 "end": {
                   "line": 55,
-                  "character": 10
+                  "character": 18
                 }
               }
             },
@@ -99,11 +99,11 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 32
+                  "character": 20
                 },
                 "end": {
                   "line": 55,
-                  "character": 20
+                  "character": 32
                 }
               }
             },
@@ -199,11 +199,11 @@
               "range": {
                 "start": {
                   "line": 12,
-                  "character": 44
+                  "character": 35
                 },
                 "end": {
                   "line": 12,
-                  "character": 35
+                  "character": 44
                 }
               }
             },
@@ -231,11 +231,11 @@
               "range": {
                 "start": {
                   "line": 15,
-                  "character": 43
+                  "character": 36
                 },
                 "end": {
                   "line": 15,
-                  "character": 36
+                  "character": 43
                 }
               }
             },
@@ -596,11 +596,11 @@
               "range": {
                 "start": {
                   "line": 54,
-                  "character": 37
+                  "character": 27
                 },
                 "end": {
                   "line": 54,
-                  "character": 27
+                  "character": 37
                 }
               }
             },
@@ -628,11 +628,11 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 18
+                  "character": 10
                 },
                 "end": {
                   "line": 55,
-                  "character": 10
+                  "character": 18
                 }
               }
             },
@@ -660,11 +660,11 @@
               "range": {
                 "start": {
                   "line": 55,
-                  "character": 32
+                  "character": 20
                 },
                 "end": {
                   "line": 55,
-                  "character": 20
+                  "character": 32
                 }
               }
             },
@@ -760,11 +760,11 @@
               "range": {
                 "start": {
                   "line": 12,
-                  "character": 44
+                  "character": 35
                 },
                 "end": {
                   "line": 12,
-                  "character": 35
+                  "character": 44
                 }
               }
             },
@@ -792,11 +792,11 @@
               "range": {
                 "start": {
                   "line": 15,
-                  "character": 43
+                  "character": 36
                 },
                 "end": {
                   "line": 15,
-                  "character": 36
+                  "character": 43
                 }
               }
             },

--- a/tests/cpp/golden/NoParamTop.json
+++ b/tests/cpp/golden/NoParamTop.json
@@ -210,7 +210,7 @@
             "range": {
               "start": {
                 "line": 361,
-                "character": 26
+                "character": 8
               },
               "end": {
                 "line": 361,
@@ -246,11 +246,11 @@
             "range": {
               "start": {
                 "line": 362,
-                "character": 27
+                "character": 8
               },
               "end": {
                 "line": 362,
-                "character": 29
+                "character": 26
               }
             }
           },
@@ -282,11 +282,11 @@
             "range": {
               "start": {
                 "line": 363,
-                "character": 27
+                "character": 8
               },
               "end": {
                 "line": 363,
-                "character": 25
+                "character": 27
               }
             }
           },
@@ -322,7 +322,7 @@
               },
               "end": {
                 "line": 367,
-                "character": 8
+                "character": 29
               }
             }
           },
@@ -358,7 +358,7 @@
               },
               "end": {
                 "line": 371,
-                "character": 8
+                "character": 27
               }
             }
           },
@@ -394,7 +394,7 @@
               },
               "end": {
                 "line": 374,
-                "character": 8
+                "character": 25
               }
             }
           },
@@ -426,11 +426,11 @@
             "range": {
               "start": {
                 "line": 297,
-                "character": 29
+                "character": 12
               },
               "end": {
                 "line": 297,
-                "character": 32
+                "character": 29
               }
             }
           },
@@ -466,7 +466,7 @@
               },
               "end": {
                 "line": 298,
-                "character": 12
+                "character": 32
               }
             }
           },

--- a/tests/cpp/golden/NoParamTop.json
+++ b/tests/cpp/golden/NoParamTop.json
@@ -210,11 +210,11 @@
             "range": {
               "start": {
                 "line": 361,
-                "character": 8
+                "character": 26
               },
               "end": {
                 "line": 361,
-                "character": 8
+                "character": 26
               }
             }
           },
@@ -246,11 +246,11 @@
             "range": {
               "start": {
                 "line": 362,
-                "character": 8
+                "character": 27
               },
               "end": {
                 "line": 362,
-                "character": 8
+                "character": 29
               }
             }
           },
@@ -282,11 +282,11 @@
             "range": {
               "start": {
                 "line": 363,
-                "character": 8
+                "character": 27
               },
               "end": {
                 "line": 363,
-                "character": 8
+                "character": 25
               }
             }
           },
@@ -426,11 +426,11 @@
             "range": {
               "start": {
                 "line": 297,
-                "character": 12
+                "character": 29
               },
               "end": {
                 "line": 297,
-                "character": 12
+                "character": 32
               }
             }
           },

--- a/tests/cpp/golden/PartialElaboration.json
+++ b/tests/cpp/golden/PartialElaboration.json
@@ -22,7 +22,7 @@
       "range": {
         "start": {
           "line": 6,
-          "character": 12
+          "character": 26
         },
         "end": {
           "line": 6,
@@ -38,11 +38,11 @@
             "range": {
               "start": {
                 "line": 6,
-                "character": 29
+                "character": 27
               },
               "end": {
                 "line": 6,
-                "character": 29
+                "character": 33
               }
             }
           },

--- a/tests/cpp/golden/PartialElaboration.json
+++ b/tests/cpp/golden/PartialElaboration.json
@@ -22,11 +22,11 @@
       "range": {
         "start": {
           "line": 6,
-          "character": 26
+          "character": 12
         },
         "end": {
           "line": 6,
-          "character": 12
+          "character": 26
         }
       },
       "severity": "Error",

--- a/tests/cpp/golden/SingleFileDiag.json
+++ b/tests/cpp/golden/SingleFileDiag.json
@@ -4,7 +4,7 @@
       "range": {
         "start": {
           "line": 6,
-          "character": 0
+          "character": 9
         },
         "end": {
           "line": 6,

--- a/tests/cpp/golden/SingleFileDiag.json
+++ b/tests/cpp/golden/SingleFileDiag.json
@@ -4,11 +4,11 @@
       "range": {
         "start": {
           "line": 6,
-          "character": 9
+          "character": 0
         },
         "end": {
           "line": 6,
-          "character": 0
+          "character": 9
         }
       },
       "severity": "Error",

--- a/tests/cpp/golden/UntakenGenerateChecks.json
+++ b/tests/cpp/golden/UntakenGenerateChecks.json
@@ -22,11 +22,11 @@
       "range": {
         "start": {
           "line": 12,
-          "character": 23
+          "character": 21
         },
         "end": {
           "line": 12,
-          "character": 21
+          "character": 23
         }
       },
       "severity": "Error",
@@ -40,11 +40,11 @@
       "range": {
         "start": {
           "line": 12,
-          "character": 37
+          "character": 32
         },
         "end": {
           "line": 12,
-          "character": 32
+          "character": 37
         }
       },
       "severity": "Error",
@@ -54,11 +54,11 @@
       "range": {
         "start": {
           "line": 14,
-          "character": 23
+          "character": 21
         },
         "end": {
           "line": 14,
-          "character": 21
+          "character": 23
         }
       },
       "severity": "Error",
@@ -72,11 +72,11 @@
       "range": {
         "start": {
           "line": 14,
-          "character": 37
+          "character": 32
         },
         "end": {
           "line": 14,
-          "character": 32
+          "character": 37
         }
       },
       "severity": "Error",
@@ -86,11 +86,11 @@
       "range": {
         "start": {
           "line": 18,
-          "character": 23
+          "character": 21
         },
         "end": {
           "line": 18,
-          "character": 21
+          "character": 23
         }
       },
       "severity": "Error",
@@ -104,11 +104,11 @@
       "range": {
         "start": {
           "line": 18,
-          "character": 37
+          "character": 32
         },
         "end": {
           "line": 18,
-          "character": 32
+          "character": 37
         }
       },
       "severity": "Error",

--- a/tests/cpp/golden/UntakenGenerateChecks.json
+++ b/tests/cpp/golden/UntakenGenerateChecks.json
@@ -22,7 +22,7 @@
       "range": {
         "start": {
           "line": 12,
-          "character": 21
+          "character": 23
         },
         "end": {
           "line": 12,
@@ -40,7 +40,7 @@
       "range": {
         "start": {
           "line": 12,
-          "character": 32
+          "character": 37
         },
         "end": {
           "line": 12,
@@ -54,7 +54,7 @@
       "range": {
         "start": {
           "line": 14,
-          "character": 21
+          "character": 23
         },
         "end": {
           "line": 14,
@@ -72,7 +72,7 @@
       "range": {
         "start": {
           "line": 14,
-          "character": 32
+          "character": 37
         },
         "end": {
           "line": 14,
@@ -86,7 +86,7 @@
       "range": {
         "start": {
           "line": 18,
-          "character": 21
+          "character": 23
         },
         "end": {
           "line": 18,
@@ -104,7 +104,7 @@
       "range": {
         "start": {
           "line": 18,
-          "character": 32
+          "character": 37
         },
         "end": {
           "line": 18,


### PR DESCRIPTION
## Summary
- expand diagnostics that only carry a source location to the identifier token at that location
- apply the same range handling to related note locations after mapping note ranges
- add regression coverage for redefinition diagnostics so the duplicate identifier range covers the whole name

Fixes #197.

## Correctness
Location-only diagnostics arrive as a zero-width range. The helper looks up the syntax token at that offset and expands the end position only when the token is an identifier; if lookup fails or the token is not an identifier, it preserves the original range. Existing non-empty diagnostic ranges remain unchanged.

## Remote Linux validation
- `git diff --check`
- `cmake --preset clang-release -DSLANG_CI_BUILD=ON`
- `cmake --build build/clang-release -j2`
- `ctest --test-dir build/clang-release --output-on-failure --no-tests=error -j2`
- `uv venv`
- `source .venv/bin/activate`
- `uv sync`
- `pytest tests/system/ --binary build/clang-release/bin/slang-server`
