### PR TITLE
Use source buffer for explicit Neovim commands

### DIFF
--- a/clients/neovim/lua/slang-server/_commands/addToWaves.lua
+++ b/clients/neovim/lua/slang-server/_commands/addToWaves.lua
@@ -7,6 +7,13 @@ M.addToWaves = {
    impl = function(args)
       local capabilities = require("slang-server._lsp.capabilities")
       local bufnr = vim.api.nvim_get_current_buf()
+      if not capabilities.get_client(bufnr) then
+         vim.notify(
+            "slang-server: addToWaves must be run from a buffer with an attached slang-server LSP client.",
+            vim.log.levels.ERROR
+         )
+         return
+      end
       if not capabilities.check_or_notify(bufnr, { "slang.getInstances", "slang.addToWaveform" }) then
          return
       end
@@ -17,7 +24,7 @@ M.addToWaves = {
 
       local recursive = args[1] == "true"
 
-      local first_client = vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })[1]
+      local first_client = vim.lsp.get_clients({ bufnr = bufnr })[1]
       local position_encoding = first_client and first_client.offset_encoding or 'utf-16'
 
       client.getInstances(bufnr, {

--- a/clients/neovim/lua/slang-server/_commands/hierarchy.lua
+++ b/clients/neovim/lua/slang-server/_commands/hierarchy.lua
@@ -6,7 +6,7 @@ local M = {}
 M.hierarchy = {
    impl = function(args, opts)
       local capabilities = require("slang-server._lsp.capabilities")
-      local bufnr = vim.api.nvim_get_current_buf()
+      local bufnr = capabilities.get_source_context()
       local required = { "slang.getScope", "slang.getScopesByModule", "slang.getInstancesOfModule" }
       if not capabilities.check_or_notify(bufnr, required) then
          return

--- a/clients/neovim/lua/slang-server/_commands/openWaveform.lua
+++ b/clients/neovim/lua/slang-server/_commands/openWaveform.lua
@@ -6,7 +6,7 @@ local M = {}
 M.openWaveform = {
    impl = function(args, opts)
       local capabilities = require("slang-server._lsp.capabilities")
-      local bufnr = vim.api.nvim_get_current_buf()
+      local bufnr = capabilities.get_source_context()
       if not capabilities.check_or_notify(bufnr, { "slang.openWaveform" }) then
          return
       end

--- a/clients/neovim/lua/slang-server/_commands/setBuildFile.lua
+++ b/clients/neovim/lua/slang-server/_commands/setBuildFile.lua
@@ -6,7 +6,7 @@ local M = {}
 M.setBuildFile = {
    impl = function(args, opts)
       local capabilities = require("slang-server._lsp.capabilities")
-      local bufnr = vim.api.nvim_get_current_buf()
+      local bufnr = capabilities.get_source_context()
       if not capabilities.check_or_notify(bufnr, { "slang.setBuildFile" }) then
          return
       end

--- a/clients/neovim/lua/slang-server/_commands/setTopLevel.lua
+++ b/clients/neovim/lua/slang-server/_commands/setTopLevel.lua
@@ -6,7 +6,21 @@ local M = {}
 M.setTopLevel = {
    impl = function(args, opts)
       local capabilities = require("slang-server._lsp.capabilities")
-      local bufnr = vim.api.nvim_get_current_buf()
+      local file = args[1]
+      local bufnr
+      if file then
+         bufnr = capabilities.get_source_context()
+      else
+         bufnr = vim.api.nvim_get_current_buf()
+         if not capabilities.get_client(bufnr) then
+            vim.notify(
+               "slang-server: setTopLevel without a file must be run from a buffer with an attached slang-server LSP client.",
+               vim.log.levels.ERROR
+            )
+            return
+         end
+         file = vim.api.nvim_buf_get_name(bufnr)
+      end
       if not capabilities.check_or_notify(bufnr, { "slang.setTopLevel" }) then
          return
       end
@@ -14,7 +28,6 @@ M.setTopLevel = {
       local client = require("slang-server._lsp.client")
       local handlers = require("slang-server.handlers")
 
-      local file = args[1] or vim.api.nvim_buf_get_name(bufnr)
       client.setTopLevel(bufnr, handlers.defaultHandlers, { uri = file })
    end,
    complete = require("slang-server.util").complete_path,

--- a/clients/neovim/lua/slang-server/_lsp/capabilities.lua
+++ b/clients/neovim/lua/slang-server/_lsp/capabilities.lua
@@ -3,6 +3,7 @@ local M = {}
 M.MIN_SERVER_VERSION = "0.2.2"
 
 local UPGRADE_HINT = "Please upgrade slang-server and possibly also this plugin."
+local SOURCE_FILETYPES = { "verilog", "systemverilog" }
 
 ---@param v string
 ---@return integer, integer, integer
@@ -36,6 +37,27 @@ function M.get_client(bufnr)
       end
    end
    return nil
+end
+
+---@return integer bufnr, integer? winid
+function M.get_source_context()
+   local bufnr = vim.api.nvim_get_current_buf()
+   if M.get_client(bufnr) then
+      return bufnr, vim.api.nvim_get_current_win()
+   end
+
+   local util = require("slang-server.util")
+   local source_win = util.last_win({ buflisted = true, filetype = SOURCE_FILETYPES })
+   if source_win and M.get_client(source_win.bufnr) then
+      return source_win.bufnr, source_win.winid
+   end
+
+   local source_buf = util.last_buf({ buflisted = true, filetype = SOURCE_FILETYPES })
+   if source_buf and M.get_client(source_buf.bufnr) then
+      return source_buf.bufnr, nil
+   end
+
+   return bufnr, nil
 end
 
 -- Per-client cached commands set. Keyed by client.id; populated lazily on the

--- a/clients/neovim/lua/slang-server/_lsp/capabilities.lua
+++ b/clients/neovim/lua/slang-server/_lsp/capabilities.lua
@@ -39,25 +39,25 @@ function M.get_client(bufnr)
    return nil
 end
 
----@return integer bufnr, integer? winid
+---@return integer bufnr
 function M.get_source_context()
    local bufnr = vim.api.nvim_get_current_buf()
    if M.get_client(bufnr) then
-      return bufnr, vim.api.nvim_get_current_win()
+      return bufnr
    end
 
    local util = require("slang-server.util")
    local source_win = util.last_win({ buflisted = true, filetype = SOURCE_FILETYPES })
    if source_win and M.get_client(source_win.bufnr) then
-      return source_win.bufnr, source_win.winid
+      return source_win.bufnr
    end
 
    local source_buf = util.last_buf({ buflisted = true, filetype = SOURCE_FILETYPES })
    if source_buf and M.get_client(source_buf.bufnr) then
-      return source_buf.bufnr, nil
+      return source_buf.bufnr
    end
 
-   return bufnr, nil
+   return bufnr
 end
 
 -- Per-client cached commands set. Keyed by client.id; populated lazily on the

--- a/clients/neovim/spec/plugin_spec.lua
+++ b/clients/neovim/spec/plugin_spec.lua
@@ -32,6 +32,21 @@ local function wait_on(buf_name)
    return lines
 end
 
+---@param fn fun()
+---@return string[]
+local function capture_notifications(fn)
+   local old_notify = vim.notify
+   local messages = {}
+   vim.notify = function(msg, ...)
+      messages[#messages + 1] = msg
+   end
+
+   local ok, err = pcall(fn)
+   vim.notify = old_notify
+   assert(ok, err)
+   return messages
+end
+
 describe("SlangServer", function()
    -- load test SV
    vim.cmd("edit tests/foo.sv")
@@ -68,6 +83,41 @@ describe("SlangServer", function()
    └╴foo
   sub (4)]=]
       assert.are.same(expected, table.concat(lines, "\n"))
+      vim.api.nvim_buf_delete(0, { force = true })
+   end)
+
+   it("Explicit commands use the source buffer when focus is in the hierarchy panel", function()
+      vim.cmd("SlangServer hierarchy")
+      wait_on("Slang-server: Hierarchy")
+
+      local messages = capture_notifications(function()
+         vim.cmd("SlangServer setTopLevel tests/foo.sv")
+      end)
+      for _, msg in ipairs(messages) do
+         assert.is_nil(string.find(msg, "no slang-server LSP client attached", 1, true))
+      end
+
+      vim.api.nvim_buf_delete(0, { force = true })
+   end)
+
+   it("Context-sensitive commands require source buffer focus", function()
+      vim.cmd("SlangServer hierarchy")
+      wait_on("Slang-server: Hierarchy")
+
+      local messages = capture_notifications(function()
+         vim.cmd("SlangServer setTopLevel")
+         vim.cmd("SlangServer addToWaves")
+      end)
+
+      assert.are.same({
+         "slang-server: setTopLevel without a file must be run from a buffer with an attached slang-server LSP client.",
+         "slang-server: addToWaves must be run from a buffer with an attached slang-server LSP client.",
+      }, messages)
+
+      for _, msg in ipairs(messages) do
+         assert.is_nil(string.find(msg, "Please upgrade slang-server", 1, true))
+      end
+
       vim.api.nvim_buf_delete(0, { force = true })
    end)
 


### PR DESCRIPTION
## Summary

- resolve explicit Neovim commands through the current buffer when it has the slang-server client, otherwise fall back to the most recently used visible SystemVerilog/Verilog source buffer
- keep cursor/current-file-sensitive commands tied to the active source buffer instead of guessing stale context
- replace the misleading upgrade hint for those context-sensitive panel invocations with a direct context error
- add Neovim regressions for both the explicit-command fallback and the context-sensitive refusal path

## Why

The Neovim command is global, but commands like `setBuildFile`, `openWaveform`, and `setTopLevel <file>` only need an attached slang-server client to send the request. When focus is inside a plugin panel, the panel buffer does not have the client attached, so those commands used to fail with `no slang-server LSP client attached` even though the source buffer is still open and attached.

Commands that depend on the current file or cursor position should not silently reuse an old source window. This keeps `addToWaves` and no-argument `setTopLevel` scoped to the current source buffer and gives a clearer message when run from the hierarchy panel.

Fixes #377

## Validation

- `git diff --check`
- `.venv/bin/pre-commit run --files clients/neovim/lua/slang-server/_lsp/capabilities.lua clients/neovim/lua/slang-server/_commands/addToWaves.lua clients/neovim/lua/slang-server/_commands/hierarchy.lua clients/neovim/lua/slang-server/_commands/openWaveform.lua clients/neovim/lua/slang-server/_commands/setBuildFile.lua clients/neovim/lua/slang-server/_commands/setTopLevel.lua clients/neovim/spec/plugin_spec.lua`
- `.venv/bin/python scripts/ci/neovim-sync.py --event pull_request --dry-run`