### PR TITLE
Revert "cancel-in-progress on pull request pushes"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,6 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,10 +6,6 @@ on:
     branches: [main]
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   linux-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/mkdocs_preview.yml
+++ b/.github/workflows/mkdocs_preview.yml
@@ -7,10 +7,6 @@ on:
       - '**/mkdocs*.yml'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/neovim-sync.yml
+++ b/.github/workflows/neovim-sync.yml
@@ -14,10 +14,6 @@ on:
       - 'clients/neovim/**'
       - '**/neovim-sync.yml'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   pre-commit-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
     paths: [clients/vscode/**]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Reverts hudson-trading/slang-server#386

This is kind of annoying to have builds cancel midway through because you pushed a new commit or not be able to run a new workflow since an old one is running.

I don't really see the point since github foots the workflow bill.