### PR TITLE
Slang fork: clean up SourceManager data access additions, split sm commit

### DIFF
--- a/include/ast/HierarchicalView.h
+++ b/include/ast/HierarchicalView.h
@@ -123,6 +123,10 @@ static void handleBlockScope(std::vector<HierItem_t>& result,
 static void handleBlockScope(std::vector<HierItem_t>& result,
                              const slang::ast::GenerateBlockSymbol& block,
                              const SourceManager& sm) {
+    if (block.isUninstantiated) {
+        // Don't return uninstantiated blocks
+        return;
+    }
     handleBlockScope(result, block, sm, block.getExternalName());
 }
 
@@ -277,8 +281,6 @@ static std::vector<HierItem_t> getScopeChildren(const slang::ast::Scope& scope,
                                                 const SourceManager& sm) {
     std::vector<HierItem_t> result;
     for (auto& sym : scope.members()) {
-        if (!sym.isInstantiated())
-            continue;
         if (auto inst = sym.as_if<slang::ast::InstanceSymbol>()) {
             handleInstance(result, *inst, sm);
         }

--- a/include/document/SlangDoc.h
+++ b/include/document/SlangDoc.h
@@ -150,9 +150,7 @@ public:
     // TODO: should this use the shallow compilation instead of syntax tree?
     std::vector<lsp::DocumentSymbol> getSymbols() { return getAnalysis()->getDocSymbols(); }
 
-    std::optional<slang::SourceLocation> getLocation(const lsp::Position& position) {
-        return m_sourceManager.getSourceLocation(m_buffer.id, position.line, position.character);
-    }
+    std::optional<slang::SourceLocation> getLocation(const lsp::Position& position);
 
     // Previous text on and before a position
     std::string getPrevText(const lsp::Position& position);

--- a/include/util/Converters.h
+++ b/include/util/Converters.h
@@ -26,9 +26,10 @@ std::optional<const parsing::Token> findNameToken(const syntax::SyntaxNode* node
 
 lsp::Position toPosition(const SourceLocation& loc, const SourceManager& sourceManager);
 
-lsp::Range toRange(const SourceRange& range, const SourceManager& sourceManager);
+std::optional<SourceLocation> toSourceLocation(BufferID buffer, const lsp::Position& position,
+                                               const SourceManager& sourceManager);
 
-lsp::Range toOriginalRange(const SourceRange& range, const SourceManager& sourceManager);
+lsp::Range toRange(const SourceRange& range, const SourceManager& sourceManager);
 
 lsp::Location toOriginalLocation(const SourceRange& range, const SourceManager& sourceManager);
 

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -494,7 +494,7 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
     auto analysis = doc->getAnalysis();
 
     // Get location, token, and syntax node at position
-    auto loc = sm.getSourceLocation(doc->getBuffer(), position.line, position.character);
+    auto loc = toSourceLocation(doc->getBuffer(), position, sm);
     if (!loc) {
         return {};
     }
@@ -625,15 +625,15 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
 
     auto macroUsageRange = SourceRange::NoLocation;
     if (nameToken && sm.isMacroLoc(nameToken->location())) {
-        auto locs = sm.getMacroExpansions(nameToken->location());
-        // TODO: maybe include more expansion infos?
-        auto macroInfo = sm.getMacroInfo(locs.back());
-        auto text = macroInfo ? sm.getText(macroInfo->expansionRange) : "";
+        auto tokenRange = SourceRange(nameToken->location(),
+                                      nameToken->location() + nameToken->rawText().length());
+        auto expansionRange = sm.getFullyExpandedRange(tokenRange);
+        auto text = sm.getSourceText(expansionRange);
         if (text.empty()) {
             ERROR("Couldn't get original range for symbol {}", nameToken->valueText());
         }
         else {
-            macroUsageRange = macroInfo->expansionRange;
+            macroUsageRange = expansionRange;
         }
     }
 
@@ -674,7 +674,7 @@ std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::P
     if (!doc) {
         return {};
     }
-    auto loc = sm.getSourceLocation(doc->getBuffer(), position.line, position.character);
+    auto loc = toSourceLocation(doc->getBuffer(), position, sm);
     if (!loc) {
         return {};
     }
@@ -710,7 +710,7 @@ std::optional<std::vector<lsp::DocumentHighlight>> ServerDriver::getDocDocumentH
     auto analysis = doc->getAnalysis();
 
     // Get the symbol at the position
-    auto loc = sm.getSourceLocation(doc->getBuffer(), position.line, position.character);
+    auto loc = toSourceLocation(doc->getBuffer(), position, sm);
     if (!loc) {
         return std::nullopt;
     }
@@ -808,7 +808,7 @@ std::optional<std::vector<lsp::Location>> ServerDriver::getDocReferences(
     // Get the symbol at the position. Hold the analysis via shared_ptr so that
     // targetSymbol remains valid even if getAnalysis() is called on this doc again.
     auto analysis = doc->getAnalysis();
-    auto loc = sm.getSourceLocation(doc->getBuffer(), position.line, position.character);
+    auto loc = toSourceLocation(doc->getBuffer(), position, sm);
     if (!loc) {
         return std::nullopt;
     }

--- a/src/ast/ServerCompilation.cpp
+++ b/src/ast/ServerCompilation.cpp
@@ -125,8 +125,7 @@ std::vector<std::string> ServerCompilation::getInstances(
         ERROR("Unknown doc: {}", params.textDocument.uri.getPath());
         return {};
     }
-    auto location = m_sourceManager.getSourceLocation(doc->getBuffer(), params.position.line,
-                                                      params.position.character);
+    auto location = toSourceLocation(doc->getBuffer(), params.position, m_sourceManager);
     if (location) {
         inst::InstanceVisitor visitor(*location);
         m_analysis->compilation.getRoot().visit(visitor);

--- a/src/codeactions/CodeActionDispatch.cpp
+++ b/src/codeactions/CodeActionDispatch.cpp
@@ -11,6 +11,7 @@
 #include "ServerDriver.h"
 #include "codeactions/AddDefine.h"
 #include "codeactions/ExpandMacro.h"
+#include "util/Converters.h"
 #include <rfl/Variant.hpp>
 
 namespace server {
@@ -32,8 +33,7 @@ std::vector<rfl::Variant<lsp::Command, lsp::CodeAction>> CodeActionDispatch::get
     const parsing::Token* token = nullptr;
     const syntax::SyntaxNode* syntax = nullptr;
 
-    auto loc = m_sourceManager.getSourceLocation(doc->getBuffer(), params.range.start.line,
-                                                 params.range.start.character);
+    auto loc = toSourceLocation(doc->getBuffer(), params.range.start, m_sourceManager);
     if (loc) {
         token = analysis->syntaxes.getWordTokenAt(*loc);
         if (token)

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -262,7 +262,7 @@ void DefinitionInfo::SyntaxTarget::renderMacroExpansion(markup::Document& doc,
                                                         const SourceManager& sm) const {
     if (macroUsageRange == SourceRange::NoLocation)
         return;
-    auto text = sm.getText(macroUsageRange);
+    auto text = sm.getSourceText(macroUsageRange);
     doc.addParagraph().appendText("Expanded from ").newLine().appendCodeBlock(text);
 }
 

--- a/src/document/InlayHintCollector.cpp
+++ b/src/document/InlayHintCollector.cpp
@@ -27,11 +27,11 @@ using namespace slang;
 static SourceLocation getArgumentHintLoc(const ArgumentSyntax& syntax,
                                          const ShallowAnalysis& analysis) {
     auto& sourceManager = analysis.getSourceManager();
-    if (auto info = sourceManager.getMacroInfo(syntax.getFirstToken().location())) {
-        return sourceManager.getFullyOriginalLoc(info->expansionRange.start());
-    }
+    auto loc = syntax.sourceRange().start();
+    if (sourceManager.isMacroLoc(loc))
+        return sourceManager.getFullyExpandedLoc(loc);
 
-    return sourceManager.getFullyOriginalLoc(syntax.sourceRange().start());
+    return sourceManager.getFullyOriginalLoc(loc);
 }
 
 InlayHintCollector::InlayHintCollector(const ShallowAnalysis& analysis, lsp::Range range,
@@ -359,13 +359,10 @@ void InlayHintCollector::handle(const ClassNameSyntax& syntax) {
 
 void InlayHintCollector::collectHints() {
 
-    auto slangStart = m_analysis.m_sourceManager.getSourceLocation(m_analysis.m_buffer,
-                                                                   m_range.start.line,
-                                                                   m_range.start.character);
+    auto slangStart = toSourceLocation(m_analysis.m_buffer, m_range.start,
+                                       m_analysis.m_sourceManager);
 
-    auto slangEnd = m_analysis.m_sourceManager.getSourceLocation(m_analysis.m_buffer,
-                                                                 m_range.end.line,
-                                                                 m_range.end.character);
+    auto slangEnd = toSourceLocation(m_analysis.m_buffer, m_range.end, m_analysis.m_sourceManager);
     if (!slangStart || !slangEnd) {
         ERROR("Invalid range for inlay hints");
         return;

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -282,7 +282,7 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
         auto lastToken = macroArgSyntax.getLastToken();
         size_t startOffset = firstToken.location().offset();
         size_t endOffset = lastToken.location().offset() + lastToken.rawText().size();
-        auto macroArgText = m_sourceManager.getText(SourceRange{
+        auto macroArgText = m_sourceManager.getSourceText(SourceRange{
             SourceLocation(m_buffer, startOffset), SourceLocation(m_buffer, endOffset)});
 
         // These will overwrite the same assigned source, but it's ok since they are temporary,

--- a/src/document/SlangDoc.cpp
+++ b/src/document/SlangDoc.cpp
@@ -11,6 +11,7 @@
 #include "ServerDriver.h"
 #include "document/ShallowAnalysis.h"
 #include "lsp/URI.h"
+#include "util/Converters.h"
 #include "util/Logging.h"
 #include "util/SlangExtensions.h"
 #include <fmt/format.h>
@@ -34,6 +35,10 @@ using namespace slang;
 SlangDoc::SlangDoc(ServerDriver& driver, URI uri, SourceBuffer buffer) :
     m_driver(driver), m_sourceManager(driver.sm), m_options(driver.options), m_uri(uri),
     m_buffer(buffer) {
+}
+
+std::optional<SourceLocation> SlangDoc::getLocation(const lsp::Position& position) {
+    return toSourceLocation(m_buffer.id, position, m_sourceManager);
 }
 
 std::shared_ptr<SlangDoc> SlangDoc::fromTree(ServerDriver& driver,
@@ -121,8 +126,13 @@ std::shared_ptr<ShallowAnalysis> SlangDoc::getAnalysis(bool refreshDependencies)
 }
 
 std::string SlangDoc::getPrevText(const lsp::Position& position) {
-    return std::string(
-        m_sourceManager.getLine(m_buffer.id, position.line + 1).substr(0, position.character));
+    auto start = m_sourceManager.getSourceLocation(m_buffer.id, position.line + 1, 1);
+    auto end = m_sourceManager.getSourceLocation(m_buffer.id, position.line + 1,
+                                                 position.character + 1);
+    if (!start || !end)
+        return "";
+
+    return std::string(m_sourceManager.getSourceText(SourceRange(*start, *end)));
 }
 
 bool SlangDoc::textMatches(std::string_view text) {
@@ -170,12 +180,12 @@ void SlangDoc::onChange(const std::vector<lsp::TextDocumentContentChangeEvent>& 
         SourceManager::computeLineOffsets(textView, lineOffsets);
         auto& start = range.start;
         auto& end = range.end;
-        auto startOffset = lineOffsets[start.line] + start.character;
-        auto endOffset = lineOffsets[end.line] + end.character;
         if (start.line >= lineOffsets.size() || end.line >= lineOffsets.size()) {
             throw std::runtime_error(fmt::format("Range out of bounds: {},{} / {}", start.line,
                                                  end.line, lineOffsets.size()));
         }
+        auto startOffset = lineOffsets[start.line] + start.character;
+        auto endOffset = lineOffsets[end.line] + end.character;
         return std::make_pair(startOffset, endOffset);
     };
 

--- a/src/util/Converters.cpp
+++ b/src/util/Converters.cpp
@@ -45,14 +45,14 @@ lsp::Position toPosition(const SourceLocation& loc, const SourceManager& sourceM
                          .character = static_cast<lsp::uint>(character > 0 ? character - 1 : 0)};
 }
 
+std::optional<SourceLocation> toSourceLocation(BufferID buffer, const lsp::Position& position,
+                                               const SourceManager& sourceManager) {
+    return sourceManager.getSourceLocation(buffer, position.line + 1, position.character + 1);
+}
+
 lsp::Range toRange(const SourceRange& range, const SourceManager& sourceManager) {
     return lsp::Range{.start = toPosition(range.start(), sourceManager),
                       .end = toPosition(range.end(), sourceManager)};
-}
-
-lsp::Range toOriginalRange(const SourceRange& range, const SourceManager& sourceManager) {
-    auto origRange = sourceManager.getFullyOriginalRange(range);
-    return toRange(origRange, sourceManager);
 }
 
 lsp::Location toOriginalLocation(const SourceRange& range, const SourceManager& sourceManager) {
@@ -75,16 +75,7 @@ lsp::Range toRange(const SourceLocation& loc, const SourceManager& sourceManager
 }
 
 lsp::Location toLocation(const SourceRange& range, const SourceManager& sourceManager) {
-    // TODO: make this logic just one function in source manager
-    auto declRange = range;
-
-    // Get location of `MACRO_USAGE if from a macro expansion
-    auto locs = sourceManager.getMacroExpansions(range.start());
-    if (locs.size()) {
-        auto macroInfo = sourceManager.getMacroInfo(locs.back());
-        declRange = macroInfo ? macroInfo->expansionRange
-                              : sourceManager.getFullyOriginalRange(range);
-    }
+    auto declRange = sourceManager.getFullyExpandedRange(range);
 
     return lsp::Location{.uri = URI::fromFile(
                              sourceManager.getFullPath(declRange.start().buffer())),

--- a/tests/cpp/InactiveRegionsTests.cpp
+++ b/tests/cpp/InactiveRegionsTests.cpp
@@ -62,7 +62,7 @@ logic h;
 
     std::vector<RegionInfo> regions;
     for (auto& r : disabled) {
-        regions.push_back({toRange(r, sm), std::string(sm.getText(r))});
+        regions.push_back({toRange(r, sm), std::string(sm.getSourceText(r))});
     }
 
     golden.record(regions);
@@ -87,7 +87,7 @@ TEST_CASE("InactiveRegions_ParseError") {
     auto& disabled = indexer.disabledRegions;
 
     REQUIRE(disabled.size() == 1);
-    auto text = std::string(sm.getText(disabled[0]));
+    auto text = std::string(sm.getSourceText(disabled[0]));
     CHECK(text.find("`ASDF") != std::string::npos);
 }
 
@@ -113,7 +113,7 @@ TEST_CASE("InactiveRegions_MacroInDisabledBranch") {
 
     // The macro usage `WIDTH should not split the disabled region
     REQUIRE(disabled.size() == 1);
-    CHECK(sm.getText(disabled[0]) == "logic [`WIDTH-1:0] a;");
+    CHECK(sm.getSourceText(disabled[0]) == "logic [`WIDTH-1:0] a;");
 }
 
 TEST_CASE("InactiveRegions_NestedDirectivesMerged") {
@@ -147,7 +147,7 @@ TEST_CASE("InactiveRegions_NestedDirectivesMerged") {
     // Each region should include the full inner `ifndef/`endif block.
     REQUIRE(disabled.size() == 3);
     for (auto& region : disabled) {
-        auto text = std::string(sm.getText(region));
+        auto text = std::string(sm.getSourceText(region));
         CHECK(text.find("`ifndef FLAG_X") != std::string::npos);
         CHECK(text.find("`endif") != std::string::npos);
     }
@@ -193,8 +193,9 @@ endmodule
     auto& syntaxes = doc.doc->getAnalysis()->syntaxes;
 
     std::vector<RegionInfo> regions;
+    regions.reserve(syntaxes.disabledRegions.size());
     for (auto& r : syntaxes.disabledRegions) {
-        regions.push_back({toRange(r, sm), std::string(sm.getText(r))});
+        regions.push_back({toRange(r, sm), std::string(sm.getSourceText(r))});
     }
 
     golden.record(regions);

--- a/tests/cpp/utils/ServerHarness.cpp
+++ b/tests/cpp/utils/ServerHarness.cpp
@@ -474,7 +474,7 @@ std::vector<lsp::DocumentHighlight> Cursor::getHighlights() {
 }
 
 std::optional<slang::SourceLocation> DocumentHandle::getLocation(lsp::uint offset) {
-    return doc->getSourceManager().getSourceLocation(doc->getBuffer(), offset);
+    return slang::SourceLocation(doc->getBuffer(), offset);
 }
 
 std::optional<lsp::Position> DocumentHandle::getLspLocation(lsp::uint offset) {

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -139,9 +139,25 @@ public:
     void open();
 
     /// @brief Get the line at a given line number
-    /// @param line The line number (0-based / Slang lines)
+    /// @param line The 1-based slang line number. Returns empty for line 0.
     std::string_view getLine(lsp::uint line) {
-        return m_server.sourceManager().getLine(doc->getBuffer(), line);
+        auto text = doc->getText();
+        if (line == 0 || text.empty())
+            return {};
+
+        std::vector<size_t> lineOffsets;
+        SourceManager::computeLineOffsets(text, lineOffsets);
+
+        size_t lineIndex = line - 1;
+        if (lineIndex >= lineOffsets.size())
+            return {};
+
+        size_t start = lineOffsets[lineIndex];
+        size_t end = lineIndex + 1 < lineOffsets.size() ? lineOffsets[lineIndex + 1] : text.size();
+        if (end > start && text[end - 1] == '\0')
+            end--;
+
+        return text.substr(start, end - start);
     }
 
     lsp::Position getPosition(lsp::uint offset);

--- a/tests/data/repo1/base_pkg.sv
+++ b/tests/data/repo1/base_pkg.sv
@@ -15,6 +15,7 @@ package base_pkg;
     export util_pkg::result_t;
     export util_pkg::SUCCESS;
     export util_pkg::ERROR_CODE;
+    import util_pkg::create_config;
     export util_pkg::create_config;
 
     function automatic config_t get_default_config();


### PR DESCRIPTION
Stacked PRs:
 * #427
 * #426
 * __->__#421


--- --- ---

### Slang fork: clean up SourceManager data access additions, split sm commit


- Picks up fix for implicit-net-port false positive https://github.com/hudson-trading/slang-server/issues/420
- Picks up fixes for package export resolution
