### PR TITLE
Load package dependencies of interfaces

### DIFF
--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -349,13 +349,8 @@ std::vector<std::shared_ptr<SlangDoc>> ServerDriver::getDependentDocs(
                 result.push_back(newdoc);
                 docs[newdoc->getURI()] = newdoc;
 
-                // Only add packages to the queue for recursive processing
-                for (auto& [decl, _] : newdoc->getSyntaxTree()->getMetadata().nodeMeta) {
-                    if (decl->kind == syntax::SyntaxKind::PackageDeclaration) {
-                        treesToProcess.push(newdoc->getSyntaxTree());
-                        break;
-                    }
-                }
+                // Interfaces and modules can add package dependencies of their own.
+                treesToProcess.push(newdoc->getSyntaxTree());
             }
             else {
                 ERROR("No doc found for {}", filePath);

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -349,8 +349,14 @@ std::vector<std::shared_ptr<SlangDoc>> ServerDriver::getDependentDocs(
                 result.push_back(newdoc);
                 docs[newdoc->getURI()] = newdoc;
 
-                // Interfaces and modules can add package dependencies of their own.
-                treesToProcess.push(newdoc->getSyntaxTree());
+                // Packages and interfaces can add package dependencies of their own.
+                for (auto& [decl, _] : newdoc->getSyntaxTree()->getMetadata().nodeMeta) {
+                    if (decl->kind == syntax::SyntaxKind::PackageDeclaration ||
+                        decl->kind == syntax::SyntaxKind::InterfaceDeclaration) {
+                        treesToProcess.push(newdoc->getSyntaxTree());
+                        break;
+                    }
+                }
             }
             else {
                 ERROR("No doc found for {}", filePath);

--- a/tests/cpp/GotoTests.cpp
+++ b/tests/cpp/GotoTests.cpp
@@ -121,6 +121,13 @@ TEST_CASE("LoadTransitivePackages") {
     scanner.scanDocument(hdl);
 }
 
+TEST_CASE("LoadPackageDependenciesOfInterfaces") {
+    ServerHarness server("repo1");
+    auto hdl = server.openFile("interface_consumer.sv");
+
+    CHECK(hdl.doc->getAnalysis()->getCompilation()->getPackage("transitive_pkg") != nullptr);
+}
+
 TEST_CASE("FindReferencesAllTokens_all.sv") {
     /// Find references at each location in all.sv
     ServerHarness server("");

--- a/tests/cpp/golden/ModuleMemberCompletion.json
+++ b/tests/cpp/golden/ModuleMemberCompletion.json
@@ -82,6 +82,20 @@
         "insertTextFormat": "Snippet"
       },
       {
+        "label": "interface_consumer",
+        "labelDetails": {
+          "detail": " Module"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\nmodule interface_consumer (\n    transitive_if.consumer_mp bus\n);\n````"
+        },
+        "filterText": "interface_consumer",
+        "insertText": "interface_consumer ${1:interface_consumer} (\n    .bus(${2:bus})\n);",
+        "insertTextFormat": "Snippet"
+      },
+      {
         "label": "logic",
         "kind": "Keyword",
         "filterText": "logic"
@@ -116,6 +130,34 @@
         "filterText": "tb",
         "insertText": "tb ${1:tb} ();",
         "insertTextFormat": "Snippet"
+      },
+      {
+        "label": "transitive_if",
+        "labelDetails": {
+          "detail": " Interface"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\ninterface transitive_if;\n````"
+        },
+        "filterText": "transitive_if",
+        "insertText": "transitive_if ${1:transitive_if} ();",
+        "insertTextFormat": "Snippet"
+      },
+      {
+        "label": "transitive_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage transitive_pkg;\n````"
+        },
+        "filterText": "transitive_pkg",
+        "insertText": "transitive_pkg",
+        "insertTextFormat": "PlainText"
       },
       {
         "label": "util_pkg",
@@ -352,6 +394,33 @@
           "value": "````systemverilog\ntypedef enum logic [1:0] {\n    IDLE = 2'b00,\n    ACTIVE = 2'b01,\n    WAIT = 2'b10\n} state_t;\n````"
         },
         "filterText": "state_t"
+      },
+      {
+        "label": "transitive_if",
+        "labelDetails": {
+          "detail": " Interface"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\ninterface transitive_if;\n````"
+        },
+        "filterText": "transitive_if",
+        "insertText": "transitive_if"
+      },
+      {
+        "label": "transitive_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage transitive_pkg;\n````"
+        },
+        "filterText": "transitive_pkg",
+        "insertText": "transitive_pkg",
+        "insertTextFormat": "PlainText"
       },
       {
         "label": "u_sub",

--- a/tests/cpp/golden/NonProceduralSignalCompletion.json
+++ b/tests/cpp/golden/NonProceduralSignalCompletion.json
@@ -76,6 +76,33 @@
         "filterText": "my_wire"
       },
       {
+        "label": "transitive_if",
+        "labelDetails": {
+          "detail": " Interface"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\ninterface transitive_if;\n````"
+        },
+        "filterText": "transitive_if",
+        "insertText": "transitive_if"
+      },
+      {
+        "label": "transitive_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage transitive_pkg;\n````"
+        },
+        "filterText": "transitive_pkg",
+        "insertText": "transitive_pkg",
+        "insertTextFormat": "PlainText"
+      },
+      {
         "label": "util_pkg",
         "labelDetails": {
           "detail": " Package"

--- a/tests/cpp/golden/PortListCompletion.json
+++ b/tests/cpp/golden/PortListCompletion.json
@@ -29,6 +29,33 @@
         "insertText": "test_intf"
       },
       {
+        "label": "transitive_if",
+        "labelDetails": {
+          "detail": " Interface"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\ninterface transitive_if;\n````"
+        },
+        "filterText": "transitive_if",
+        "insertText": "transitive_if"
+      },
+      {
+        "label": "transitive_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage transitive_pkg;\n````"
+        },
+        "filterText": "transitive_pkg",
+        "insertText": "transitive_pkg",
+        "insertTextFormat": "PlainText"
+      },
+      {
         "label": "util_pkg",
         "labelDetails": {
           "detail": " Package"

--- a/tests/cpp/golden/WildcardImportCompletion.json
+++ b/tests/cpp/golden/WildcardImportCompletion.json
@@ -218,6 +218,33 @@
         "filterText": "result"
       },
       {
+        "label": "transitive_if",
+        "labelDetails": {
+          "detail": " Interface"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\ninterface transitive_if;\n````"
+        },
+        "filterText": "transitive_if",
+        "insertText": "transitive_if"
+      },
+      {
+        "label": "transitive_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage transitive_pkg;\n````"
+        },
+        "filterText": "transitive_pkg",
+        "insertText": "transitive_pkg",
+        "insertTextFormat": "PlainText"
+      },
+      {
         "label": "util_pkg",
         "labelDetails": {
           "detail": " Package"
@@ -450,6 +477,33 @@
         },
         "kind": "Variable",
         "filterText": "result"
+      },
+      {
+        "label": "transitive_if",
+        "labelDetails": {
+          "detail": " Interface"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\ninterface transitive_if;\n````"
+        },
+        "filterText": "transitive_if",
+        "insertText": "transitive_if"
+      },
+      {
+        "label": "transitive_pkg",
+        "labelDetails": {
+          "detail": " Package"
+        },
+        "kind": "Module",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\npackage transitive_pkg;\n````"
+        },
+        "filterText": "transitive_pkg",
+        "insertText": "transitive_pkg",
+        "insertTextFormat": "PlainText"
       },
       {
         "label": "util_pkg",

--- a/tests/data/repo1/interface_consumer.sv
+++ b/tests/data/repo1/interface_consumer.sv
@@ -1,0 +1,4 @@
+module interface_consumer (
+    transitive_if.consumer_mp bus
+);
+endmodule

--- a/tests/data/repo1/transitive_if.sv
+++ b/tests/data/repo1/transitive_if.sv
@@ -1,0 +1,7 @@
+import transitive_pkg::*;
+
+interface transitive_if;
+    payload_t payload;
+
+    modport consumer_mp(input payload);
+endinterface

--- a/tests/data/repo1/transitive_pkg.sv
+++ b/tests/data/repo1/transitive_pkg.sv
@@ -1,0 +1,6 @@
+package transitive_pkg;
+    typedef struct packed {
+        logic valid;
+        logic [7:0] data;
+    } payload_t;
+endpackage


### PR DESCRIPTION
## Summary
- queue newly discovered package and interface trees for recursive dependency discovery
- add interface-imported packages to shallow compilation without recursively walking discovered modules
- add a regression fixture where a module depends on an interface that imports its payload type from a package

## Correctness
The originating tree is always inspected. Discovered documents are always added to the shallow dependency set, but only package and interface syntax trees are queued for another discovery step. For the regression graph, the walk reaches `interface_consumer -> transitive_if -> transitive_pkg`. A module discovered beneath another file is not queued, so the loader does not recursively follow the design hierarchy.

Fixes #349

## Remote Linux validation
- `git diff --check`
- `uv run pre-commit run --all-files`
- `cmake --preset clang-release -DSLANG_CI_BUILD=ON`
- `cmake --build build/clang-release -j2`
- `ctest --test-dir build/clang-release --output-on-failure --no-tests=error -j2`
- `uv venv`
- `source .venv/bin/activate`
- `uv sync`
- `pytest tests/system/ --binary build/clang-release/bin/slang-server`
