### PR TITLE
[Neovim] Handle `textDocument/inactiveRegions`

### DIFF
--- a/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
+++ b/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
@@ -2,19 +2,18 @@ local M = {}
 
 local ns = vim.api.nvim_create_namespace("SlangServerInactiveRegions")
 
-local files = {}
-
 vim.api.nvim_set_hl(0, "SlangServerInactiveRegion", {
    link = "Comment",
    default = true,
 })
 
-local function apply_highlights(uri)
-   local ranges = files[uri]
-   if not ranges then
-      return
-   end
+---@class slang-server.InactiveRegionsParams
+---@field uri string
+---@field regions lsp.Range[]
 
+---@param uri string
+---@param ranges lsp.Range[]
+local function apply_highlights(uri, ranges)
    local bufnr = vim.fn.bufnr(vim.uri_to_fname(uri), false)
    if bufnr == -1 then
       return
@@ -32,6 +31,8 @@ local function apply_highlights(uri)
    end
 end
 
+---@param err lsp.ResponseError?
+---@param params slang-server.InactiveRegionsParams?
 function M.handler(err, params, _, _)
    if err then
       return
@@ -45,8 +46,7 @@ function M.handler(err, params, _, _)
       return
    end
 
-   files[params.uri] = params.regions
-   apply_highlights(params.uri)
+   apply_highlights(params.uri, params.regions)
 end
 
 return M

--- a/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
+++ b/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
@@ -1,5 +1,3 @@
--- lua/slang-server/_lsp/inactive_regions.lua
-
 local M = {}
 
 local ns = vim.api.nvim_create_namespace("SlangServerInactiveRegions")

--- a/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
+++ b/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
@@ -1,0 +1,54 @@
+-- lua/slang-server/_lsp/inactive_regions.lua
+
+local M = {}
+
+local ns = vim.api.nvim_create_namespace("SlangServerInactiveRegions")
+
+local files = {}
+
+vim.api.nvim_set_hl(0, "SlangServerInactiveRegion", {
+   link = "Comment",
+   default = true,
+})
+
+local function apply_highlights(uri)
+   local ranges = files[uri]
+   if not ranges then
+      return
+   end
+
+   local bufnr = vim.fn.bufnr(vim.uri_to_fname(uri), false)
+   if bufnr == -1 then
+      return
+   end
+
+   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+
+   for _, range in ipairs(ranges) do
+      vim.api.nvim_buf_set_extmark(bufnr, ns, range.start.line, range.start.character, {
+         end_row = range["end"].line,
+         end_col = range["end"].character,
+         hl_group = "SlangServerInactiveRegion",
+         hl_eol = true,
+      })
+   end
+end
+
+function M.handler(err, params, _, _)
+   if err then
+      return
+   end
+
+   if not params then
+      return
+   end
+
+   if not params.uri or not params.regions then
+      return
+   end
+
+   files[params.uri] = params.regions
+   apply_highlights(params.uri)
+end
+
+return M

--- a/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
+++ b/clients/neovim/lua/slang-server/_lsp/experimental/inactive_regions.lua
@@ -7,10 +7,6 @@ vim.api.nvim_set_hl(0, "SlangServerInactiveRegion", {
    default = true,
 })
 
----@class slang-server.InactiveRegionsParams
----@field uri string
----@field regions lsp.Range[]
-
 ---@param uri string
 ---@param ranges lsp.Range[]
 local function apply_highlights(uri, ranges)

--- a/clients/neovim/lua/slang-server/_lsp/experimental/types.lua
+++ b/clients/neovim/lua/slang-server/_lsp/experimental/types.lua
@@ -1,0 +1,3 @@
+---@class slang-server.InactiveRegionsParams
+---@field uri string
+---@field regions lsp.Range[]

--- a/clients/neovim/lua/slang-server/init.lua
+++ b/clients/neovim/lua/slang-server/init.lua
@@ -13,7 +13,6 @@ M.setup = function(opts)
    config.update(opts)
 
    -- note: this config requires the slang_server to be explicitly named slang_server
-   -- so slang-server wouldn't work; idk the best practices here
    vim.lsp.config("slang_server", {
       capabilities = {
          experimental = {

--- a/clients/neovim/lua/slang-server/init.lua
+++ b/clients/neovim/lua/slang-server/init.lua
@@ -1,6 +1,7 @@
 -- Main module file
 
 local config = require("slang-server._core.config")
+local inactive_regions = require("slang-server._lsp.experimental.inactive_regions")
 
 ---@class SlangModule
 local M = {}
@@ -10,6 +11,22 @@ config.initialise()
 ---@param opts slang-server.config.Configuration?
 M.setup = function(opts)
    config.update(opts)
+
+   -- note: this config requires the slang_server to be explicitly named slang_server
+   -- so slang-server wouldn't work; idk the best practices here
+   vim.lsp.config("slang_server", {
+      capabilities = {
+         experimental = {
+            inactiveRegions = {
+               inactiveRegions = true,
+            },
+         },
+      },
+
+      handlers = {
+         ["textDocument/inactiveRegions"] = inactive_regions.handler,
+      },
+   })
 end
 
 return M


### PR DESCRIPTION
This adds the `inactiveRegions` capability (introduced in #287) to the neovim plugin.

We should still merge #352 since some people might not have the plugin, and some editors may not have support for this (ie: zed).

It works in basic cases, but there is an error when deleting many lines.

Feedback would be appreciated, since this is my first time doing substantial work w/ Neovim.

FYI: This PR is bootstrapped by AI.

Images:

<img width="1278" height="802" alt="image" src="https://github.com/user-attachments/assets/8b7ab9c5-5d19-47e7-aa7a-7cdb44d1b739" />