### PR TITLE
Neovim client config improvements

### DIFF
--- a/clients/neovim/README.md
+++ b/clients/neovim/README.md
@@ -21,12 +21,56 @@ If installing with lazy.nvim, plugin dependencies are resolved automatically.
 * [nui.nvim](https://github.com/MunifTanjim/nui.nvim)
 
 ## Installation
-Use your favorite Neovim plugin manager to download and install the plugin.  If you happen to use lazy.nvim you can [install the plugin](https://www.lazyvim.org/configuration/plugins) by adding `~/.config/nvim/lua/plugins/slang-server.lua`:
+
+Clone and place the plugin directory in your Neovim runtimepath. It is lazily loaded by default on the first invocation of a `:SlangServer` command, so there's no need to rely on a plugin manager for lazy loading.
+
+Alternatively, use your favorite Neovim plugin manager to download and install the plugin.  If you happen to use lazy.nvim you can [install the plugin](https://www.lazyvim.org/configuration/plugins) by adding, e.g., `~/.config/nvim/lua/plugins/slang-server.lua`:
 ```lua
 return {
   {
     "hudson-trading/slang-server.nvim",
   },
+}
+```
+
+## Configuration
+
+The default configuration is shown below. Override options can be defined in the global `vim.g.slang_server_config`, or passed to `opts = {...}` in the lazy.nvim plugin spec.
+
+```lua
+{
+   hierarchy = {
+      position = "left",
+      size = 40,
+   },
+   kinds = {
+      instance = { icon = "", hl = "SlangServerInstance" },
+      instancearray = { icon = "", hl = "SlangServerInstanceArray" },
+      scope = { icon = "󰅩", hl = "SlangServerScope" },
+      scopearray = { icon = "󰅩", hl = "SlangServerScopeArray" },
+      package = { icon = "📦", hl = "SlangServerPackage" },
+      port = {
+         input = { icon = "", hl = "SlangServerPortInput" },
+         output = { icon = "", hl = "SlangServerPortOutput" },
+         inout = { icon = "", hl = "SlangServerPortInout" },
+      },
+      param = { icon = "", hl = "SlangServerParam" },
+      logic = { icon = "󱒖", hl = "SlangServerLogic" },
+      reg = { icon = "", hl = "SlangServerReg" },
+   },
+   highlights = {
+      SlangServerInstance = { fg = "#efbd5d" },
+      SlangServerInstanceArray = { fg = "#efbd5d" },
+      SlangServerScope = { fg = "#41a7fc" },
+      SlangServerScopeArray = { fg = "#41a7fc" },
+      SlangServerPackage = { fg = "#f48fb1" },
+      SlangServerPortInput = { fg = "#8bcd5b" },
+      SlangServerPortOutput = { fg = "#f65866" },
+      SlangServerPortInout = { fg = "#34bfd0" },
+      SlangServerParam = { fg = "#c75ae8" },
+      SlangServerLogic = { fg = "#dd9046" },
+      SlangServerReg = { fg = "#dd9046" },
+   },
 }
 ```
 

--- a/clients/neovim/README.md
+++ b/clients/neovim/README.md
@@ -22,9 +22,8 @@ If installing with lazy.nvim, plugin dependencies are resolved automatically.
 
 ## Installation
 
-Clone and place the plugin directory in your Neovim runtimepath. It is lazily loaded by default on the first invocation of a `:SlangServer` command, so there's no need to rely on a plugin manager for lazy loading.
+You can use your favorite Neovim plugin manager to download and install the plugin. If you happen to use lazy.nvim you can install the plugin by adding, e.g., `~/.config/nvim/lua/plugins/slang-server.lua`:
 
-Alternatively, use your favorite Neovim plugin manager to download and install the plugin.  If you happen to use lazy.nvim you can [install the plugin](https://www.lazyvim.org/configuration/plugins) by adding, e.g., `~/.config/nvim/lua/plugins/slang-server.lua`:
 ```lua
 return {
   {
@@ -33,46 +32,11 @@ return {
 }
 ```
 
+The plugin is lazily loaded by default on the first invocation of a `:SlangServer` command, so there's no need to rely on a plugin manager for lazy loading. To install without a plugin manager, simply clone and place the plugin directory in your Neovim runtimepath.
+
 ## Configuration
 
-The default configuration is shown below. Override options can be defined in the global `vim.g.slang_server_config`, or passed to `opts = {...}` in the lazy.nvim plugin spec.
-
-```lua
-{
-   hierarchy = {
-      position = "left",
-      size = 40,
-   },
-   kinds = {
-      instance = { icon = "", hl = "SlangServerInstance" },
-      instancearray = { icon = "", hl = "SlangServerInstanceArray" },
-      scope = { icon = "󰅩", hl = "SlangServerScope" },
-      scopearray = { icon = "󰅩", hl = "SlangServerScopeArray" },
-      package = { icon = "📦", hl = "SlangServerPackage" },
-      port = {
-         input = { icon = "", hl = "SlangServerPortInput" },
-         output = { icon = "", hl = "SlangServerPortOutput" },
-         inout = { icon = "", hl = "SlangServerPortInout" },
-      },
-      param = { icon = "", hl = "SlangServerParam" },
-      logic = { icon = "󱒖", hl = "SlangServerLogic" },
-      reg = { icon = "", hl = "SlangServerReg" },
-   },
-   highlights = {
-      SlangServerInstance = { fg = "#efbd5d" },
-      SlangServerInstanceArray = { fg = "#efbd5d" },
-      SlangServerScope = { fg = "#41a7fc" },
-      SlangServerScopeArray = { fg = "#41a7fc" },
-      SlangServerPackage = { fg = "#f48fb1" },
-      SlangServerPortInput = { fg = "#8bcd5b" },
-      SlangServerPortOutput = { fg = "#f65866" },
-      SlangServerPortInout = { fg = "#34bfd0" },
-      SlangServerParam = { fg = "#c75ae8" },
-      SlangServerLogic = { fg = "#dd9046" },
-      SlangServerReg = { fg = "#dd9046" },
-   },
-}
-```
+The default configuration can be found in [config.lua](./lua/slang-server/_core/config.lua). Override options can be defined in the global `vim.g.slang_server_config`, or passed to `opts = {...}` in the lazy.nvim plugin spec.
 
 ## GitHub Repos
 

--- a/clients/neovim/lazy.lua
+++ b/clients/neovim/lazy.lua
@@ -1,4 +1,4 @@
 return {
    { "MunifTanjim/nui.nvim", lazy = true },
-   { "hudson-trading/slang-server.nvim", opts = {} },
+   { "hudson-trading/slang-server.nvim" },
 }

--- a/clients/neovim/lua/slang-server/_core/config.lua
+++ b/clients/neovim/lua/slang-server/_core/config.lua
@@ -3,8 +3,6 @@ local M = {}
 ---@type slang-server.config.Configuration
 M.CONFIG = {}
 
-vim.g.loaded_slang_server = false
-
 ---@type slang-server.config.Configuration
 local default_config = {
    hierarchy = {
@@ -41,18 +39,14 @@ local default_config = {
    },
 }
 
-M.initialise = function()
-   if not vim.g.loaded_slang_server then
-      M.update(default_config)
-      M.update(vim.g.slang_server_config)
-
-      vim.g.loaded_slang_server = true
-   end
-end
-
 ---@param opts slang-server.config.Configuration?
 M.update = function(opts)
    M.CONFIG = vim.tbl_deep_extend("force", M.CONFIG, opts or {})
 end
+
+M.update(default_config)
+
+-- User config can be provided as a vim global, rather than an argument to setup()
+M.update(vim.g.slang_server_config)
 
 return M

--- a/clients/neovim/lua/slang-server/_core/config.lua
+++ b/clients/neovim/lua/slang-server/_core/config.lua
@@ -5,10 +5,12 @@ M.CONFIG = {}
 
 ---@type slang-server.config.Configuration
 local default_config = {
+   -- Hierarchy split window layout
    hierarchy = {
       position = "left",
       size = 40,
    },
+   -- Icon and highlight group for each element kind show in the hierarchy view
    kinds = {
       instance = { icon = "", hl = "SlangServerInstance" },
       instancearray = { icon = "", hl = "SlangServerInstanceArray" },
@@ -24,6 +26,7 @@ local default_config = {
       logic = { icon = "󱒖", hl = "SlangServerLogic" },
       reg = { icon = "", hl = "SlangServerReg" },
    },
+   -- Default colors for the highlight groups; can be overridden by your colorscheme
    highlights = {
       SlangServerInstance = { fg = "#efbd5d" },
       SlangServerInstanceArray = { fg = "#efbd5d" },

--- a/clients/neovim/lua/slang-server/init.lua
+++ b/clients/neovim/lua/slang-server/init.lua
@@ -5,8 +5,6 @@ local config = require("slang-server._core.config")
 ---@class SlangModule
 local M = {}
 
-config.initialise()
-
 ---@param opts slang-server.config.Configuration?
 M.setup = function(opts)
    config.update(opts)


### PR DESCRIPTION
- Remove the unintuitive `opts = {}` / `setup({})` requirement when using lazy.nvim.
- Document the manual installation & configuration methods, as well as the lazy.nvim ones.