### PR TITLE
Build canonical Linux releases in manylinux_2_28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,27 +39,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: linux-x64-clang
+          # Canonical Linux release builds: built in manylinux_2_28 (glibc 2.28)
+          # so binaries run on older distros (RHEL/Rocky/Alma 8, Debian 10, etc.).
+          - name: linux-x64
+            preset: gcc-release
+            os: ubuntu-24.04
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            cmake_args: -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++
+          - name: linux-arm64
+            preset: gcc-release
+            os: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            cmake_args: -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++
+          # Dev-only Linux builds for additional compiler/host coverage.
+          # OS is in the name to distinguish from the canonical release builds.
+          - name: linux-x64-ubuntu-24.04-clang
             preset: clang-release
             os: ubuntu-24.04
-          - name: linux-arm64-clang
+            skip_upload: true
+          - name: linux-arm64-ubuntu-24.04-clang
             preset: clang-release
             os: ubuntu-24.04-arm
-          - name: linux-x64-clang-debug
+            skip_upload: true
+          - name: linux-x64-ubuntu-24.04-clang-debug
             preset: clang-debug
             os: ubuntu-24.04
             skip_pytests: true
             skip_neovim_tests: true
             skip_upload: true
-          - name: linux-x64-gcc
+          - name: linux-x64-ubuntu-24.04-gcc
             preset: gcc-release
             os: ubuntu-24.04
-            # to support older libc
-          - name: old-linux-x64-gcc
-            preset: gcc-release
-            os: ubuntu-24.04
-            container: rockylinux:8
-            cmake_args: -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++
+            skip_upload: true
           - name: macos
             preset: macos-release
             os: macos-15
@@ -75,17 +86,12 @@ jobs:
     env:
       SLANG_SERVER_ARTIFACT_NAME: slang-server-${{ matrix.name }}
     steps:
-      - name: Install dependencies (Rocky Linux 8)
-        if: matrix.container == 'rockylinux:8'
+      - name: Install dependencies (manylinux_2_28)
+        if: startsWith(matrix.container, 'quay.io/pypa/manylinux_2_28')
         run: |
-          dnf -y update
-          dnf -y install 'dnf-command(config-manager)'
-          dnf config-manager --set-enabled powertools
-          dnf -y install epel-release
-          dnf -y install gcc-c++ clang git make gcc-toolset-14-gcc-c++ gcc-toolset-14-libatomic-devel python39-pip
-          # Need newer cmake
-          python3.9 -m pip install --upgrade pip
-          python3.9 -m pip install cmake==3.31.6
+          # manylinux_2_28 already provides gcc-toolset-14, cmake, make, git, python.
+          # Only need gcc-toolset-14-libatomic-devel for the atomic intrinsics.
+          dnf -y install gcc-toolset-14-libatomic-devel
           cmake --version
       - name: Install Clang 21 (Ubuntu)
         if: startsWith(matrix.preset, 'clang-')
@@ -140,11 +146,9 @@ jobs:
       - name: Run Neovim plugin tests
         # This should work on Windows as well, but there's some linker error
         # that I don't feel like debugging via GH
-        # Also skip rockylinux since the container makes action-setup-vim sad
-        # This can easily be fixed by copying instead of moving the neovim install,
-        # unfortunately that uncovers the fact that the neovim builds from that
-        # GH action require a newer GLIBC version than rockylinux provides.
-        # Not going down that rabbit hole right now
+        # Also skip when running inside a container (manylinux_2_28): the
+        # prebuilt nvim binaries from nvim-busted-action require a newer GLIBC
+        # than the container provides. The dev-only Ubuntu jobs cover this.
         if: runner.os != 'Windows' && matrix.container == '' && matrix.skip_neovim_tests != true
         uses: nvim-neorocks/nvim-busted-action@v1
         env:

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -143,7 +143,7 @@ File input is sent to stdin, and formatted output is read from stdout.',
         githubRepo: 'hudson-trading/slang-server',
         assetNames: {
           windows: 'slang-server-windows-x64.zip',
-          linux: 'slang-server-linux-x64-gcc.tar.gz',
+          linux: 'slang-server-linux-x64.tar.gz',
           mac: 'slang-server-macos.tar.gz',
         },
       },

--- a/clients/vscode/test/unit/assets/release.json
+++ b/clients/vscode/test/unit/assets/release.json
@@ -3,12 +3,8 @@
   "tag_name": "v0.2.1",
   "assets": [
     {
-      "name": "slang-server-linux-x64-gcc.tar.gz",
-      "browser_download_url": "http://127.0.0.1:9999/slang-server-linux-x64-gcc.tar.gz"
-    },
-    {
-      "name": "slang-server-linux-x64-clang.tar.gz",
-      "browser_download_url": "http://127.0.0.1:9999/slang-server-linux-x64-clang.tar.gz"
+      "name": "slang-server-linux-x64.tar.gz",
+      "browser_download_url": "http://127.0.0.1:9999/slang-server-linux-x64.tar.gz"
     },
     {
       "name": "slang-server-windows-x64.zip",

--- a/clients/vscode/test/unit/harness.ts
+++ b/clients/vscode/test/unit/harness.ts
@@ -34,7 +34,6 @@ export async function createFakeAssets(root: string, platform: 'linux' | 'window
   } else if (platform === 'mac') {
     await makeTarGz('slang-server-macos', 'slang-server')
   } else if (platform === 'linux') {
-    await makeTarGz('slang-server-linux-x64-gcc', 'slang-server')
-    await makeTarGz('slang-server-linux-x64-clang', 'slang-server')
+    await makeTarGz('slang-server-linux-x64', 'slang-server')
   }
 }

--- a/clients/vscode/test/unit/installer.test.ts
+++ b/clients/vscode/test/unit/installer.test.ts
@@ -20,7 +20,7 @@ function testConfig(platform: Platform): GithubInstallerConfig {
     githubRepo: 'test/repo',
     assetNames: {
       windows: 'slang-server-windows-x64.zip',
-      linux: 'slang-server-linux-x64-gcc.tar.gz',
+      linux: 'slang-server-linux-x64.tar.gz',
       mac: 'slang-server-macos.tar.gz',
     },
     platform,


### PR DESCRIPTION
Closes #384. This does a few things:
1. Uses manylinux_2_28 images to build Linux x86_64 and ARM binaries which is a better environment than RockyLinux8 specifically built for this purpose: old glibc (RHEL8 equivalent glibc 2.28), new compilers (GCC 13 with full C++20 support), new CMake, Python, etc. etc.
2. Turns off release upload of different OSes and compilers because that really doesn't matter.
3. Does some renaming on packages to reflect the fact we aren't uploading flavored binaries anymore
4. Updates the VSCode extension to pull binaries based on new names.

Also confirmed that Windows and Apple binaries don't have this issue.

Follow ons:
- [x] Fix neovim binary dependency
- [ ] Fix VSCode extension to pull in ARM version on ARM devices