### PR TITLE
Add support for WholeDocument LSP changes

### DIFF
--- a/include/lsp/LspTypes.h
+++ b/include/lsp/LspTypes.h
@@ -1077,8 +1077,10 @@ struct TextDocumentContentClientCapabilities {
 
 /// An event describing a change to a text document. If only a text is provided
 /// it is considered to be the full content of the document.
-using TextDocumentContentChangeEvent =
-    rfl::Variant<TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>;
+using TextDocumentContentChangeEvent = rfl::Variant<
+    // ORDER MATTERS: Partial and WholeDocument both have a text field, but Partial is more
+    // specific, so it must be checked first.
+    TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>;
 
 /// A string value used as a snippet is a template which allows to insert text
 /// and to control the editor cursor when insertion happens.

--- a/src/document/SlangDoc.cpp
+++ b/src/document/SlangDoc.cpp
@@ -140,6 +140,22 @@ bool SlangDoc::textMatches(std::string_view text) {
 }
 
 void SlangDoc::onChange(const std::vector<lsp::TextDocumentContentChangeEvent>& contentChanges) {
+    // From the LSP spec:
+    //
+    // The actual content changes. The content changes describe single state changes to the
+    // document. So if there are two content changes c1 (at array index 0) and c2 (at array
+    // index 1) for a document in state S then c1 moves the document from S to S' and c2 from
+    // S' to S''. So c1 is computed on the state S and c2 is computed on the state S'.
+    //
+    // To mirror the content of a document using change events use the following approach:
+    // - start with the same initial content
+    // - apply the 'textDocument/didChange' notifications in the order you receive them.
+    // - apply the `TextDocumentContentChangeEvent`s in a single notification in the order you
+    //   receive them.
+    //
+    // Partial is defined in the variant first, so it will match first iff range and text are both
+    // present. WholeDocument will match if text is present, but only be tried second. Less specific
+    // cases are tried later.
     SmallVector<char> buffer;
     std::string_view textView = getText();
     std::vector<size_t> lineOffsets;
@@ -163,29 +179,54 @@ void SlangDoc::onChange(const std::vector<lsp::TextDocumentContentChangeEvent>& 
         return std::make_pair(startOffset, endOffset);
     };
 
+    auto ensureNullTerminated = [&]() {
+        if (buffer.empty() || buffer.back() != '\0')
+            buffer.push_back('\0');
+    };
+
     // Single change (most common)
-    auto change = rfl::get<lsp::TextDocumentContentChangePartial>(contentChanges[0]);
-    auto offsets = getOffsets(change.range);
-    // insert all parts
-    buffer.append(textView.begin(), textView.begin() + offsets.first);
-    buffer.append(change.text.begin(), change.text.end());
-    buffer.append(textView.begin() + offsets.second, textView.end());
-    if (buffer.empty() || buffer.back() != '\0')
-        buffer.push_back('\0');
+    rfl::visit(
+        [&](const auto& change) {
+            using T = std::decay_t<decltype(change)>;
+            if constexpr (std::is_same_v<T, lsp::TextDocumentContentChangePartial>) {
+                auto offsets = getOffsets(change.range);
+                buffer.append(textView.begin(), textView.begin() + offsets.first);
+                buffer.append(change.text.begin(), change.text.end());
+                buffer.append(textView.begin() + offsets.second, textView.end());
+            }
+            else {
+                buffer.append(change.text.begin(), change.text.end());
+            }
+        },
+        contentChanges[0]);
+    ensureNullTerminated();
 
     // More than one change is rare- typically things like rename actions, or if there's some lag.
     for (size_t i = 1; i < contentChanges.size(); i++) {
         textView = std::string_view{buffer.data(), buffer.size()};
-        change = rfl::get<lsp::TextDocumentContentChangePartial>(contentChanges[i]);
         lineOffsets.clear();
-        auto offsets = getOffsets(change.range);
-
-        // handle deletes
-        if (offsets.second > offsets.first) {
-            buffer.erase(buffer.begin() + offsets.first, buffer.begin() + offsets.second);
-        }
-        // handle inserts
-        buffer.insert(buffer.begin() + offsets.first, change.text.begin(), change.text.end());
+        rfl::visit(
+            [&](const auto& change) {
+                using T = std::decay_t<decltype(change)>;
+                if constexpr (std::is_same_v<T, lsp::TextDocumentContentChangePartial>) {
+                    auto offsets = getOffsets(change.range);
+                    // handle deletes
+                    if (offsets.second > offsets.first) {
+                        buffer.erase(buffer.begin() + offsets.first,
+                                     buffer.begin() + offsets.second);
+                    }
+                    // handle inserts
+                    buffer.insert(buffer.begin() + offsets.first, change.text.begin(),
+                                  change.text.end());
+                }
+                else {
+                    // WholeDocument collapses all prior changes
+                    buffer.clear();
+                    buffer.append(change.text.begin(), change.text.end());
+                    ensureNullTerminated();
+                }
+            },
+            contentChanges[i]);
     }
     m_buffer = m_sourceManager.replaceBuffer(m_buffer.id, std::move(buffer));
 

--- a/tests/cpp/DriverTests.cpp
+++ b/tests/cpp/DriverTests.cpp
@@ -3,6 +3,7 @@
 
 #include "utils/ServerHarness.h"
 #include <cstdlib>
+#include <functional>
 
 TEST_CASE("getAnalysis returns same object on repeated calls") {
     ServerHarness server;
@@ -36,6 +37,91 @@ endmodule
 
     auto after = hdl.doc->getAnalysis();
     CHECK(before.get() != after.get());
+}
+
+TEST_CASE("onChange handles WholeDocument content change") {
+    ServerHarness server;
+    auto hdl = server.openFile("test.sv", R"(module test;
+    logic [7:0] foo;
+endmodule
+)");
+
+    auto before = hdl.doc->getAnalysis();
+
+    // Replace the entire document with a renamed symbol (the wire form Claude's
+    // LSP client uses: { text } only, no range).
+    std::string newText = R"(module test;
+    logic [7:0] bar;
+endmodule
+)";
+    hdl.replaceAll(newText);
+    hdl.publishChanges();
+
+    // Buffer was actually swapped (analysis invalidated)
+    auto after = hdl.doc->getAnalysis();
+    CHECK(before.get() != after.get());
+
+    // Buffer text reflects the new contents (getText returns view including
+    // the trailing null terminator, so size is +1).
+    auto text = hdl.doc->getText();
+    REQUIRE(text.size() == newText.size() + 1);
+    CHECK(std::string_view{text.data(), newText.size()} == newText);
+
+    // Follow-up symbol query reflects the renamed identifier
+    auto syms = hdl.getSymbolTree();
+    REQUIRE(!syms.empty());
+    bool foundBar = false;
+    bool foundFoo = false;
+    std::function<void(const std::vector<lsp::DocumentSymbol>&)> walk =
+        [&](const std::vector<lsp::DocumentSymbol>& nodes) {
+            for (const auto& node : nodes) {
+                if (node.name == "bar")
+                    foundBar = true;
+                if (node.name == "foo")
+                    foundFoo = true;
+                if (node.children.has_value())
+                    walk(*node.children);
+            }
+        };
+    walk(syms);
+    CHECK(foundBar);
+    CHECK_FALSE(foundFoo);
+}
+
+TEST_CASE("onChange handles mixed WholeDocument and Partial changes") {
+    ServerHarness server;
+    auto hdl = server.openFile("test.sv", R"(module test;
+    logic [7:0] foo;
+endmodule
+)");
+
+    // First queue a WholeDocument change that resets the buffer
+    std::string replacement = R"(module test;
+    logic [7:0] bar;
+endmodule
+)";
+    hdl.replaceAll(replacement);
+
+    // Then queue a Partial change that depends on the post-replacement buffer:
+    // append a new line at the end of the file (offset 0,0 -> append empty
+    // wouldn't exercise it; instead insert at a position that requires the new
+    // buffer's line offsets).
+    auto insertOffset = replacement.size();
+    auto insertPos = hdl.getPosition(insertOffset);
+    std::string appended = "// trailing\n";
+    hdl.pending_changes.push_back({lsp::TextDocumentContentChangePartial{
+        .range = lsp::Range{insertPos, insertPos}, .text = appended}});
+
+    // Apply both in a single didChange request
+    server.onDocDidChange(lsp::DidChangeTextDocumentParams{
+        .textDocument = lsp::VersionedTextDocumentIdentifier{.uri = hdl.doc->getURI()},
+        .contentChanges = hdl.pending_changes});
+    hdl.pending_changes.clear();
+
+    std::string expected = replacement + appended;
+    auto text = hdl.doc->getText();
+    REQUIRE(text.size() == expected.size() + 1);
+    CHECK(std::string_view{text.data(), expected.size()} == expected);
 }
 
 TEST_CASE("getAnalysis with cross-file dependencies is stable") {

--- a/tests/cpp/utils/ServerHarness.cpp
+++ b/tests/cpp/utils/ServerHarness.cpp
@@ -279,6 +279,16 @@ void DocumentHandle::erase(size_t start, size_t end) {
     state = DocState::Dirty;
 }
 
+void DocumentHandle::replaceAll(std::string text) {
+    CHECK(state != DocState::Closed);
+
+    m_text = text;
+    pending_changes.push_back(
+        {lsp::TextDocumentContentChangeWholeDocument{.text = std::move(text)}});
+
+    state = DocState::Dirty;
+}
+
 void DocumentHandle::publishChanges() {
     CHECK(state == DocState::Dirty);
     m_server.onDocDidChange(lsp::DidChangeTextDocumentParams{

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -117,6 +117,7 @@ public:
     void insert(lsp::uint offset, std::string text);
     void append(std::string text);
     void erase(size_t start, size_t end);
+    void replaceAll(std::string text);
 
     Cursor before(std::string before, lsp::uint start_pos = 0);
     Cursor after(std::string after, lsp::uint start_pos = 0);


### PR DESCRIPTION
slang-server advertises Incremental update support and expects Partial update changes from clients. However, claude's LSP integration ignores that and just sends WholeDocument always instead.

Seeing as the input isn't malformed or breaks protocol invariants, it's just non-compliant, support was added to service WholeDocument updates.