### PR TITLE
Neovim LSP and client docs + dependency management

### DIFF
--- a/clients/neovim/README.md
+++ b/clients/neovim/README.md
@@ -14,16 +14,18 @@ More information on plugin features can be [found here](https://hudson-trading.g
 * `slang-server` configured as a Neovim language server
 * [Nerd Font](https://www.nerdfonts.com/) is recommended
 
+### Plugin dependencies
+
+If installing with lazy.nvim, plugin dependencies are resolved automatically.
+
+* [nui.nvim](https://github.com/MunifTanjim/nui.nvim)
+
 ## Installation
 Use your favorite Neovim plugin manager to download and install the plugin.  If you happen to use lazy.nvim you can [install the plugin](https://www.lazyvim.org/configuration/plugins) by adding `~/.config/nvim/lua/plugins/slang-server.lua`:
 ```lua
 return {
   {
     "hudson-trading/slang-server.nvim",
-    dependencies = {
-      "MunifTanjim/nui.nvim",
-    },
-    opts = {},
   },
 }
 ```

--- a/clients/neovim/lazy.lua
+++ b/clients/neovim/lazy.lua
@@ -1,0 +1,4 @@
+return {
+   { "MunifTanjim/nui.nvim", lazy = true },
+   { "hudson-trading/slang-server.nvim", opts = {} },
+}

--- a/docs/start/installing.md
+++ b/docs/start/installing.md
@@ -12,7 +12,7 @@ Install from your editor, or download from the [OpenVSX Marketplace](https://ope
 
 `slang-server` is available in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) as `slang_server` (note the underscore) and in the [mason.nvim](https://github.com/mason-org/mason.nvim) package registry as `slang-server`, so no additional configuration is required in most cases. The default configuration shipped with nvim-lspconfig can be found [here](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/slang_server.lua).
 
-Install the binary via `:MasonInstall slang-server` (or otherwise place it on `PATH`), then enable the server with `vim.lsp.enable("slang_server")`, or following your own Neovim configuration's convention for enabling servers.
+Install the binary via `:MasonInstall slang-server` (or otherwise place it on `PATH`), then enable the server with `vim.lsp.enable("slang_server")`, or follow your own Neovim configuration's convention for enabling servers.
 
 Restart and run `:LspInfo` to make sure the LSP was correctly installed.
 

--- a/docs/start/installing.md
+++ b/docs/start/installing.md
@@ -22,8 +22,7 @@ return {
   opts = {
     servers = {
       slang_server = {
-        -- Tell LazyVim that Mason isn't needed since this is a manual config
-        mason = false,
+        enabled = true
       },
     },
   },

--- a/docs/start/installing.md
+++ b/docs/start/installing.md
@@ -10,61 +10,9 @@ Install from your editor, or download from the [OpenVSX Marketplace](https://ope
 
 ### Neovim
 
-> `slang-server` will eventually be added to [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) and [mason.nvim](https://github.com/mason-org/mason.nvim) so that no additional configuration will be required. Until then, follow one of the methods below to manually add the server configuration.
+`slang-server` is available in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) as `slang_server` (note the underscore) and in the [mason.nvim](https://github.com/mason-org/mason.nvim) package registry as `slang-server`, so no additional configuration is required in most cases. The default configuration shipped with nvim-lspconfig can be found [here](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/slang_server.lua).
 
-For newer versions of Neovim (≥ v0.11), the new [vim.lsp API](<https://neovim.io/doc/user/lsp.html#vim.lsp.start()>) is the preferred, simpler way to configure language servers:
-
-```lua
-vim.lsp.config("slang-server", {
-  cmd = { "slang-server" },
-  root_markers = { ".git", ".slang" },
-  filetypes = {
-    "systemverilog",
-    "verilog",
-  },
-})
-
-vim.lsp.enable("slang-server")
-```
-
-Alternatively, adding the below to `<runtimepath>/lsp/slang_server.lua` will automatically be picked up by `vim.lsp`:
-
-```lua
----@type vim.lsp.Config
-return {
-  cmd = { "slang-server" },
-  root_markers = { ".git", ".slang" },
-  filetypes = {
-    "systemverilog",
-    "verilog",
-  },
-}
-```
-
-For older versions of Neovim (< v0.11) with `nvim-lspconfig`, the server can be configured with:
-
-```lua
-local configs = require("lspconfig.configs")
-local util = require("lspconfig.util")
-
-if not configs.slang_server then
-  configs.slang_server = {
-    default_config = {
-      cmd = {
-        "slang-server",
-      },
-      filetypes = {
-        "systemverilog",
-        "verilog",
-      },
-      single_file_support = true,
-      root_dir = function(fname)
-        return util.root_pattern(".git", ".slang")(fname)
-      end,
-    },
-  }
-end
-```
+Install the binary via `:MasonInstall slang-server` (or otherwise place it on `PATH`), then enable the server with `vim.lsp.enable("slang_server")`.
 
 For users of lazy.nvim, natively enable the server by adding the following to `<runtimepath>/lua/plugins/slang_server.lua`:
 
@@ -81,8 +29,6 @@ return {
   },
 }
 ```
-
-The above assumes that a slang-server config has been added to `vim.lsp.config` or `nvim-lspconfig` using one of the preceding steps.
 
 Optionally, run `:LspInfo` to make sure the LSP was correctly installed.
 

--- a/docs/start/installing.md
+++ b/docs/start/installing.md
@@ -12,26 +12,13 @@ Install from your editor, or download from the [OpenVSX Marketplace](https://ope
 
 `slang-server` is available in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) as `slang_server` (note the underscore) and in the [mason.nvim](https://github.com/mason-org/mason.nvim) package registry as `slang-server`, so no additional configuration is required in most cases. The default configuration shipped with nvim-lspconfig can be found [here](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/slang_server.lua).
 
-Install the binary via `:MasonInstall slang-server` (or otherwise place it on `PATH`), then enable the server with `vim.lsp.enable("slang_server")`.
+Install the binary via `:MasonInstall slang-server` (or otherwise place it on `PATH`), then enable the server with `vim.lsp.enable("slang_server")`, or following your own Neovim configuration's convention for enabling servers.
 
-For users of lazy.nvim, natively enable the server by adding the following to `<runtimepath>/lua/plugins/slang_server.lua`:
+Restart and run `:LspInfo` to make sure the LSP was correctly installed.
 
-```lua
-return {
-  "neovim/nvim-lspconfig",
-  opts = {
-    servers = {
-      slang_server = {
-        enabled = true
-      },
-    },
-  },
-}
-```
+#### Enhanced features
 
-Optionally, run `:LspInfo` to make sure the LSP was correctly installed.
-
-Pointing at the binary is all you need for standard language features, however a plugin is provided to enable some client-side features which extend the LSP (e.g. the hierarchy view, waveform integration). The plugin can be found in `clients/neovim/` and is also mirrored in [slang-server.nvim](https://github.com/hudson-trading/slang-server.nvim) for ease of use with Neovim plugin managers.
+Once the language server is installed, it is recommended to install the [slang-server.nvim](https://github.com/hudson-trading/slang-server.nvim) plugin; this provides enhanced HDL specific features such as design hierarchy view and waveform integration.
 
 ### Other editors
 


### PR DESCRIPTION
I've updated the Neovim LSP install docs to reflect `slang-server` being available in nvim-lspconfig and Mason.

I've also moved the dependency management into a `lazy.lua` in the plugin root — this is resolved automatically by lazy.nvim, so users don't have to keep their config updated if dependencies change.