### PR TITLE
Distinguish net and register hovers

### DIFF
--- a/include/Hovers.h
+++ b/include/Hovers.h
@@ -10,6 +10,8 @@
 namespace server {
 
 lsp::MarkupContent getHover(const SourceManager& sm, const BufferID docBuffer,
-                            const DefinitionInfo& info, const Config::HoverConfig& hovers);
+                            const DefinitionInfo& info,
+                            std::optional<std::string_view> variableKind,
+                            const Config::HoverConfig& hovers);
 
 }

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -31,6 +31,11 @@
 #include "slang/text/SourceLocation.h"
 #include "slang/text/SourceManager.h"
 #include "slang/util/Bag.h"
+
+namespace slang::analysis {
+class AnalysisManager;
+}
+
 namespace server {
 using namespace slang;
 struct DefinitionInfo {
@@ -71,6 +76,7 @@ public:
     ShallowAnalysis(SourceManager& sourceManager, slang::BufferID buffer,
                     std::shared_ptr<slang::syntax::SyntaxTree> tree, slang::Bag options,
                     const std::vector<std::shared_ptr<slang::syntax::SyntaxTree>>& allTrees = {});
+    ~ShallowAnalysis();
 
     /// @brief Retrieves document symbols for LSP outline view, called right after open
     /// @return Vector of LSP document symbols representing the document structure
@@ -165,6 +171,9 @@ public:
     /// @return The analysis diagnostics (owned by internal AnalysisManager)
     Diagnostics getAnalysisDiags();
 
+    /// @brief Returns a more specific kind for variables with definitive driver semantics
+    std::optional<std::string_view> getVariableKind(const slang::ast::Symbol& symbol);
+
 private:
     /// Reference to the source manager. Not const because we may need to parse macro args.
     SourceManager& m_sourceManager;
@@ -183,6 +192,9 @@ private:
 
     /// Analysis options for driver analysis (numThreads=1 to avoid persistent threads)
     slang::analysis::AnalysisOptions m_analysisOptions;
+
+    /// Driver analysis is shared by diagnostics and hover classification.
+    std::unique_ptr<slang::analysis::AnalysisManager> m_driverAnalysis;
 
     /// Symbol tree visitor for /documentSymbols
     /// Currently this is relies on syntax, but we should switch it to use the shallow compilation
@@ -218,6 +230,8 @@ private:
     /// @param node The syntax node to search from
     /// @return Pointer to the name syntax, or nullptr if none found
     const slang::syntax::NameSyntax* findNameSyntax(const slang::syntax::SyntaxNode& node) const;
+
+    slang::analysis::AnalysisManager& getDriverAnalysis();
 };
 
 } // namespace server

--- a/src/Hovers.cpp
+++ b/src/Hovers.cpp
@@ -21,7 +21,9 @@
 namespace server {
 
 lsp::MarkupContent getHover(const SourceManager& sm, const BufferID docBuffer,
-                            const DefinitionInfo& info, const Config::HoverConfig& hovers) {
+                            const DefinitionInfo& info,
+                            std::optional<std::string_view> variableKind,
+                            const Config::HoverConfig& hovers) {
     markup::Document doc;
 
     auto& infoPg = doc.addParagraph();
@@ -29,7 +31,8 @@ lsp::MarkupContent getHover(const SourceManager& sm, const BufferID docBuffer,
     if (info.symbol) {
         // <Kind/Type> <Name> in <Scope>
 
-        infoPg.appendBold(toString(info.symbol->kind)).appendCode(info.symbol->name);
+        infoPg.appendBold(variableKind.value_or(toString(info.symbol->kind)))
+            .appendCode(info.symbol->name);
 
         auto symbolScope = info.symbol->getParentScope();
         auto& parentSym = symbolScope->asSymbol();

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -657,7 +657,10 @@ std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::P
         return {};
     }
     const auto& info = *maybeInfo;
-    return lsp::Hover{.contents = getHover(sm, doc->getBuffer(), info, m_config.hovers.value())};
+    auto analysis = doc->getAnalysis();
+    auto variableKind = info.symbol ? analysis->getVariableKind(*info.symbol) : std::nullopt;
+    return lsp::Hover{
+        .contents = getHover(sm, doc->getBuffer(), info, variableKind, m_config.hovers.value())};
 }
 
 std::vector<lsp::LocationLink> ServerDriver::getDocDefinition(const URI& uri,

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -18,12 +18,14 @@
 #include <string_view>
 
 #include "slang/analysis/AnalysisManager.h"
+#include "slang/analysis/ValueDriver.h"
 #include "slang/ast/ASTContext.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/ast/symbols/PortSymbols.h"
 #include "slang/ast/symbols/ValueSymbol.h"
+#include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/AllTypes.h"
 #include "slang/ast/types/Type.h"
 #include "slang/diagnostics/AnalysisDiags.h"
@@ -104,6 +106,8 @@ ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID b
     // - syntax -> scopes
     m_compilation->getRoot().visit(m_symbolIndexer);
 }
+
+ShallowAnalysis::~ShallowAnalysis() = default;
 
 std::vector<lsp::DocumentSymbol> ShallowAnalysis::getDocSymbols() {
     if (!m_tree) {
@@ -600,15 +604,45 @@ Diagnostics ShallowAnalysis::getAnalysisDiags() {
         return {};
     }
 
-    slang::analysis::AnalysisManager driverAnalysis(m_analysisOptions);
-    m_compilation->freeze();
-    driverAnalysis.analyze(*m_compilation);
-    m_compilation->unfreeze();
-
     // filter out unused def/decl diags, since shallow analysis will likely not have all references.
-    return driverAnalysis.getDiagnostics().filter(
+    return getDriverAnalysis().getDiagnostics().filter(
         {diag::UnusedDefinition, diag::UnusedPackageParameter, diag::UnusedPackageSubroutine,
          diag::UnusedPackageTypedef, diag::UnusedPackageVar});
+}
+
+std::optional<std::string_view> ShallowAnalysis::getVariableKind(const ast::Symbol& symbol) {
+    if (symbol.kind != ast::SymbolKind::Variable) {
+        return std::nullopt;
+    }
+
+    bool isNet = false;
+    for (auto driver : getDriverAnalysis().getDrivers(symbol.as<ast::ValueSymbol>())) {
+        if (driver->flags.has(analysis::DriverFlags::Initializer) ||
+            driver->isUnidirectionalPort()) {
+            continue;
+        }
+
+        if (driver->source == analysis::DriverSource::AlwaysLatch ||
+            driver->source == analysis::DriverSource::AlwaysFF) {
+            return "Register";
+        }
+
+        if (driver->kind == analysis::DriverKind::Continuous ||
+            driver->source == analysis::DriverSource::AlwaysComb) {
+            isNet = true;
+        }
+    }
+    return isNet ? std::optional<std::string_view>("Net") : std::nullopt;
+}
+
+analysis::AnalysisManager& ShallowAnalysis::getDriverAnalysis() {
+    if (!m_driverAnalysis) {
+        m_driverAnalysis = std::make_unique<analysis::AnalysisManager>(m_analysisOptions);
+        m_compilation->freeze();
+        m_driverAnalysis->analyze(*m_compilation);
+        m_compilation->unfreeze();
+    }
+    return *m_driverAnalysis;
 }
 
 } // namespace server

--- a/tests/cpp/HoverTests.cpp
+++ b/tests/cpp/HoverTests.cpp
@@ -179,7 +179,7 @@ endmodule
 )");
 
     auto checkKind = [&](std::string_view signal, std::string_view kind) {
-        auto cursor = doc.before(signal);
+        auto cursor = doc.before(std::string(signal));
         auto hover = doc.getHoverAt(cursor.m_offset);
         REQUIRE(hover.has_value());
         auto content = rfl::get<lsp::MarkupContent>(hover->contents);

--- a/tests/cpp/HoverTests.cpp
+++ b/tests/cpp/HoverTests.cpp
@@ -4,6 +4,7 @@
 #include "utils/GoldenTest.h"
 #include "utils/ServerHarness.h"
 #include <cstdlib>
+#include <fmt/format.h>
 
 TEST_CASE("HoverMacroExpansion") {
     ServerHarness server;
@@ -156,4 +157,39 @@ endmodule
     // Raw mode preserves the comment markers verbatim
     CHECK(content.value.find("/// a doc line") != std::string::npos);
     CHECK(content.value.find("/// another line") != std::string::npos);
+}
+
+TEST_CASE("HoverNetAndRegisterKinds") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module top(input logic clk);
+    wire wire_signal;
+    logic continuous_signal;
+    logic combinational_signal;
+    logic register_signal;
+    logic latch_signal;
+    logic undriven_signal;
+
+    assign continuous_signal = wire_signal;
+    always_comb combinational_signal = wire_signal;
+    always_ff @(posedge clk) register_signal <= combinational_signal;
+    always_latch latch_signal <= combinational_signal;
+endmodule
+)");
+
+    auto checkKind = [&](std::string_view signal, std::string_view kind) {
+        auto cursor = doc.before(signal);
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover.has_value());
+        auto content = rfl::get<lsp::MarkupContent>(hover->contents);
+        CHECK(content.value.find(fmt::format("**{}** `{}`", kind, signal)) != std::string::npos);
+    };
+
+    checkKind("wire_signal", "Net");
+    checkKind("continuous_signal", "Net");
+    checkKind("combinational_signal", "Net");
+    checkKind("register_signal", "Register");
+    checkKind("latch_signal", "Register");
+    checkKind("undriven_signal", "Variable");
 }

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -475,8 +475,8 @@ macromodule m3;
 
                             tagged JmpU .a : pc = pc + a;
                                          ^ Sym a : PatternVar
-                                             ^^ Ref -> **Variable** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
-                                                  ^^ Ref -> **Variable** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
+                                             ^^ Ref -> **Net** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
+                                                  ^^ Ref -> **Net** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
                                                        ^ Ref -> **PatternVar** `a` in `m3`  \n\Type: `bit[9:0]`  \n\Width: `10`  \n\\n\\n\---\n\\n\`.a`
 
                             tagged JmpC '{.c, .a} : if (rf[c]) pc = a;
@@ -484,7 +484,7 @@ macromodule m3;
                                                ^ Sym a : PatternVar
                                                         ^^ Ref -> **Variable** `rf` in `m3`  \n\Type: `int$[]`  \n\\n\\n\---\n\\n\`automatic int rf[] = new [3];`
                                                            ^ Ref -> **PatternVar** `c` in `m3`  \n\Type: `bit[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`.c`
-                                                               ^^ Ref -> **Variable** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
+                                                               ^^ Ref -> **Net** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
                                                                     ^ Ref -> **PatternVar** `a` in `m3`  \n\Type: `bit[9:0]`  \n\Width: `10`  \n\\n\\n\---\n\\n\`.a`
 
                            endcase
@@ -503,12 +503,12 @@ macromodule m3;
                                                  ^ Sym a : PatternVar
 
             pc = c[0] & a[0];
-            ^^ Ref -> **Variable** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
+            ^^ Ref -> **Net** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
                  ^ Ref -> **PatternVar** `c` in `m3`  \n\Type: `bit[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`.c`
                         ^ Ref -> **PatternVar** `a` in `m3`  \n\Type: `bit[9:0]`  \n\Width: `10`  \n\\n\\n\---\n\\n\`.a`
 
             pc = instr matches (tagged Jmp .j) &&&
-            ^^ Ref -> **Variable** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
+            ^^ Ref -> **Net** `pc` in `m3`  \n\Type: `longint`  \n\Width: `64`  \n\\n\\n\---\n\\n\`static longint pc = 'x;`
                  ^^^^^ Ref -> **Variable** `instr` in `m3`  \n\Type: UnpackedUnion `Instr`  \n\\n\\n\---\n\\n\`Instr instr;`
 
                   j matches (tagged JmpC '{cc:.c,addr:.a}) ? c[0] & a[0] : 0;
@@ -1010,24 +1010,24 @@ checker assert_window1 (
 
         if (reset || window && end_event)
             ^^^^^ Ref -> **AssertionPort** `reset` in `assert_window1`  \n\\n\\n\---\n\\n\`logic reset = $inferred_disable`
-                     ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                     ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
                                ^^^^^^^^^ Ref -> **AssertionPort** `end_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped end_event`
 
             next_window = 1'b0;
-            ^^^^^^^^^^^ Ref -> **Variable** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+            ^^^^^^^^^^^ Ref -> **Net** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
         else if (!window && start_event)
-                  ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                  ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
                             ^^^^^^^^^^^ Ref -> **AssertionPort** `start_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped start_event`
 
             next_window = 1'b1;
-            ^^^^^^^^^^^ Ref -> **Variable** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+            ^^^^^^^^^^^ Ref -> **Net** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
         else
 
             next_window = window;
-            ^^^^^^^^^^^ Ref -> **Variable** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
-                          ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+            ^^^^^^^^^^^ Ref -> **Net** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                          ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
     end
 
@@ -1037,8 +1037,8 @@ checker assert_window1 (
                ^^^^^ Ref -> **AssertionPort** `clock` in `assert_window1`  \n\\n\\n\---\n\\n\`event clock = $inferred_clock`
 
         window <= next_window;
-        ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
-                  ^^^^^^^^^^^ Ref -> **Variable** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+        ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                  ^^^^^^^^^^^ Ref -> **Net** `next_window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
 
 
@@ -1047,7 +1047,7 @@ checker assert_window1 (
 
         start_event && !window |=> test_expr[+] ##0 end_event;
         ^^^^^^^^^^^ Ref -> **AssertionPort** `start_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped start_event`
-                        ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                        ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
                                    ^^^^^^^^^ Ref -> **AssertionPort** `test_expr` in `assert_window1`  \n\\n\\n\---\n\\n\`logic test_expr`
                                                     ^^^^^^^^^ Ref -> **AssertionPort** `end_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped end_event`
 
@@ -1070,7 +1070,7 @@ checker assert_window1 (
         cover_window_open: cover property (start_event && !window)
         ^^^^^^^^^^^^^^^^^ Sym cover_window_open : StatementBlock
                                            ^^^^^^^^^^^ Ref -> **AssertionPort** `start_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped start_event`
-                                                           ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                                                           ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
         $display("window_open covered");
 
@@ -1079,15 +1079,15 @@ checker assert_window1 (
 
             start_event && !window
             ^^^^^^^^^^^ Ref -> **AssertionPort** `start_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped start_event`
-                            ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                            ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
             ##1 (!end_event && window) [*]
                   ^^^^^^^^^ Ref -> **AssertionPort** `end_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped end_event`
-                               ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                               ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
             ##1 end_event && window
                 ^^^^^^^^^ Ref -> **AssertionPort** `end_event` in `assert_window1`  \n\\n\\n\---\n\\n\`untyped end_event`
-                             ^^^^^^ Ref -> **Variable** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
+                             ^^^^^^ Ref -> **Register** `window` in `assert_window1`  \n\Type: `bit`  \n\\n\\n\---\n\\n\`bit window = 1'b0, next_window = 1'b1;`
 
         ) $display("window covered");
 

--- a/tests/cpp/golden/FindSymbolRefHdl.out
+++ b/tests/cpp/golden/FindSymbolRefHdl.out
@@ -375,7 +375,7 @@ module TestModule #(
                  ^^^^^^^^^^^ Ref -> **Variable** `sub_data_in` in `TestModule`  \n\Type: `logic[15:0]$[4]`  \n\\n\\n\---\n\\n\Instance array that depends on NUM_SUBS parameter  \n\  \n\\n\\n\---\n\\n\`logic [15:0] sub_data_in [NUM_SUBS];`
 
         .data_out(sub_data_out)
-         ^^^^^^^^ Ref -> **Variable** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+         ^^^^^^^^ Ref -> **Register** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
                   ^^^^^^^^^^^^ Ref -> **Variable** `sub_data_out` in `TestModule`  \n\Type: `logic[15:0]$[4]`  \n\\n\\n\---\n\\n\`logic [15:0] sub_data_out [NUM_SUBS];`
 
     );
@@ -388,9 +388,9 @@ module TestModule #(
                  ^^^^^^^^^^^^^^^ Sym inst_array_test : Variable
 
     assign inst_array_test = sub_inst[0].data_out + sub_inst[1].data_out;
-           ^^^^^^^^^^^^^^^ Ref -> **Variable** `inst_array_test` in `TestModule`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\Test instance array access - goto on sub_inst[0] should go to sub_inst declaration  \n\  \n\\n\\n\---\n\\n\`logic [15:0] inst_array_test;`
+           ^^^^^^^^^^^^^^^ Ref -> **Net** `inst_array_test` in `TestModule`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\Test instance array access - goto on sub_inst[0] should go to sub_inst declaration  \n\  \n\\n\\n\---\n\\n\`logic [15:0] inst_array_test;`
                              ^^^^^^^^ Ref -> **InstanceArray** `sub_inst` in `TestModule`  \n\\n\\n\---\n\\n\`Sub #(.WIDTH(16)) sub_inst [NUM_SUBS] (\n\    .clk(clk),\n\    .rst(rst),\n\    .data_in(sub_data_in),\n\    .data_out(sub_data_out)\n\);`
-                                         ^^^^^^^^ Ref -> **Variable** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+                                         ^^^^^^^^ Ref -> **Register** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
                                                     ^^^^^^^^ Ref -> **InstanceArray** `sub_inst` in `TestModule`  \n\\n\\n\---\n\\n\`Sub #(.WIDTH(16)) sub_inst [NUM_SUBS] (\n\    .clk(clk),\n\    .rst(rst),\n\    .data_in(sub_data_in),\n\    .data_out(sub_data_out)\n\);`
                                                                 ^^^^^^^^ Ref -> **Variable** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
 
@@ -403,22 +403,22 @@ module TestModule #(
             ^^^ Ref -> **Variable** `rst` in `TestModule`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
 
             state <= test_pkg::STATE_A;
-            ^^^^^ Ref -> **Variable** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+            ^^^^^ Ref -> **Register** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
                      ^^^^^^^^ Ref -> **Package** `test_pkg`  \n\\n\\n\---\n\\n\`package test_pkg;`
                                ^^^^^^^ Ref -> **EnumValue** `STATE_A` in `test_pkg::state_t`  \n\Value: `2'b0`  \n\\n\\n\---\n\\n\`typedef enum logic [1:0] {\n\    STATE_A,\n\    STATE_B,\n\    STATE_C\n\} state_t;`
 
             counter <= '0;
-            ^^^^^^^ Ref -> **Variable** `counter` in `TestModule`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\This comment is just here to test the multi line  \n\comment functionality.  \n\  \n\\n\\n\---\n\\n\`test_pkg::id_t counter;`
+            ^^^^^^^ Ref -> **Register** `counter` in `TestModule`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\This comment is just here to test the multi line  \n\comment functionality.  \n\  \n\\n\\n\---\n\\n\`test_pkg::id_t counter;`
 
         end else begin
 
             state <= state_next;
-            ^^^^^ Ref -> **Variable** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
-                     ^^^^^^^^^^ Ref -> **Variable** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+            ^^^^^ Ref -> **Register** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+                     ^^^^^^^^^^ Ref -> **Net** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
 
             counter <= counter + 1'b1;
-            ^^^^^^^ Ref -> **Variable** `counter` in `TestModule`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\This comment is just here to test the multi line  \n\comment functionality.  \n\  \n\\n\\n\---\n\\n\`test_pkg::id_t counter;`
-                       ^^^^^^^ Ref -> **Variable** `counter` in `TestModule`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\This comment is just here to test the multi line  \n\comment functionality.  \n\  \n\\n\\n\---\n\\n\`test_pkg::id_t counter;`
+            ^^^^^^^ Ref -> **Register** `counter` in `TestModule`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\This comment is just here to test the multi line  \n\comment functionality.  \n\  \n\\n\\n\---\n\\n\`test_pkg::id_t counter;`
+                       ^^^^^^^ Ref -> **Register** `counter` in `TestModule`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\This comment is just here to test the multi line  \n\comment functionality.  \n\  \n\\n\\n\---\n\\n\`test_pkg::id_t counter;`
 
         end
 
@@ -429,24 +429,24 @@ module TestModule #(
     always_comb begin
 
         case (state)
-              ^^^^^ Ref -> **Variable** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+              ^^^^^ Ref -> **Register** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
 
             test_pkg::STATE_A: state_next = test_pkg::STATE_B;
             ^^^^^^^^ Ref -> **Package** `test_pkg`  \n\\n\\n\---\n\\n\`package test_pkg;`
                       ^^^^^^^ Ref -> **EnumValue** `STATE_A` in `test_pkg::state_t`  \n\Value: `2'b0`  \n\\n\\n\---\n\\n\`typedef enum logic [1:0] {\n\    STATE_A,\n\    STATE_B,\n\    STATE_C\n\} state_t;`
-                               ^^^^^^^^^^ Ref -> **Variable** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+                               ^^^^^^^^^^ Ref -> **Net** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
                                             ^^^^^^^^ Ref -> **Package** `test_pkg`  \n\\n\\n\---\n\\n\`package test_pkg;`
                                                       ^^^^^^^ Ref -> **EnumValue** `STATE_B` in `test_pkg::state_t`  \n\Value: `2'b1`  \n\\n\\n\---\n\\n\`typedef enum logic [1:0] {\n\    STATE_A,\n\    STATE_B,\n\    STATE_C\n\} state_t;`
 
             test_pkg::STATE_B: state_next = test_pkg::STATE_C;
             ^^^^^^^^ Ref -> **Package** `test_pkg`  \n\\n\\n\---\n\\n\`package test_pkg;`
                       ^^^^^^^ Ref -> **EnumValue** `STATE_B` in `test_pkg::state_t`  \n\Value: `2'b1`  \n\\n\\n\---\n\\n\`typedef enum logic [1:0] {\n\    STATE_A,\n\    STATE_B,\n\    STATE_C\n\} state_t;`
-                               ^^^^^^^^^^ Ref -> **Variable** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+                               ^^^^^^^^^^ Ref -> **Net** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
                                             ^^^^^^^^ Ref -> **Package** `test_pkg`  \n\\n\\n\---\n\\n\`package test_pkg;`
                                                       ^^^^^^^ Ref -> **EnumValue** `STATE_C` in `test_pkg::state_t`  \n\Value: `2'b10`  \n\\n\\n\---\n\\n\`typedef enum logic [1:0] {\n\    STATE_A,\n\    STATE_B,\n\    STATE_C\n\} state_t;`
 
             default: state_next = test_pkg::STATE_A;
-                     ^^^^^^^^^^ Ref -> **Variable** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+                     ^^^^^^^^^^ Ref -> **Net** `state_next` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
                                   ^^^^^^^^ Ref -> **Package** `test_pkg`  \n\\n\\n\---\n\\n\`package test_pkg;`
                                             ^^^^^^^ Ref -> **EnumValue** `STATE_A` in `test_pkg::state_t`  \n\Value: `2'b0`  \n\\n\\n\---\n\\n\`typedef enum logic [1:0] {\n\    STATE_A,\n\    STATE_B,\n\    STATE_C\n\} state_t;`
 
@@ -518,7 +518,7 @@ module TestModule #(
         bus_master.data <= state;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
                    ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
-                           ^^^^^ Ref -> **Variable** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
+                           ^^^^^ Ref -> **Register** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`
 
 
 
@@ -895,15 +895,15 @@ module StructAssignmentTest (
             // Basic struct member assignment
 
             single_struct.addr <= 8'h00;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                           ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             single_struct.data <= 16'h0000;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                           ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
             single_struct.valid <= 1'b0;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                           ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
 
 
@@ -911,15 +911,15 @@ module StructAssignmentTest (
             // Array index struct member assignment
 
             struct_array[0].addr <= 8'hAA;
-            ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+            ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                             ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             struct_array[1].data <= 16'hBBBB;
-            ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+            ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                             ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
             struct_array[2].valid <= 1'b1;
-            ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+            ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                             ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
 
 
@@ -927,41 +927,41 @@ module StructAssignmentTest (
             // Variable index struct member assignment
 
             struct_array[index].addr <= 8'hCC;
-            ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
-                         ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+                         ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                 ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             struct_array[index].data <= data_val;
-            ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
-                         ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+                         ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                 ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
-                                        ^^^^^^^^ Ref -> **Variable** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
+                                        ^^^^^^^^ Ref -> **Register** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
 
 
 
             // Nested struct member assignment
 
             nested_struct.inner.addr <= 8'hDD;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                 ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             nested_struct.inner.data <= 16'hEEEE;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                 ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
             nested_struct.inner.valid <= 1'b0;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                 ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
 
             nested_struct.tag <= 4'h5;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^ Ref -> **Field** `tag` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic[3:0]`  \n\Width: `4`  \n\\n\\n\---\n\\n\`logic [3:0] tag;`
 
             nested_struct.enable <= 1'b1;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^^ Ref -> **Field** `enable` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic enable;`
 
 
@@ -969,18 +969,18 @@ module StructAssignmentTest (
             // Nested struct array assignment
 
             nested_array[0].inner.addr <= 8'hFF;
-            ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+            ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
                             ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                   ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             nested_array[1].inner.data <= 16'h1234;
-            ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+            ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
                             ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                   ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
             nested_array[index].tag <= 4'h7;
-            ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
-                         ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+                         ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                 ^^^ Ref -> **Field** `tag` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic[3:0]`  \n\Width: `4`  \n\\n\\n\---\n\\n\`logic [3:0] tag;`
 
 
@@ -988,11 +988,11 @@ module StructAssignmentTest (
             // Package struct member assignment
 
             pkg_struct.id <= 32'h123;
-            ^^^^^^^^^^ Ref -> **Variable** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
+            ^^^^^^^^^^ Ref -> **Register** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
                        ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
 
             pkg_struct.data <= 16'h5678;
-            ^^^^^^^^^^ Ref -> **Variable** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
+            ^^^^^^^^^^ Ref -> **Register** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
                        ^^^^ Ref -> **Field** `data` in `test_pkg::packet_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
 
@@ -1000,48 +1000,48 @@ module StructAssignmentTest (
             // Package struct array assignment
 
             pkg_array[0].id <= 32'h456;
-            ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+            ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
                          ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
 
             pkg_array[1].data <= 16'h9ABC;
-            ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+            ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
                          ^^^^ Ref -> **Field** `data` in `test_pkg::packet_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
             pkg_array[index].id <= {24'h0, addr_val};
-            ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
-                      ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+                      ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                              ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
-                                           ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+                                           ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
 
 
 
             index <= 2'b00;
-            ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
 
             addr_val <= 8'h11;
-            ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+            ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
 
             data_val <= 16'h2222;
-            ^^^^^^^^ Ref -> **Variable** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
+            ^^^^^^^^ Ref -> **Register** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
 
         end else begin
 
             // Runtime assignments with expressions
 
             single_struct.addr <= addr_val + 8'h10;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                           ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
-                                  ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+                                  ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
 
             single_struct.data <= data_val << 1;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                           ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
-                                  ^^^^^^^^ Ref -> **Variable** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
+                                  ^^^^^^^^ Ref -> **Register** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
 
             single_struct.valid <= ~single_struct.valid;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                           ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
-                                    ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+                                    ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                                                   ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
 
 
@@ -1049,17 +1049,17 @@ module StructAssignmentTest (
             // Complex array indexing with struct members
 
             struct_array[index + 1].addr <= single_struct.addr;
-            ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
-                         ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+                         ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                     ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
-                                            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+                                            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                                                           ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             struct_array[addr_val[1:0]].data <= nested_struct.inner.data;
-            ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
-                         ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+            ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+                         ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
                                         ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
-                                                ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+                                                ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                                                               ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                                                     ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
@@ -1068,25 +1068,25 @@ module StructAssignmentTest (
             // Chained struct member assignments
 
             nested_struct.inner.addr <= struct_array[0].addr;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                 ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
-                                        ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+                                        ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                                                         ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             nested_struct.inner.data <= pkg_struct.data;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                 ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
-                                        ^^^^^^^^^^ Ref -> **Variable** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
+                                        ^^^^^^^^^^ Ref -> **Register** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
                                                    ^^^^ Ref -> **Field** `data` in `test_pkg::packet_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
             nested_struct.inner.valid <= pkg_array[index].id[0];
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                 ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
-                                         ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
-                                                   ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+                                         ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+                                                   ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                                           ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
 
 
@@ -1094,21 +1094,21 @@ module StructAssignmentTest (
             // Multi-dimensional style access
 
             nested_array[index].inner.addr <= struct_array[addr_val[1:0]].addr;
-            ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
-                         ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+                         ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                 ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                       ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
-                                              ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
-                                                           ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+                                              ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+                                                           ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
                                                                           ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             nested_array[~index].inner.data <= pkg_array[index + 1].data;
-            ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
-                          ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+                          ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                  ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                        ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
-                                               ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
-                                                         ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+                                               ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+                                                         ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                                                                     ^^^^ Ref -> **Field** `data` in `test_pkg::packet_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
 
@@ -1116,18 +1116,18 @@ module StructAssignmentTest (
             // Expression-based assignments
 
             pkg_struct.id <= {16'h0, addr_val, data_val[7:0]};
-            ^^^^^^^^^^ Ref -> **Variable** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
+            ^^^^^^^^^^ Ref -> **Register** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
                        ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
-                                     ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
-                                               ^^^^^^^^ Ref -> **Variable** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
+                                     ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+                                               ^^^^^^^^ Ref -> **Register** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
 
             pkg_array[index].data <= single_struct.data ^ nested_struct.inner.data;
-            ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
-                      ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+                      ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
                              ^^^^ Ref -> **Field** `data` in `test_pkg::packet_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
-                                     ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+                                     ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                                                    ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
-                                                          ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+                                                          ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                                                                         ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                                                                               ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
@@ -1136,16 +1136,16 @@ module StructAssignmentTest (
             // Increment index for next cycle
 
             index <= index + 1;
-            ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
-                     ^^^^^ Ref -> **Variable** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+            ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
+                     ^^^^^ Ref -> **Register** `index` in `StructAssignmentTest`  \n\Type: `logic[1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [1:0] index;`
 
             addr_val <= addr_val + 8'h01;
-            ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
-                        ^^^^^^^^ Ref -> **Variable** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+            ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
+                        ^^^^^^^^ Ref -> **Register** `addr_val` in `StructAssignmentTest`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr_val;`
 
             data_val <= data_val + 16'h0011;
-            ^^^^^^^^ Ref -> **Variable** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
-                        ^^^^^^^^ Ref -> **Variable** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
+            ^^^^^^^^ Ref -> **Register** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
+                        ^^^^^^^^ Ref -> **Register** `data_val` in `StructAssignmentTest`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data_val;`
 
         end
 
@@ -1160,29 +1160,29 @@ module StructAssignmentTest (
         // Direct member assignments in combinational logic
 
         if (single_struct.valid) begin
-            ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                           ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
 
             nested_struct.tag = struct_array[0].addr[3:0];
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^ Ref -> **Field** `tag` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic[3:0]`  \n\Width: `4`  \n\\n\\n\---\n\\n\`logic [3:0] tag;`
-                                ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+                                ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                                                 ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
             nested_struct.enable = |pkg_struct.id;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^^ Ref -> **Field** `enable` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic enable;`
-                                    ^^^^^^^^^^ Ref -> **Variable** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
+                                    ^^^^^^^^^^ Ref -> **Register** `pkg_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `packet_t` (`logic[47:0]`)  \n\Width: `48`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_struct;`
                                                ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
 
         end else begin
 
             nested_struct.tag = 4'h0;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^ Ref -> **Field** `tag` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic[3:0]`  \n\Width: `4`  \n\\n\\n\---\n\\n\`logic [3:0] tag;`
 
             nested_struct.enable = 1'b0;
-            ^^^^^^^^^^^^^ Ref -> **Variable** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
+            ^^^^^^^^^^^^^ Ref -> **Register** `nested_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `nested_struct_t` (`logic[29:0]`)  \n\Width: `30`  \n\\n\\n\---\n\\n\`nested_struct_t nested_struct;`
                           ^^^^^^ Ref -> **Field** `enable` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic enable;`
 
         end
@@ -1196,55 +1196,55 @@ module StructAssignmentTest (
     initial begin
 
         single_struct.addr = 8'h77;
-        ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+        ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                       ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
         single_struct.data = 16'h8888;
-        ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+        ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                       ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
         single_struct.valid = 1'b1;
-        ^^^^^^^^^^^^^ Ref -> **Variable** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
+        ^^^^^^^^^^^^^ Ref -> **Register** `single_struct` in `StructAssignmentTest`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\Variables for testing  \n\  \n\\n\\n\---\n\\n\`simple_struct_t single_struct;`
                       ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
 
 
 
         struct_array[3].addr = 8'h99;
-        ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+        ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                         ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
         struct_array[3].data = 16'hAAAA;
-        ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+        ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                         ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
         struct_array[3].valid = 1'b0;
-        ^^^^^^^^^^^^ Ref -> **Variable** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
+        ^^^^^^^^^^^^ Ref -> **Register** `struct_array` in `StructAssignmentTest`  \n\Type: `simple_struct_t$[4]`  \n\\n\\n\---\n\\n\`simple_struct_t struct_array[4];`
                         ^^^^^ Ref -> **Field** `valid` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic valid;`
 
 
 
         nested_array[1].inner.addr = 8'hBB;
-        ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+        ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
                         ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                               ^^^^ Ref -> **Field** `addr` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[7:0]`  \n\Width: `8`  \n\\n\\n\---\n\\n\`logic [7:0] addr;`
 
         nested_array[1].inner.data = 16'hCCCC;
-        ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+        ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
                         ^^^^^ Ref -> **Field** `inner` in `StructAssignmentTest::nested_struct_t`  \n\Type: PackedStruct `simple_struct_t` (`logic[24:0]`)  \n\Width: `25`  \n\\n\\n\---\n\\n\`simple_struct_t inner;`
                               ^^^^ Ref -> **Field** `data` in `StructAssignmentTest::simple_struct_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
         nested_array[1].tag = 4'hD;
-        ^^^^^^^^^^^^ Ref -> **Variable** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
+        ^^^^^^^^^^^^ Ref -> **Register** `nested_array` in `StructAssignmentTest`  \n\Type: `nested_struct_t$[2]`  \n\\n\\n\---\n\\n\`nested_struct_t nested_array[2];`
                         ^^^ Ref -> **Field** `tag` in `StructAssignmentTest::nested_struct_t`  \n\Type: `logic[3:0]`  \n\Width: `4`  \n\\n\\n\---\n\\n\`logic [3:0] tag;`
 
 
 
         pkg_array[2].id = 32'hDEAD;
-        ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+        ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
                      ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
 
         pkg_array[2].data = 16'hBEEF;
-        ^^^^^^^^^ Ref -> **Variable** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
+        ^^^^^^^^^ Ref -> **Register** `pkg_array` in `StructAssignmentTest`  \n\Type: `packet_t$[3]`  \n\\n\\n\---\n\\n\`test_pkg::packet_t pkg_array[3];`
                      ^^^^ Ref -> **Field** `data` in `test_pkg::packet_t`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`logic [15:0] data;`
 
     end

--- a/tests/cpp/golden/FindSymbolRefMacro.out
+++ b/tests/cpp/golden/FindSymbolRefMacro.out
@@ -259,11 +259,11 @@ module test;
 
             `SIMPLE_MACRO: bus_signal = `TWO_ARG_MACRO(1, 2);
             ^^^^^^^^^^^^^ Ref -> DefineDirective SIMPLE_MACRO  \n\\n\\n\---\n\\n\Basic macro definitions  \n\  \n\\n\\n\---\n\\n\``define SIMPLE_MACRO 42`\n\\n\---\n\\n\Expands to   \n\`42`
-                           ^^^^^^^^^^ Ref -> **Variable** `bus_signal` in `test`  \n\Type: `logic[-1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [-1:0] bus_signal;`
+                           ^^^^^^^^^^ Ref -> **Net** `bus_signal` in `test`  \n\Type: `logic[-1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [-1:0] bus_signal;`
                                         ^^^^^^^^^^^^^^ Ref -> DefineDirective TWO_ARG_MACRO  \n\\n\\n\---\n\\n\``define TWO_ARG_MACRO(a, b) (a + b)`\n\\n\---\n\\n\Expands to   \n\`(1 + 2)`
 
             default: bus_signal = `FUNC_MACRO(0);
-                     ^^^^^^^^^^ Ref -> **Variable** `bus_signal` in `test`  \n\Type: `logic[-1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [-1:0] bus_signal;`
+                     ^^^^^^^^^^ Ref -> **Net** `bus_signal` in `test`  \n\Type: `logic[-1:0]`  \n\Width: `2`  \n\\n\\n\---\n\\n\`logic [-1:0] bus_signal;`
                                   ^^^^^^^^^^^ Ref -> DefineDirective FUNC_MACRO  \n\\n\\n\---\n\\n\``define FUNC_MACRO(x) (x + 1)`\n\\n\---\n\\n\Expands to   \n\`(0 + 1)`
 
         endcase


### PR DESCRIPTION
## Summary
- reuse shallow driver analysis for hover classification instead of discarding it after diagnostics
- label continuously driven and `always_comb` variables as `Net`
- label `always_ff` and `always_latch` variables as `Register`
- retain the existing `Variable` label when the driver semantics are not definitive

## Validation
- `git diff --check HEAD^ HEAD`
- `/Library/Developer/CommandLineTools/usr/bin/clang-format -i include/Hovers.h include/document/ShallowAnalysis.h src/Hovers.cpp src/ServerDriver.cpp src/document/ShallowAnalysis.cpp tests/cpp/HoverTests.cpp`
- added hover regression coverage for explicit wires, continuous assignments, `always_comb`, `always_ff`, `always_latch`, and undriven variables

Fixes #351

## Remote Linux validation
- `git diff --check`
- `cmake --preset clang-release -DSLANG_CI_BUILD=ON`
- `cmake --build build/clang-release -j2`
- `ctest --test-dir build/clang-release --output-on-failure --no-tests=error -j2`
- `uv venv`
- `source .venv/bin/activate`
- `uv sync`
- `pytest tests/system/ --binary build/clang-release/bin/slang-server`
