### PR TITLE
Fixes for Kate and QtCreator editors

### DIFF
--- a/include/SlangLspClient.h
+++ b/include/SlangLspClient.h
@@ -17,6 +17,7 @@ public:
     struct {
         bool inactiveRegionsSupported = false;
     } experimentalCapabilities;
+    bool linkSupport = false;
 
     void setConfig(const Config& params) {
         lsp::sendNotification("slang/setConfig", rfl::to_generic(params));

--- a/include/SlangLspClient.h
+++ b/include/SlangLspClient.h
@@ -17,7 +17,7 @@ public:
     struct {
         bool inactiveRegionsSupported = false;
     } experimentalCapabilities;
-    bool linkSupport = false;
+    lsp::ClientCapabilities capabilities;
 
     virtual void setConfig(const Config& params) {
         lsp::sendNotification("slang/setConfig", rfl::to_generic(params));

--- a/include/SlangLspClient.h
+++ b/include/SlangLspClient.h
@@ -17,6 +17,7 @@ public:
     struct {
         bool inactiveRegionsSupported = false;
     } experimentalCapabilities;
+    bool linkSupport = false;
 
     virtual void setConfig(const Config& params) {
         lsp::sendNotification("slang/setConfig", rfl::to_generic(params));

--- a/include/lsp/LspTypes.h
+++ b/include/lsp/LspTypes.h
@@ -271,7 +271,8 @@ enum class CompletionItemTag : uint8_t {
 /// A set of predefined code action kinds
 using CodeActionKind = rfl::Literal<"", "quickfix", "refactor", "refactor.extract",
                                     "refactor.inline", "refactor.rewrite", "source",
-                                    "source.organizeImports", "source.fixAll", "notebook">;
+                                    "source.organizeImports", "source.fixAll", "notebook",
+                                    "*">;
 
 /// A document filter denotes a document by different properties like
 /// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of

--- a/include/lsp/LspTypes.h
+++ b/include/lsp/LspTypes.h
@@ -607,7 +607,8 @@ using LanguageKind =
                  "objective-c", "objective-cpp", "perl", "perl6", "php", "powershell", "jade",
                  "python", "r", "razor", "ruby", "rust", "scss", "sass", "scala", "shaderlab",
                  "shellscript", "sql", "swift", "systemverilog", "systemverilogheader", "verilog",
-                 "typescript", "typescriptreact", "tex", "vb", "xml", "xsl", "yaml">;
+                 "typescript", "typescriptreact", "tex", "vb", "xml", "xsl", "yaml",
+                 "">;
 
 /// A filter to describe in which file operation requests or notifications
 /// the server is interested in receiving.

--- a/include/lsp/LspTypes.h
+++ b/include/lsp/LspTypes.h
@@ -274,7 +274,8 @@ enum class CompletionItemTag : uint8_t {
 /// so clients can advertise and request extension kinds outside this predefined set.
 using CodeActionKindOptions = rfl::Literal<"", "quickfix", "refactor", "refactor.extract",
                                            "refactor.inline", "refactor.rewrite", "source",
-                                           "source.organizeImports", "source.fixAll", "notebook">;
+                                           "source.organizeImports", "source.fixAll", "notebook",
+                                           "*">;
 using CodeActionKind = std::string;
 
 /// A document filter denotes a document by different properties like

--- a/include/lsp/LspTypes.h
+++ b/include/lsp/LspTypes.h
@@ -615,7 +615,8 @@ using LanguageKindOptions =
                  "objective-c", "objective-cpp", "perl", "perl6", "php", "powershell", "jade",
                  "python", "r", "razor", "ruby", "rust", "scss", "sass", "scala", "shaderlab",
                  "shellscript", "sql", "swift", "systemverilog", "systemverilogheader", "verilog",
-                 "typescript", "typescriptreact", "tex", "vb", "xml", "xsl", "yaml">;
+                 "typescript", "typescriptreact", "tex", "vb", "xml", "xsl", "yaml",
+                 "">;
 using LanguageKind = std::string;
 
 /// A filter to describe in which file operation requests or notifications

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -164,6 +164,12 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
 
     loadConfig();
 
+    if (const auto& tDoc = params.capabilities.textDocument) {
+        if (const auto& tDef = tDoc->definition) {
+            m_client.linkSupport = tDef->linkSupport.value_or(false);
+        }
+    }
+
     if (params.capabilities.experimental) {
         auto exp = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
             *params.capabilities.experimental);
@@ -631,7 +637,19 @@ std::monostate SlangServer::addDefine(const std::string& macroName) {
 
 rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate> SlangServer::
     getDocDefinition(const lsp::DefinitionParams& params) {
-    return m_driver->getDocDefinition(params.textDocument.uri, params.position);
+    auto lls(m_driver->getDocDefinition(params.textDocument.uri, params.position));
+    if (!m_client.linkSupport) {
+        // translate LocationLink to old fashioned Location
+        std::vector<lsp::Location> ls;
+        for (const auto& ll : lls) {
+            ls.emplace_back(
+                ll.targetUri,
+                ll.targetRange
+            );
+        }
+        return lsp::Definition(ls);
+    }
+    return lls;
 }
 
 std::optional<lsp::Hover> SlangServer::getDocHover(const lsp::HoverParams& params) {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -159,11 +159,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
 
     loadConfig();
 
-    if (const auto& tDoc = params.capabilities.textDocument) {
-        if (const auto& tDef = tDoc->definition) {
-            m_client.linkSupport = tDef->linkSupport.value_or(false);
-        }
-    }
+    m_client.capabilities = params.capabilities;
 
     if (params.capabilities.experimental) {
         auto exp = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
@@ -623,18 +619,27 @@ std::monostate SlangServer::addDefine(const std::string& macroName) {
 rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate> SlangServer::
     getDocDefinition(const lsp::DefinitionParams& params) {
     auto lls(m_driver->getDocDefinition(params.textDocument.uri, params.position));
-    if (!m_client.linkSupport) {
-        // translate LocationLink to old fashioned Location
-        std::vector<lsp::Location> ls;
-        for (const auto& ll : lls) {
-            ls.emplace_back(
-                ll.targetUri,
-                ll.targetRange
-            );
+
+    bool linkSupport = false;
+    if (const auto& tDoc = m_client.capabilities.textDocument) {
+        if (const auto& tDef = tDoc->definition) {
+            linkSupport = tDef->linkSupport.value_or(false);
         }
-        return lsp::Definition(ls);
     }
-    return lls;
+
+    if (linkSupport) {
+        return lls;
+    }
+
+    // translate LocationLink to old fashioned Location
+    std::vector<lsp::Location> ls;
+    for (const auto& ll : lls) {
+        ls.emplace_back(
+            ll.targetUri,
+            ll.targetRange
+        );
+    }
+    return lsp::Definition(ls);
 }
 
 std::optional<lsp::Hover> SlangServer::getDocHover(const lsp::HoverParams& params) {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -159,6 +159,12 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
 
     loadConfig();
 
+    if (const auto& tDoc = params.capabilities.textDocument) {
+        if (const auto& tDef = tDoc->definition) {
+            m_client.linkSupport = tDef->linkSupport.value_or(false);
+        }
+    }
+
     if (params.capabilities.experimental) {
         auto exp = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
             *params.capabilities.experimental);
@@ -616,7 +622,19 @@ std::monostate SlangServer::addDefine(const std::string& macroName) {
 
 rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate> SlangServer::
     getDocDefinition(const lsp::DefinitionParams& params) {
-    return m_driver->getDocDefinition(params.textDocument.uri, params.position);
+    auto lls(m_driver->getDocDefinition(params.textDocument.uri, params.position));
+    if (!m_client.linkSupport) {
+        // translate LocationLink to old fashioned Location
+        std::vector<lsp::Location> ls;
+        for (const auto& ll : lls) {
+            ls.emplace_back(
+                ll.targetUri,
+                ll.targetRange
+            );
+        }
+        return lsp::Definition(ls);
+    }
+    return lls;
 }
 
 std::optional<lsp::Hover> SlangServer::getDocHover(const lsp::HoverParams& params) {

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -268,7 +268,13 @@ async def client(my_options: Flags) -> AsyncGenerator[SlangClient, None]:
 
     response = await client.initialize_async(
         types.InitializeParams(
-            capabilities=types.ClientCapabilities(),  # Ignored for now
+            capabilities=types.ClientCapabilities(
+                text_document=types.TextDocumentClientCapabilities(
+                    definition=types.DefinitionClientCapabilities(
+                        link_support=True,
+                    ),
+                ),
+            ),
             root_uri=client.get_root_uri(),
         )
     )


### PR DESCRIPTION
Address issues from #395.

- Accept `CodeActionKind` `"*"`, as delivered by QtCreator
- Accept `LanguageKind` with empty string, as delivered by Kate
- Respect `textDocument.definition.linkSupport`.  Both Kate and QtC omit `linkSupport`, and in turn expect `Location` to be returned.

For the last.  I took `capabilities.experimental` as a template.  Since `Location` is practically a sub-set of `LocationLink`, I added a back translation in `SlangServer::getDocDefinition()`.  I also changed (I think) the test client to pass `linkSupport=true` to avoid breaking any existing tests.