### PR TITLE
Implement initial semantic token enchancement

### DIFF
--- a/clients/vscode/resources/config.schema.json
+++ b/clients/vscode/resources/config.schema.json
@@ -94,6 +94,10 @@
           "$ref": "#/$defs/Config__InlayHints",
           "description": "Inline hints for things like ordered arguments, wildcard ports, and others"
         },
+        "semanticTokens": {
+          "$ref": "#/$defs/Config__SemanticTokensConfig",
+          "description": "Semantic token highlighting settings"
+        },
         "builds": {
           "type": "array",
           "description": "Builds for direct .f selection or command-based .f generation",
@@ -201,6 +205,16 @@
         "macroArgNames": {
           "type": "integer",
           "description": "Macro argument hints: 0=off, N=only calls with >=N args"
+        }
+      },
+      "required": []
+    },
+    "Config__SemanticTokensConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable semantic token highlighting. Off by default: semanticTokens/full is a whole-document request whose latency has not been characterized yet.",
+          "type": "boolean"
         }
       },
       "required": []

--- a/clients/vscode/src/config.gen.ts
+++ b/clients/vscode/src/config.gen.ts
@@ -36,6 +36,8 @@ export interface Config {
   hovers?: Config__HoverConfig
   /** Inline hints for things like ordered arguments, wildcard ports, and others */
   inlayHints?: Config__InlayHints
+  /** Semantic token highlighting settings */
+  semanticTokens?: Config__SemanticTokensConfig
   /** Builds for direct .f selection or command-based .f generation */
   builds?: Config__Build[]
 }
@@ -72,4 +74,9 @@ export interface Config__InlayHints {
   funcArgNames?: number
   /** Macro argument hints: 0=off, N=only calls with >=N args */
   macroArgNames?: number
+}
+
+export interface Config__SemanticTokensConfig {
+  /** Enable semantic token highlighting. Off by default: semanticTokens/full is a whole-document request whose latency has not been characterized yet. */
+  enabled?: boolean
 }

--- a/include/Config.h
+++ b/include/Config.h
@@ -115,6 +115,17 @@ struct Config {
                      InlayHints>
         inlayHints = InlayHints{};
 
+    struct SemanticTokensConfig {
+        rfl::Description<"Enable semantic token highlighting. Off by default: semanticTokens/full "
+                         "is a whole-document request whose latency has not been characterized "
+                         "yet.",
+                         bool>
+            enabled = false;
+    };
+
+    rfl::Description<"Semantic token highlighting settings", SemanticTokensConfig> semanticTokens =
+        SemanticTokensConfig{};
+
     struct Build {
         rfl::Description<"Optional name used for generated build files and UI labels",
                          std::optional<std::string>>

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -189,6 +189,9 @@ public:
     std::optional<std::vector<lsp::InlayHint>> getDocInlayHint(
         const lsp::InlayHintParams&) override;
 
+    std::optional<lsp::SemanticTokens> getDocSemanticTokensFull(
+        const lsp::SemanticTokensParams&) override;
+
     std::optional<std::vector<lsp::Location>> getDocReferences(
         const lsp::ReferenceParams&) override;
 

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -142,6 +142,11 @@ public:
     std::vector<lsp::InlayHint> getInlayHints(lsp::Range range,
                                               const struct Config::InlayHints& config);
 
+    lsp::SemanticTokens getSemanticTokens() const;
+
+    static const std::vector<std::string>& semanticTokenLegendTypes();
+    static const std::vector<std::string>& semanticTokenLegendModifiers();
+
     /// @brief Finds all references to a symbol in this document and adds them to the vector
     /// @param references Vector to append references to
     /// @param targetLocation The source location of the target symbol

--- a/include/document/SlangDoc.h
+++ b/include/document/SlangDoc.h
@@ -157,6 +157,8 @@ public:
 
     std::vector<lsp::DocumentLink> getDocLinks() { return getAnalysis()->getDocLinks(); }
 
+    lsp::SemanticTokens getSemanticTokens() { return getAnalysis()->getSemanticTokens(); }
+
     std::vector<lsp::Range> getInactiveRegions();
 };
 

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -169,6 +169,21 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
         }
     }
 
+    // Opt-in: semanticTokens/full re-classifies the whole document, so it stays unadvertised
+    // until the request path is threaded and its latency is measured.
+    std::optional<rfl::Variant<lsp::SemanticTokensOptions, lsp::SemanticTokensRegistrationOptions>>
+        semanticTokensProvider;
+    if (m_config.semanticTokens.get().enabled.get()) {
+        semanticTokensProvider = lsp::SemanticTokensOptions{
+            .legend =
+                lsp::SemanticTokensLegend{
+                    .tokenTypes = ShallowAnalysis::semanticTokenLegendTypes(),
+                    .tokenModifiers = ShallowAnalysis::semanticTokenLegendModifiers(),
+                },
+            .full = true,
+        };
+    }
+
     auto result =
         lsp::InitializeResult{
             .capabilities =
@@ -217,16 +232,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
                             .commands = getCommandList(),
                         },
                     .callHierarchyProvider = true,
-                    .semanticTokensProvider =
-                        lsp::SemanticTokensOptions{
-                            .legend =
-                                lsp::SemanticTokensLegend{
-                                    .tokenTypes = ShallowAnalysis::semanticTokenLegendTypes(),
-                                    .tokenModifiers =
-                                        ShallowAnalysis::semanticTokenLegendModifiers(),
-                                },
-                            .full = true,
-                        },
+                    .semanticTokensProvider = std::move(semanticTokensProvider),
                     .inlayHintProvider =
                         lsp::InlayHintOptions{
                             .resolveProvider = false,
@@ -838,6 +844,12 @@ std::optional<std::vector<lsp::InlayHint>> SlangServer::getDocInlayHint(
 
 std::optional<lsp::SemanticTokens> SlangServer::getDocSemanticTokensFull(
     const lsp::SemanticTokensParams& params) {
+    // Checked per request, not just at initialize: config can be reloaded while the
+    // server is running, but capabilities are only sent once.
+    if (!m_config.semanticTokens.get().enabled.get()) {
+        return {};
+    }
+
     auto doc = m_driver->getDocument(params.textDocument.uri);
     if (!doc) {
         return {};

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -75,6 +75,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     registerDocDocumentHighlight();
 
     registerDocInlayHint();
+    registerDocSemanticTokensFull();
     registerDocReferences();
     registerDocRename();
     registerDocCodeAction();
@@ -216,6 +217,16 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
                             .commands = getCommandList(),
                         },
                     .callHierarchyProvider = true,
+                    .semanticTokensProvider =
+                        lsp::SemanticTokensOptions{
+                            .legend =
+                                lsp::SemanticTokensLegend{
+                                    .tokenTypes = ShallowAnalysis::semanticTokenLegendTypes(),
+                                    .tokenModifiers =
+                                        ShallowAnalysis::semanticTokenLegendModifiers(),
+                                },
+                            .full = true,
+                        },
                     .inlayHintProvider =
                         lsp::InlayHintOptions{
                             .resolveProvider = false,
@@ -823,6 +834,19 @@ std::optional<std::vector<lsp::InlayHint>> SlangServer::getDocInlayHint(
     auto hints = doc->getAnalysis()->getInlayHints(params.range, m_config.inlayHints.get());
     INFO("Providing {} inlay hints for {}", hints.size(), params.textDocument.uri.getPath());
     return hints;
+}
+
+std::optional<lsp::SemanticTokens> SlangServer::getDocSemanticTokensFull(
+    const lsp::SemanticTokensParams& params) {
+    auto doc = m_driver->getDocument(params.textDocument.uri);
+    if (!doc) {
+        return {};
+    }
+
+    auto tokens = doc->getSemanticTokens();
+    INFO("Providing {} semantic tokens for {}", tokens.data.size() / 5,
+         params.textDocument.uri.getPath());
+    return tokens;
 }
 
 std::optional<std::vector<lsp::Location>> SlangServer::getDocReferences(

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -13,7 +13,6 @@
 #include "util/Converters.h"
 #include "util/Logging.h"
 #include "util/SlangExtensions.h"
-#include <array>
 #include <fmt/format.h>
 #include <memory>
 #include <string_view>
@@ -60,41 +59,40 @@ static bool symbolsMatch(const ast::Symbol* a, const ast::Symbol* b) {
 }
 
 namespace {
-enum class SemanticTokenTypeIndex : lsp::uint {
-    Namespace = 0,
-    Type = 1,
-    Class = 2,
-    Parameter = 3,
-    Variable = 4,
-    Property = 5,
-    EnumMember = 6,
-    Function = 7,
-    Macro = 8,
-    Keyword = 9,
-    String = 10,
-    Number = 11,
-    Operator = 12,
+// A token's type and modifiers travel over the wire as indices into the legend we
+// advertise at initialize. Both the indices below and that legend are derived from
+// the spec's own literals, so the two cannot drift apart: value_of<> is a compile
+// error for a name the spec does not define.
+using TokenTypeLegend = lsp::SemanticTokenTypesOptions;
+using TokenModifierLegend = lsp::SemanticTokenModifiersOptions;
+
+enum class SemanticTokenTypeIndex : TokenTypeLegend::ValueType {
+    Namespace = TokenTypeLegend::value_of<"namespace">(),
+    Type = TokenTypeLegend::value_of<"type">(),
+    Class = TokenTypeLegend::value_of<"class">(),
+    Parameter = TokenTypeLegend::value_of<"parameter">(),
+    Variable = TokenTypeLegend::value_of<"variable">(),
+    Property = TokenTypeLegend::value_of<"property">(),
+    EnumMember = TokenTypeLegend::value_of<"enumMember">(),
+    Function = TokenTypeLegend::value_of<"function">(),
+    Macro = TokenTypeLegend::value_of<"macro">(),
+    Keyword = TokenTypeLegend::value_of<"keyword">(),
+    String = TokenTypeLegend::value_of<"string">(),
+    Number = TokenTypeLegend::value_of<"number">(),
+    Operator = TokenTypeLegend::value_of<"operator">(),
+    // Sentinel for an unclassified token. One past the end of the legend, so it can
+    // never collide with a real type.
+    None = static_cast<TokenTypeLegend::ValueType>(TokenTypeLegend::size()),
 };
 
-enum class SemanticTokenModifierIndex : lsp::uint {
-    Declaration = 0,
-    Readonly = 1,
-    DefaultLibrary = 2,
-};
-
-constexpr std::array<std::string_view, 13> kSemanticTokenTypes = {
-    "namespace", "type",  "class",   "parameter", "variable", "property", "enumMember",
-    "function",  "macro", "keyword", "string",    "number",   "operator",
-};
-
-constexpr std::array<std::string_view, 3> kSemanticTokenModifiers = {
-    "declaration",
-    "readonly",
-    "defaultLibrary",
+enum class SemanticTokenModifierIndex : TokenModifierLegend::ValueType {
+    Declaration = TokenModifierLegend::value_of<"declaration">(),
+    Readonly = TokenModifierLegend::value_of<"readonly">(),
+    DefaultLibrary = TokenModifierLegend::value_of<"defaultLibrary">(),
 };
 
 struct SemanticClassification {
-    lsp::uint tokenType = 0;
+    SemanticTokenTypeIndex tokenType = SemanticTokenTypeIndex::None;
     lsp::uint tokenModifiers = 0;
 };
 
@@ -214,12 +212,12 @@ bool isOperatorToken(parsing::TokenKind kind) {
     }
 }
 
-std::optional<lsp::uint> tokenTypeFromSymbolKind(ast::SymbolKind kind) {
+SemanticTokenTypeIndex tokenTypeFromSymbolKind(ast::SymbolKind kind) {
     switch (kind) {
         case ast::SymbolKind::Package:
         case ast::SymbolKind::ExplicitImport:
         case ast::SymbolKind::WildcardImport:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Namespace);
+            return SemanticTokenTypeIndex::Namespace;
         case ast::SymbolKind::TypeAlias:
         case ast::SymbolKind::NetType:
         case ast::SymbolKind::ClassType:
@@ -229,7 +227,7 @@ std::optional<lsp::uint> tokenTypeFromSymbolKind(ast::SymbolKind kind) {
         case ast::SymbolKind::PackedUnionType:
         case ast::SymbolKind::UnpackedUnionType:
         case ast::SymbolKind::TypeRefType:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Type);
+            return SemanticTokenTypeIndex::Type;
         case ast::SymbolKind::Definition:
         case ast::SymbolKind::Instance:
         case ast::SymbolKind::InstanceBody:
@@ -237,7 +235,7 @@ std::optional<lsp::uint> tokenTypeFromSymbolKind(ast::SymbolKind kind) {
         case ast::SymbolKind::Checker:
         case ast::SymbolKind::CheckerInstance:
         case ast::SymbolKind::CheckerInstanceBody:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+            return SemanticTokenTypeIndex::Class;
         case ast::SymbolKind::Parameter:
         case ast::SymbolKind::TypeParameter:
         case ast::SymbolKind::Port:
@@ -245,26 +243,26 @@ std::optional<lsp::uint> tokenTypeFromSymbolKind(ast::SymbolKind kind) {
         case ast::SymbolKind::InterfacePort:
         case ast::SymbolKind::FormalArgument:
         case ast::SymbolKind::Specparam:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Parameter);
+            return SemanticTokenTypeIndex::Parameter;
         case ast::SymbolKind::Variable:
         case ast::SymbolKind::Net:
         case ast::SymbolKind::Genvar:
         case ast::SymbolKind::LocalAssertionVar:
         case ast::SymbolKind::PatternVar:
         case ast::SymbolKind::Iterator:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Variable);
+            return SemanticTokenTypeIndex::Variable;
         case ast::SymbolKind::Field:
         case ast::SymbolKind::ClassProperty:
         case ast::SymbolKind::ModportPort:
         case ast::SymbolKind::ClockVar:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Property);
+            return SemanticTokenTypeIndex::Property;
         case ast::SymbolKind::EnumValue:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::EnumMember);
+            return SemanticTokenTypeIndex::EnumMember;
         case ast::SymbolKind::Subroutine:
         case ast::SymbolKind::MethodPrototype:
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Function);
+            return SemanticTokenTypeIndex::Function;
         default:
-            return std::nullopt;
+            return SemanticTokenTypeIndex::None;
     }
 }
 
@@ -295,8 +293,8 @@ bool isTransparentSyntaxKind(syntax::SyntaxKind kind) {
     }
 }
 
-std::optional<lsp::uint> tokenTypeFromSyntaxContext(const parsing::Token* token,
-                                                    const syntax::SyntaxNode* syntax) {
+SemanticTokenTypeIndex tokenTypeFromSyntaxContext(const parsing::Token* token,
+                                                  const syntax::SyntaxNode* syntax) {
     for (auto* node = syntax; node; node = node->parent) {
         if (isTransparentSyntaxKind(node->kind)) {
             continue;
@@ -314,29 +312,29 @@ std::optional<lsp::uint> tokenTypeFromSyntaxContext(const parsing::Token* token,
             case syntax::SyntaxKind::InterfacePortHeader:
             case syntax::SyntaxKind::NetPortHeader:
             case syntax::SyntaxKind::VariablePortHeader:
-                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Parameter);
+                return SemanticTokenTypeIndex::Parameter;
 
             case syntax::SyntaxKind::TypedefDeclaration:
             case syntax::SyntaxKind::ForwardTypedefDeclaration:
             case syntax::SyntaxKind::NamedType:
             case syntax::SyntaxKind::EnumType:
-                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Type);
+                return SemanticTokenTypeIndex::Type;
 
             case syntax::SyntaxKind::StructUnionMember:
             case syntax::SyntaxKind::ClassPropertyDeclaration:
-                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Property);
+                return SemanticTokenTypeIndex::Property;
 
             case syntax::SyntaxKind::FunctionPrototype:
             case syntax::SyntaxKind::FunctionDeclaration:
             case syntax::SyntaxKind::TaskDeclaration:
             case syntax::SyntaxKind::ClassMethodDeclaration:
             case syntax::SyntaxKind::ClassMethodPrototype:
-                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Function);
+                return SemanticTokenTypeIndex::Function;
 
             case syntax::SyntaxKind::PackageHeader: {
                 auto& header = node->as<syntax::ModuleHeaderSyntax>();
                 if (header.name == *token) {
-                    return static_cast<lsp::uint>(SemanticTokenTypeIndex::Namespace);
+                    return SemanticTokenTypeIndex::Namespace;
                 }
                 break;
             }
@@ -345,21 +343,21 @@ std::optional<lsp::uint> tokenTypeFromSyntaxContext(const parsing::Token* token,
             case syntax::SyntaxKind::ProgramHeader: {
                 auto& header = node->as<syntax::ModuleHeaderSyntax>();
                 if (header.name == *token) {
-                    return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+                    return SemanticTokenTypeIndex::Class;
                 }
                 break;
             }
             case syntax::SyntaxKind::ClassDeclaration: {
                 auto& decl = node->as<syntax::ClassDeclarationSyntax>();
                 if (decl.name == *token) {
-                    return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+                    return SemanticTokenTypeIndex::Class;
                 }
                 break;
             }
             case syntax::SyntaxKind::HierarchyInstantiation:
             case syntax::SyntaxKind::PrimitiveInstantiation:
             case syntax::SyntaxKind::ClassName:
-                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+                return SemanticTokenTypeIndex::Class;
 
             case syntax::SyntaxKind::DataDeclaration:
             case syntax::SyntaxKind::CheckerDataDeclaration:
@@ -369,63 +367,57 @@ std::optional<lsp::uint> tokenTypeFromSyntaxContext(const parsing::Token* token,
             case syntax::SyntaxKind::ForVariableDeclaration:
             case syntax::SyntaxKind::GenvarDeclaration:
             case syntax::SyntaxKind::LetDeclaration:
-                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Variable);
+                return SemanticTokenTypeIndex::Variable;
 
             default:
                 break;
         }
     }
 
-    return std::nullopt;
+    return SemanticTokenTypeIndex::None;
 }
 
-std::optional<SemanticClassification> classifyToken(const parsing::Token* token,
-                                                    const syntax::SyntaxNode* tokenParent,
-                                                    const SymbolIndexer& symbolIndexer) {
+SemanticClassification classifyToken(const parsing::Token* token, const SyntaxIndexer& syntaxes,
+                                     const SymbolIndexer& symbolIndexer) {
     if (!token || token->isMissing() || token->kind == parsing::TokenKind::Placeholder ||
         token->kind == parsing::TokenKind::EndOfFile) {
-        return std::nullopt;
+        return {};
     }
 
     if (parsing::LexerFacts::isKeyword(token->kind)) {
-        return SemanticClassification{
-            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Keyword)};
+        return SemanticClassification{.tokenType = SemanticTokenTypeIndex::Keyword};
     }
 
     if (isStringToken(token->kind)) {
-        return SemanticClassification{
-            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::String)};
+        return SemanticClassification{.tokenType = SemanticTokenTypeIndex::String};
     }
 
     if (isNumberToken(token->kind)) {
-        return SemanticClassification{
-            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Number)};
+        return SemanticClassification{.tokenType = SemanticTokenTypeIndex::Number};
     }
 
     if (isMacroToken(token->kind)) {
-        return SemanticClassification{
-            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Macro)};
+        return SemanticClassification{.tokenType = SemanticTokenTypeIndex::Macro};
     }
 
     if (token->kind == parsing::TokenKind::SystemIdentifier) {
-        SemanticClassification classification{
-            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Function)};
+        SemanticClassification classification{.tokenType = SemanticTokenTypeIndex::Function};
         addModifier(classification.tokenModifiers, SemanticTokenModifierIndex::DefaultLibrary);
         return classification;
     }
 
     if (isOperatorToken(token->kind)) {
-        return SemanticClassification{
-            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Operator)};
+        return SemanticClassification{.tokenType = SemanticTokenTypeIndex::Operator};
     }
 
     if (token->kind != parsing::TokenKind::Identifier) {
-        return std::nullopt;
+        return {};
     }
 
     if (auto* symbol = symbolIndexer.getSymbol(token)) {
-        if (auto tokenType = tokenTypeFromSymbolKind(symbol->kind)) {
-            SemanticClassification classification{.tokenType = *tokenType};
+        if (auto tokenType = tokenTypeFromSymbolKind(symbol->kind);
+            tokenType != SemanticTokenTypeIndex::None) {
+            SemanticClassification classification{.tokenType = tokenType};
             addModifier(classification.tokenModifiers, SemanticTokenModifierIndex::Declaration);
             if (symbolIsReadonly(symbol->kind)) {
                 addModifier(classification.tokenModifiers, SemanticTokenModifierIndex::Readonly);
@@ -434,11 +426,10 @@ std::optional<SemanticClassification> classifyToken(const parsing::Token* token,
         }
     }
 
-    if (auto tokenType = tokenTypeFromSyntaxContext(token, tokenParent)) {
-        return SemanticClassification{.tokenType = *tokenType};
-    }
-
-    return std::nullopt;
+    // Only identifiers the symbol index could not resolve get this far, so the parent
+    // lookup is deferred to here rather than paid once per token in the document.
+    return SemanticClassification{
+        .tokenType = tokenTypeFromSyntaxContext(token, syntaxes.getTokenParent(token))};
 }
 
 void appendTokenData(std::vector<lsp::uint>& data, lsp::Position& previousStart,
@@ -451,7 +442,7 @@ void appendTokenData(std::vector<lsp::uint>& data, lsp::Position& previousStart,
     data.push_back(deltaLine);
     data.push_back(deltaCharacter);
     data.push_back(length);
-    data.push_back(classification.tokenType);
+    data.push_back(static_cast<lsp::uint>(classification.tokenType));
     data.push_back(classification.tokenModifiers);
 
     previousStart = start;
@@ -889,9 +880,8 @@ lsp::SemanticTokens ShallowAnalysis::getSemanticTokens() const {
 
     lsp::Position previousStart{.line = 0, .character = 0};
     for (const auto* token : syntaxes.collected) {
-        auto tokenParent = syntaxes.getTokenParent(token);
-        auto classification = classifyToken(token, tokenParent, m_symbolIndexer);
-        if (!classification) {
+        auto classification = classifyToken(token, syntaxes, m_symbolIndexer);
+        if (classification.tokenType == SemanticTokenTypeIndex::None) {
             continue;
         }
 
@@ -901,33 +891,19 @@ lsp::SemanticTokens ShallowAnalysis::getSemanticTokens() const {
         }
 
         appendTokenData(tokens.data, previousStart, range.start,
-                        range.end.character - range.start.character, *classification);
+                        range.end.character - range.start.character, classification);
     }
 
     return tokens;
 }
 
 const std::vector<std::string>& ShallowAnalysis::semanticTokenLegendTypes() {
-    static const std::vector<std::string> legend = [] {
-        std::vector<std::string> values;
-        values.reserve(kSemanticTokenTypes.size());
-        for (auto value : kSemanticTokenTypes) {
-            values.emplace_back(value);
-        }
-        return values;
-    }();
+    static const std::vector<std::string> legend = TokenTypeLegend::strings();
     return legend;
 }
 
 const std::vector<std::string>& ShallowAnalysis::semanticTokenLegendModifiers() {
-    static const std::vector<std::string> legend = [] {
-        std::vector<std::string> values;
-        values.reserve(kSemanticTokenModifiers.size());
-        for (auto value : kSemanticTokenModifiers) {
-            values.emplace_back(value);
-        }
-        return values;
-    }();
+    static const std::vector<std::string> legend = TokenModifierLegend::strings();
     return legend;
 }
 

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -13,6 +13,7 @@
 #include "util/Converters.h"
 #include "util/Logging.h"
 #include "util/SlangExtensions.h"
+#include <array>
 #include <fmt/format.h>
 #include <memory>
 #include <string_view>
@@ -28,6 +29,7 @@
 #include "slang/ast/types/Type.h"
 #include "slang/diagnostics/AnalysisDiags.h"
 #include "slang/driver/Driver.h"
+#include "slang/parsing/LexerFacts.h"
 #include "slang/parsing/Token.h"
 #include "slang/parsing/TokenKind.h"
 #include "slang/syntax/AllSyntax.h"
@@ -56,6 +58,348 @@ static bool symbolsMatch(const ast::Symbol* a, const ast::Symbol* b) {
     }
     return false;
 }
+
+namespace {
+enum class SemanticTokenTypeIndex : lsp::uint {
+    Namespace = 0,
+    Type = 1,
+    Class = 2,
+    Parameter = 3,
+    Variable = 4,
+    Property = 5,
+    EnumMember = 6,
+    Function = 7,
+    Macro = 8,
+    Keyword = 9,
+    String = 10,
+    Number = 11,
+    Operator = 12,
+};
+
+enum class SemanticTokenModifierIndex : lsp::uint {
+    Declaration = 0,
+    Readonly = 1,
+    DefaultLibrary = 2,
+};
+
+constexpr std::array<std::string_view, 13> kSemanticTokenTypes = {
+    "namespace", "type",  "class",   "parameter", "variable", "property", "enumMember",
+    "function",  "macro", "keyword", "string",    "number",   "operator",
+};
+
+constexpr std::array<std::string_view, 3> kSemanticTokenModifiers = {
+    "declaration",
+    "readonly",
+    "defaultLibrary",
+};
+
+struct SemanticClassification {
+    lsp::uint tokenType = 0;
+    lsp::uint tokenModifiers = 0;
+};
+
+constexpr lsp::uint toModifierMask(SemanticTokenModifierIndex modifier) {
+    return 1u << static_cast<lsp::uint>(modifier);
+}
+
+void addModifier(lsp::uint& mask, SemanticTokenModifierIndex modifier) {
+    mask |= toModifierMask(modifier);
+}
+
+bool isStringToken(parsing::TokenKind kind) {
+    return kind == parsing::TokenKind::StringLiteral;
+}
+
+bool isNumberToken(parsing::TokenKind kind) {
+    switch (kind) {
+        case parsing::TokenKind::IntegerLiteral:
+        case parsing::TokenKind::IntegerBase:
+        case parsing::TokenKind::UnbasedUnsizedLiteral:
+        case parsing::TokenKind::RealLiteral:
+        case parsing::TokenKind::TimeLiteral:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool isMacroToken(parsing::TokenKind kind) {
+    switch (kind) {
+        case parsing::TokenKind::Directive:
+        case parsing::TokenKind::MacroUsage:
+        case parsing::TokenKind::MacroQuote:
+        case parsing::TokenKind::MacroTripleQuote:
+        case parsing::TokenKind::MacroEscapedQuote:
+        case parsing::TokenKind::MacroPaste:
+        case parsing::TokenKind::EmptyMacroArgument:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool isOperatorToken(parsing::TokenKind kind) {
+    switch (kind) {
+        case parsing::TokenKind::ColonEquals:
+        case parsing::TokenKind::ColonSlash:
+        case parsing::TokenKind::DoubleColon:
+        case parsing::TokenKind::Slash:
+        case parsing::TokenKind::Star:
+        case parsing::TokenKind::DoubleStar:
+        case parsing::TokenKind::StarArrow:
+        case parsing::TokenKind::Plus:
+        case parsing::TokenKind::DoublePlus:
+        case parsing::TokenKind::PlusColon:
+        case parsing::TokenKind::PlusDivMinus:
+        case parsing::TokenKind::PlusModMinus:
+        case parsing::TokenKind::Minus:
+        case parsing::TokenKind::DoubleMinus:
+        case parsing::TokenKind::MinusColon:
+        case parsing::TokenKind::MinusArrow:
+        case parsing::TokenKind::MinusDoubleArrow:
+        case parsing::TokenKind::Tilde:
+        case parsing::TokenKind::TildeAnd:
+        case parsing::TokenKind::TildeOr:
+        case parsing::TokenKind::TildeXor:
+        case parsing::TokenKind::Question:
+        case parsing::TokenKind::Hash:
+        case parsing::TokenKind::DoubleHash:
+        case parsing::TokenKind::HashMinusHash:
+        case parsing::TokenKind::HashEqualsHash:
+        case parsing::TokenKind::Xor:
+        case parsing::TokenKind::XorTilde:
+        case parsing::TokenKind::Equals:
+        case parsing::TokenKind::DoubleEquals:
+        case parsing::TokenKind::DoubleEqualsQuestion:
+        case parsing::TokenKind::TripleEquals:
+        case parsing::TokenKind::EqualsArrow:
+        case parsing::TokenKind::PlusEqual:
+        case parsing::TokenKind::MinusEqual:
+        case parsing::TokenKind::SlashEqual:
+        case parsing::TokenKind::StarEqual:
+        case parsing::TokenKind::AndEqual:
+        case parsing::TokenKind::OrEqual:
+        case parsing::TokenKind::PercentEqual:
+        case parsing::TokenKind::XorEqual:
+        case parsing::TokenKind::LeftShiftEqual:
+        case parsing::TokenKind::TripleLeftShiftEqual:
+        case parsing::TokenKind::RightShiftEqual:
+        case parsing::TokenKind::TripleRightShiftEqual:
+        case parsing::TokenKind::LeftShift:
+        case parsing::TokenKind::RightShift:
+        case parsing::TokenKind::TripleLeftShift:
+        case parsing::TokenKind::TripleRightShift:
+        case parsing::TokenKind::Exclamation:
+        case parsing::TokenKind::ExclamationEquals:
+        case parsing::TokenKind::ExclamationEqualsQuestion:
+        case parsing::TokenKind::ExclamationDoubleEquals:
+        case parsing::TokenKind::Percent:
+        case parsing::TokenKind::LessThan:
+        case parsing::TokenKind::LessThanEquals:
+        case parsing::TokenKind::LessThanMinusArrow:
+        case parsing::TokenKind::GreaterThan:
+        case parsing::TokenKind::GreaterThanEquals:
+        case parsing::TokenKind::Or:
+        case parsing::TokenKind::DoubleOr:
+        case parsing::TokenKind::OrMinusArrow:
+        case parsing::TokenKind::OrEqualsArrow:
+        case parsing::TokenKind::At:
+        case parsing::TokenKind::DoubleAt:
+        case parsing::TokenKind::And:
+        case parsing::TokenKind::DoubleAnd:
+        case parsing::TokenKind::TripleAnd:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::optional<lsp::uint> tokenTypeFromSymbolKind(ast::SymbolKind kind) {
+    switch (kind) {
+        case ast::SymbolKind::Package:
+        case ast::SymbolKind::ExplicitImport:
+        case ast::SymbolKind::WildcardImport:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Namespace);
+        case ast::SymbolKind::TypeAlias:
+        case ast::SymbolKind::NetType:
+        case ast::SymbolKind::ClassType:
+        case ast::SymbolKind::EnumType:
+        case ast::SymbolKind::PackedStructType:
+        case ast::SymbolKind::UnpackedStructType:
+        case ast::SymbolKind::PackedUnionType:
+        case ast::SymbolKind::UnpackedUnionType:
+        case ast::SymbolKind::TypeRefType:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Type);
+        case ast::SymbolKind::Definition:
+        case ast::SymbolKind::Instance:
+        case ast::SymbolKind::InstanceBody:
+        case ast::SymbolKind::InstanceArray:
+        case ast::SymbolKind::Checker:
+        case ast::SymbolKind::CheckerInstance:
+        case ast::SymbolKind::CheckerInstanceBody:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+        case ast::SymbolKind::Parameter:
+        case ast::SymbolKind::TypeParameter:
+        case ast::SymbolKind::Port:
+        case ast::SymbolKind::MultiPort:
+        case ast::SymbolKind::InterfacePort:
+        case ast::SymbolKind::FormalArgument:
+        case ast::SymbolKind::Specparam:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Parameter);
+        case ast::SymbolKind::Variable:
+        case ast::SymbolKind::Net:
+        case ast::SymbolKind::Genvar:
+        case ast::SymbolKind::LocalAssertionVar:
+        case ast::SymbolKind::PatternVar:
+        case ast::SymbolKind::Iterator:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Variable);
+        case ast::SymbolKind::Field:
+        case ast::SymbolKind::ClassProperty:
+        case ast::SymbolKind::ModportPort:
+        case ast::SymbolKind::ClockVar:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Property);
+        case ast::SymbolKind::EnumValue:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::EnumMember);
+        case ast::SymbolKind::Subroutine:
+        case ast::SymbolKind::MethodPrototype:
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Function);
+        default:
+            return std::nullopt;
+    }
+}
+
+bool symbolIsReadonly(ast::SymbolKind kind) {
+    switch (kind) {
+        case ast::SymbolKind::Parameter:
+        case ast::SymbolKind::TypeParameter:
+        case ast::SymbolKind::Specparam:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::optional<lsp::uint> tokenTypeFromSyntaxContext(const syntax::SyntaxNode* syntax) {
+    for (auto* node = syntax; node; node = node->parent) {
+        auto kindName = toString(node->kind);
+        if (kindName.find("Parameter") != std::string_view::npos ||
+            kindName.find("Port") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Parameter);
+        }
+        if (kindName.find("Typedef") != std::string_view::npos ||
+            kindName.find("Type") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Type);
+        }
+        if (kindName.find("EnumValue") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::EnumMember);
+        }
+        if (kindName.find("Function") != std::string_view::npos ||
+            kindName.find("Task") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Function);
+        }
+        if (kindName.find("Package") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Namespace);
+        }
+        if (kindName.find("Class") != std::string_view::npos ||
+            kindName.find("Module") != std::string_view::npos ||
+            kindName.find("Interface") != std::string_view::npos ||
+            kindName.find("Program") != std::string_view::npos ||
+            kindName.find("Checker") != std::string_view::npos ||
+            kindName.find("Primitive") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+        }
+        if (kindName.find("Member") != std::string_view::npos ||
+            kindName.find("Field") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Property);
+        }
+        if (kindName.find("Variable") != std::string_view::npos ||
+            kindName.find("Declarator") != std::string_view::npos) {
+            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Variable);
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<SemanticClassification> classifyToken(const parsing::Token* token,
+                                                    const syntax::SyntaxNode* tokenParent,
+                                                    const SymbolIndexer& symbolIndexer) {
+    if (!token || token->isMissing() || token->kind == parsing::TokenKind::Placeholder ||
+        token->kind == parsing::TokenKind::EndOfFile) {
+        return std::nullopt;
+    }
+
+    if (parsing::LexerFacts::isKeyword(token->kind)) {
+        return SemanticClassification{
+            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Keyword)};
+    }
+
+    if (isStringToken(token->kind)) {
+        return SemanticClassification{
+            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::String)};
+    }
+
+    if (isNumberToken(token->kind)) {
+        return SemanticClassification{
+            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Number)};
+    }
+
+    if (isMacroToken(token->kind)) {
+        return SemanticClassification{
+            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Macro)};
+    }
+
+    if (token->kind == parsing::TokenKind::SystemIdentifier) {
+        SemanticClassification classification{
+            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Function)};
+        addModifier(classification.tokenModifiers, SemanticTokenModifierIndex::DefaultLibrary);
+        return classification;
+    }
+
+    if (isOperatorToken(token->kind)) {
+        return SemanticClassification{
+            .tokenType = static_cast<lsp::uint>(SemanticTokenTypeIndex::Operator)};
+    }
+
+    if (token->kind != parsing::TokenKind::Identifier) {
+        return std::nullopt;
+    }
+
+    if (auto* symbol = symbolIndexer.getSymbol(token)) {
+        if (auto tokenType = tokenTypeFromSymbolKind(symbol->kind)) {
+            SemanticClassification classification{.tokenType = *tokenType};
+            addModifier(classification.tokenModifiers, SemanticTokenModifierIndex::Declaration);
+            if (symbolIsReadonly(symbol->kind)) {
+                addModifier(classification.tokenModifiers, SemanticTokenModifierIndex::Readonly);
+            }
+            return classification;
+        }
+    }
+
+    if (auto tokenType = tokenTypeFromSyntaxContext(tokenParent)) {
+        return SemanticClassification{.tokenType = *tokenType};
+    }
+
+    return std::nullopt;
+}
+
+void appendTokenData(std::vector<lsp::uint>& data, lsp::Position& previousStart,
+                     lsp::Position start, lsp::uint length,
+                     const SemanticClassification& classification) {
+    auto deltaLine = start.line - previousStart.line;
+    auto deltaCharacter = deltaLine == 0 ? start.character - previousStart.character
+                                         : start.character;
+
+    data.push_back(deltaLine);
+    data.push_back(deltaCharacter);
+    data.push_back(length);
+    data.push_back(classification.tokenType);
+    data.push_back(classification.tokenModifiers);
+
+    previousStart = start;
+}
+} // namespace
+
 ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID buffer,
                                  std::shared_ptr<SyntaxTree> tree, slang::Bag options,
                                  const std::vector<std::shared_ptr<SyntaxTree>>& allTrees) :
@@ -479,6 +823,54 @@ std::vector<lsp::InlayHint> ShallowAnalysis::getInlayHints(lsp::Range range,
     InlayHintCollector collector(*this, range, config);
     collector.collectHints();
     return collector.result;
+}
+
+lsp::SemanticTokens ShallowAnalysis::getSemanticTokens() const {
+    lsp::SemanticTokens tokens;
+    tokens.data.reserve(syntaxes.collected.size() * 5);
+
+    lsp::Position previousStart{.line = 0, .character = 0};
+    for (const auto* token : syntaxes.collected) {
+        auto tokenParent = syntaxes.getTokenParent(token);
+        auto classification = classifyToken(token, tokenParent, m_symbolIndexer);
+        if (!classification) {
+            continue;
+        }
+
+        auto range = toRange(token->range(), m_sourceManager);
+        if (range.start.line != range.end.line || range.end.character <= range.start.character) {
+            continue;
+        }
+
+        appendTokenData(tokens.data, previousStart, range.start,
+                        range.end.character - range.start.character, *classification);
+    }
+
+    return tokens;
+}
+
+const std::vector<std::string>& ShallowAnalysis::semanticTokenLegendTypes() {
+    static const std::vector<std::string> legend = [] {
+        std::vector<std::string> values;
+        values.reserve(kSemanticTokenTypes.size());
+        for (auto value : kSemanticTokenTypes) {
+            values.emplace_back(value);
+        }
+        return values;
+    }();
+    return legend;
+}
+
+const std::vector<std::string>& ShallowAnalysis::semanticTokenLegendModifiers() {
+    static const std::vector<std::string> legend = [] {
+        std::vector<std::string> values;
+        values.reserve(kSemanticTokenModifiers.size());
+        for (auto value : kSemanticTokenModifiers) {
+            values.emplace_back(value);
+        }
+        return values;
+    }();
+    return legend;
 }
 
 void ShallowAnalysis::addLocalReferences(std::vector<lsp::Location>& references,

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -279,42 +279,100 @@ bool symbolIsReadonly(ast::SymbolKind kind) {
     }
 }
 
-std::optional<lsp::uint> tokenTypeFromSyntaxContext(const syntax::SyntaxNode* syntax) {
+bool isTransparentSyntaxKind(syntax::SyntaxKind kind) {
+    switch (kind) {
+        case syntax::SyntaxKind::IdentifierName:
+        case syntax::SyntaxKind::EmptyIdentifierName:
+        case syntax::SyntaxKind::Declarator:
+        case syntax::SyntaxKind::ParameterPortList:
+        case syntax::SyntaxKind::AnsiPortList:
+        case syntax::SyntaxKind::NonAnsiPortList:
+        case syntax::SyntaxKind::WildcardPortList:
+        case syntax::SyntaxKind::FunctionPortList:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::optional<lsp::uint> tokenTypeFromSyntaxContext(const parsing::Token* token,
+                                                    const syntax::SyntaxNode* syntax) {
     for (auto* node = syntax; node; node = node->parent) {
-        auto kindName = toString(node->kind);
-        if (kindName.find("Parameter") != std::string_view::npos ||
-            kindName.find("Port") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Parameter);
+        if (isTransparentSyntaxKind(node->kind)) {
+            continue;
         }
-        if (kindName.find("Typedef") != std::string_view::npos ||
-            kindName.find("Type") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Type);
-        }
-        if (kindName.find("EnumValue") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::EnumMember);
-        }
-        if (kindName.find("Function") != std::string_view::npos ||
-            kindName.find("Task") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Function);
-        }
-        if (kindName.find("Package") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Namespace);
-        }
-        if (kindName.find("Class") != std::string_view::npos ||
-            kindName.find("Module") != std::string_view::npos ||
-            kindName.find("Interface") != std::string_view::npos ||
-            kindName.find("Program") != std::string_view::npos ||
-            kindName.find("Checker") != std::string_view::npos ||
-            kindName.find("Primitive") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
-        }
-        if (kindName.find("Member") != std::string_view::npos ||
-            kindName.find("Field") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Property);
-        }
-        if (kindName.find("Variable") != std::string_view::npos ||
-            kindName.find("Declarator") != std::string_view::npos) {
-            return static_cast<lsp::uint>(SemanticTokenTypeIndex::Variable);
+
+        switch (node->kind) {
+            case syntax::SyntaxKind::ParameterDeclaration:
+            case syntax::SyntaxKind::ParameterDeclarationStatement:
+            case syntax::SyntaxKind::TypeParameterDeclaration:
+            case syntax::SyntaxKind::TypeAssignment:
+            case syntax::SyntaxKind::SpecparamDeclarator:
+            case syntax::SyntaxKind::PortDeclaration:
+            case syntax::SyntaxKind::ImplicitAnsiPort:
+            case syntax::SyntaxKind::ExplicitAnsiPort:
+            case syntax::SyntaxKind::InterfacePortHeader:
+            case syntax::SyntaxKind::NetPortHeader:
+            case syntax::SyntaxKind::VariablePortHeader:
+                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Parameter);
+
+            case syntax::SyntaxKind::TypedefDeclaration:
+            case syntax::SyntaxKind::ForwardTypedefDeclaration:
+            case syntax::SyntaxKind::NamedType:
+            case syntax::SyntaxKind::EnumType:
+                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Type);
+
+            case syntax::SyntaxKind::StructUnionMember:
+            case syntax::SyntaxKind::ClassPropertyDeclaration:
+                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Property);
+
+            case syntax::SyntaxKind::FunctionPrototype:
+            case syntax::SyntaxKind::FunctionDeclaration:
+            case syntax::SyntaxKind::TaskDeclaration:
+            case syntax::SyntaxKind::ClassMethodDeclaration:
+            case syntax::SyntaxKind::ClassMethodPrototype:
+                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Function);
+
+            case syntax::SyntaxKind::PackageHeader: {
+                auto& header = node->as<syntax::ModuleHeaderSyntax>();
+                if (header.name == *token) {
+                    return static_cast<lsp::uint>(SemanticTokenTypeIndex::Namespace);
+                }
+                break;
+            }
+            case syntax::SyntaxKind::ModuleHeader:
+            case syntax::SyntaxKind::InterfaceHeader:
+            case syntax::SyntaxKind::ProgramHeader: {
+                auto& header = node->as<syntax::ModuleHeaderSyntax>();
+                if (header.name == *token) {
+                    return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+                }
+                break;
+            }
+            case syntax::SyntaxKind::ClassDeclaration: {
+                auto& decl = node->as<syntax::ClassDeclarationSyntax>();
+                if (decl.name == *token) {
+                    return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+                }
+                break;
+            }
+            case syntax::SyntaxKind::HierarchyInstantiation:
+            case syntax::SyntaxKind::PrimitiveInstantiation:
+            case syntax::SyntaxKind::ClassName:
+                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Class);
+
+            case syntax::SyntaxKind::DataDeclaration:
+            case syntax::SyntaxKind::CheckerDataDeclaration:
+            case syntax::SyntaxKind::NetDeclaration:
+            case syntax::SyntaxKind::UserDefinedNetDeclaration:
+            case syntax::SyntaxKind::LocalVariableDeclaration:
+            case syntax::SyntaxKind::ForVariableDeclaration:
+            case syntax::SyntaxKind::GenvarDeclaration:
+            case syntax::SyntaxKind::LetDeclaration:
+                return static_cast<lsp::uint>(SemanticTokenTypeIndex::Variable);
+
+            default:
+                break;
         }
     }
 
@@ -376,7 +434,7 @@ std::optional<SemanticClassification> classifyToken(const parsing::Token* token,
         }
     }
 
-    if (auto tokenType = tokenTypeFromSyntaxContext(tokenParent)) {
+    if (auto tokenType = tokenTypeFromSyntaxContext(token, tokenParent)) {
         return SemanticClassification{.tokenType = *tokenType};
     }
 

--- a/tests/cpp/SemanticTokensTests.cpp
+++ b/tests/cpp/SemanticTokensTests.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "document/ShallowAnalysis.h"
+#include "util/Converters.h"
+#include "utils/GoldenTest.h"
+#include "utils/ServerHarness.h"
+#include <algorithm>
+#include <string>
+#include <vector>
+
+struct SemanticTokenInfo {
+    lsp::Range range;
+    std::string text;
+    std::string type;
+    std::vector<std::string> modifiers;
+};
+
+static std::vector<SemanticTokenInfo> decodeSemanticTokens(DocumentHandle& hdl,
+                                                           const lsp::SemanticTokens& tokens) {
+    std::vector<SemanticTokenInfo> decoded;
+    decoded.reserve(tokens.data.size() / 5);
+
+    const auto& typeLegend = server::ShallowAnalysis::semanticTokenLegendTypes();
+    const auto& modifierLegend = server::ShallowAnalysis::semanticTokenLegendModifiers();
+    auto& sm = hdl.doc->getSourceManager();
+
+    lsp::uint line = 0;
+    lsp::uint character = 0;
+    for (size_t i = 0; i + 4 < tokens.data.size(); i += 5) {
+        auto deltaLine = tokens.data[i];
+        auto deltaCharacter = tokens.data[i + 1];
+        auto length = tokens.data[i + 2];
+        auto typeIndex = tokens.data[i + 3];
+        auto modifierMask = tokens.data[i + 4];
+
+        line += deltaLine;
+        if (deltaLine == 0) {
+            character += deltaCharacter;
+        }
+        else {
+            character = deltaCharacter;
+        }
+
+        lsp::Position start{.line = line, .character = character};
+        lsp::Position end{.line = line, .character = character + length};
+        lsp::Range range{.start = start, .end = end};
+
+        std::vector<std::string> modifiers;
+        for (lsp::uint bit = 0; bit < modifierLegend.size(); bit++) {
+            if ((modifierMask & (1u << bit)) != 0) {
+                modifiers.push_back(modifierLegend[bit]);
+            }
+        }
+
+        std::string text;
+        auto startLoc = server::toSourceLocation(hdl.doc->getBuffer(), start, sm);
+        if (startLoc) {
+            text = std::string(sm.getSourceText(
+                slang::SourceRange(*startLoc, *startLoc + static_cast<size_t>(length))));
+        }
+
+        std::string tokenType = typeIndex < typeLegend.size() ? typeLegend[typeIndex] : "unknown";
+        decoded.push_back(SemanticTokenInfo{
+            .range = range,
+            .text = std::move(text),
+            .type = std::move(tokenType),
+            .modifiers = std::move(modifiers),
+        });
+    }
+
+    return decoded;
+}
+
+static bool hasModifier(const SemanticTokenInfo& token, std::string_view modifier) {
+    return std::find(token.modifiers.begin(), token.modifiers.end(), modifier) !=
+           token.modifiers.end();
+}
+
+TEST_CASE("SemanticTokens_Phase1") {
+    ServerHarness server;
+    auto hdl = server.openFile("semantic_tokens_phase1.sv", R"(
+module m #(
+    parameter int WIDTH = 4,
+    parameter type ENTRY_T = logic
+);
+    typedef logic [31:0] word_t;
+    word_t addr;
+
+    function automatic word_t f(input word_t x);
+        return x + WIDTH;
+    endfunction
+
+    initial begin
+        word_t y = f(addr);
+        $display("%0d", y);
+    end
+endmodule
+)");
+
+    auto maybeTokens = server.getDocSemanticTokensFull(lsp::SemanticTokensParams{
+        .textDocument = {.uri = hdl.m_uri},
+    });
+
+    REQUIRE(maybeTokens.has_value());
+    auto decoded = decodeSemanticTokens(hdl, *maybeTokens);
+    REQUIRE_FALSE(decoded.empty());
+
+    auto findByText = [&](std::string_view text, std::string_view type) {
+        return std::find_if(decoded.begin(), decoded.end(), [&](const SemanticTokenInfo& token) {
+            return token.text == text && token.type == type;
+        });
+    };
+
+    auto width = findByText("WIDTH", "parameter");
+    REQUIRE(width != decoded.end());
+    CHECK(hasModifier(*width, "declaration"));
+    CHECK(hasModifier(*width, "readonly"));
+
+    auto typedefName = findByText("word_t", "type");
+    REQUIRE(typedefName != decoded.end());
+    CHECK(hasModifier(*typedefName, "declaration"));
+
+    auto systemTask = findByText("$display", "function");
+    REQUIRE(systemTask != decoded.end());
+    CHECK(hasModifier(*systemTask, "defaultLibrary"));
+
+    JsonGoldenTest golden;
+    golden.record(decoded);
+}

--- a/tests/cpp/SemanticTokensTests.cpp
+++ b/tests/cpp/SemanticTokensTests.cpp
@@ -79,6 +79,7 @@ static bool hasModifier(const SemanticTokenInfo& token, std::string_view modifie
 
 TEST_CASE("SemanticTokens_Phase1") {
     ServerHarness server;
+    server.m_config.semanticTokens.get().enabled = true;
     auto hdl = server.openFile("semantic_tokens_phase1.sv", R"(
 module m #(
     parameter int WIDTH = 4,
@@ -127,4 +128,25 @@ endmodule
 
     JsonGoldenTest golden;
     golden.record(decoded);
+}
+
+TEST_CASE("SemanticTokens_DisabledByDefault") {
+    ServerHarness server;
+    auto hdl = server.openFile("semantic_tokens_disabled.sv", R"(
+module m;
+    logic a;
+endmodule
+)");
+
+    auto tokens = server.getDocSemanticTokensFull(lsp::SemanticTokensParams{
+        .textDocument = {.uri = hdl.m_uri},
+    });
+    CHECK_FALSE(tokens.has_value());
+
+    server.m_config.semanticTokens.get().enabled = true;
+    auto enabled = server.getDocSemanticTokensFull(lsp::SemanticTokensParams{
+        .textDocument = {.uri = hdl.m_uri},
+    });
+    REQUIRE(enabled.has_value());
+    CHECK_FALSE(enabled->data.empty());
 }

--- a/tests/cpp/golden/SemanticTokens_Phase1.json
+++ b/tests/cpp/golden/SemanticTokens_Phase1.json
@@ -637,21 +637,6 @@
     {
       "range": {
         "start": {
-          "line": 14,
-          "character": 24
-        },
-        "end": {
-          "line": 14,
-          "character": 25
-        }
-      },
-      "text": "y",
-      "type": "class",
-      "modifiers": []
-    },
-    {
-      "range": {
-        "start": {
           "line": 15,
           "character": 4
         },

--- a/tests/cpp/golden/SemanticTokens_Phase1.json
+++ b/tests/cpp/golden/SemanticTokens_Phase1.json
@@ -1,0 +1,683 @@
+[
+  [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 6
+        }
+      },
+      "text": "module",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 7
+        },
+        "end": {
+          "line": 1,
+          "character": 8
+        }
+      },
+      "text": "m",
+      "type": "class",
+      "modifiers": [
+        "declaration"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 9
+        },
+        "end": {
+          "line": 1,
+          "character": 10
+        }
+      },
+      "text": "#",
+      "type": "operator",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 4
+        },
+        "end": {
+          "line": 2,
+          "character": 13
+        }
+      },
+      "text": "parameter",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 14
+        },
+        "end": {
+          "line": 2,
+          "character": 17
+        }
+      },
+      "text": "int",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 18
+        },
+        "end": {
+          "line": 2,
+          "character": 23
+        }
+      },
+      "text": "WIDTH",
+      "type": "parameter",
+      "modifiers": [
+        "declaration",
+        "readonly"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 24
+        },
+        "end": {
+          "line": 2,
+          "character": 25
+        }
+      },
+      "text": "=",
+      "type": "operator",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 26
+        },
+        "end": {
+          "line": 2,
+          "character": 27
+        }
+      },
+      "text": "4",
+      "type": "number",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 4
+        },
+        "end": {
+          "line": 3,
+          "character": 13
+        }
+      },
+      "text": "parameter",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 14
+        },
+        "end": {
+          "line": 3,
+          "character": 18
+        }
+      },
+      "text": "type",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 19
+        },
+        "end": {
+          "line": 3,
+          "character": 26
+        }
+      },
+      "text": "ENTRY_T",
+      "type": "type",
+      "modifiers": [
+        "declaration"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 27
+        },
+        "end": {
+          "line": 3,
+          "character": 28
+        }
+      },
+      "text": "=",
+      "type": "operator",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 29
+        },
+        "end": {
+          "line": 3,
+          "character": 34
+        }
+      },
+      "text": "logic",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 4
+        },
+        "end": {
+          "line": 5,
+          "character": 11
+        }
+      },
+      "text": "typedef",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 12
+        },
+        "end": {
+          "line": 5,
+          "character": 17
+        }
+      },
+      "text": "logic",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 19
+        },
+        "end": {
+          "line": 5,
+          "character": 21
+        }
+      },
+      "text": "31",
+      "type": "number",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 22
+        },
+        "end": {
+          "line": 5,
+          "character": 23
+        }
+      },
+      "text": "0",
+      "type": "number",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 25
+        },
+        "end": {
+          "line": 5,
+          "character": 31
+        }
+      },
+      "text": "word_t",
+      "type": "type",
+      "modifiers": [
+        "declaration"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 4
+        },
+        "end": {
+          "line": 6,
+          "character": 10
+        }
+      },
+      "text": "word_t",
+      "type": "type",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 11
+        },
+        "end": {
+          "line": 6,
+          "character": 15
+        }
+      },
+      "text": "addr",
+      "type": "variable",
+      "modifiers": [
+        "declaration"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 4
+        },
+        "end": {
+          "line": 8,
+          "character": 12
+        }
+      },
+      "text": "function",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 13
+        },
+        "end": {
+          "line": 8,
+          "character": 22
+        }
+      },
+      "text": "automatic",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 23
+        },
+        "end": {
+          "line": 8,
+          "character": 29
+        }
+      },
+      "text": "word_t",
+      "type": "type",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 30
+        },
+        "end": {
+          "line": 8,
+          "character": 31
+        }
+      },
+      "text": "f",
+      "type": "function",
+      "modifiers": [
+        "declaration"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 32
+        },
+        "end": {
+          "line": 8,
+          "character": 37
+        }
+      },
+      "text": "input",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 38
+        },
+        "end": {
+          "line": 8,
+          "character": 44
+        }
+      },
+      "text": "word_t",
+      "type": "type",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 45
+        },
+        "end": {
+          "line": 8,
+          "character": 46
+        }
+      },
+      "text": "x",
+      "type": "parameter",
+      "modifiers": [
+        "declaration"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 8
+        },
+        "end": {
+          "line": 9,
+          "character": 14
+        }
+      },
+      "text": "return",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 15
+        },
+        "end": {
+          "line": 9,
+          "character": 16
+        }
+      },
+      "text": "x",
+      "type": "function",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 17
+        },
+        "end": {
+          "line": 9,
+          "character": 18
+        }
+      },
+      "text": "+",
+      "type": "operator",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 19
+        },
+        "end": {
+          "line": 9,
+          "character": 24
+        }
+      },
+      "text": "WIDTH",
+      "type": "function",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 4
+        },
+        "end": {
+          "line": 10,
+          "character": 15
+        }
+      },
+      "text": "endfunction",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 4
+        },
+        "end": {
+          "line": 12,
+          "character": 11
+        }
+      },
+      "text": "initial",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 12
+        },
+        "end": {
+          "line": 12,
+          "character": 17
+        }
+      },
+      "text": "begin",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 8
+        },
+        "end": {
+          "line": 13,
+          "character": 14
+        }
+      },
+      "text": "word_t",
+      "type": "type",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 15
+        },
+        "end": {
+          "line": 13,
+          "character": 16
+        }
+      },
+      "text": "y",
+      "type": "variable",
+      "modifiers": [
+        "declaration"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 17
+        },
+        "end": {
+          "line": 13,
+          "character": 18
+        }
+      },
+      "text": "=",
+      "type": "operator",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 19
+        },
+        "end": {
+          "line": 13,
+          "character": 20
+        }
+      },
+      "text": "f",
+      "type": "variable",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 21
+        },
+        "end": {
+          "line": 13,
+          "character": 25
+        }
+      },
+      "text": "addr",
+      "type": "variable",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 8
+        },
+        "end": {
+          "line": 14,
+          "character": 16
+        }
+      },
+      "text": "$display",
+      "type": "function",
+      "modifiers": [
+        "defaultLibrary"
+      ]
+    },
+    {
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 17
+        },
+        "end": {
+          "line": 14,
+          "character": 22
+        }
+      },
+      "text": "\"%0d\"",
+      "type": "string",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 24
+        },
+        "end": {
+          "line": 14,
+          "character": 25
+        }
+      },
+      "text": "y",
+      "type": "class",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 4
+        },
+        "end": {
+          "line": 15,
+          "character": 7
+        }
+      },
+      "text": "end",
+      "type": "keyword",
+      "modifiers": []
+    },
+    {
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 16,
+          "character": 9
+        }
+      },
+      "text": "endmodule",
+      "type": "keyword",
+      "modifiers": []
+    }
+  ]
+]

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -98,6 +98,9 @@ public:
 
     // For access to indexer in tests
     using SlangServer::m_indexer;
+
+    // For toggling opt-in features that config normally gates
+    using SlangServer::m_config;
 };
 
 enum DocState {


### PR DESCRIPTION
## Summary
- add Phase 1 LSP semantic tokens: classify slang tokens using `TokenKind` + declaration/`SyntaxIndexer` context (no eager full-document symbol resolution on edit).
- Advertise `textDocument/semanticTokens/full` and return delta-encoded tokens from `ShallowAnalysis`.
- Golden-test the high-value cases TextMate gets wrong: parameters, typedef names, system tasks.
- Parent-syntax fallback uses an explicit `SyntaxKind` switch (not string matching on kind names). Declaration containers like `ModuleHeader` / `ClassDeclaration` only classify when the token is that declaration’s name.
## Motivation
Syntax highlighting today is client TextMate. That fails for user types (`word_t`), parameters (`WIDTH`, `ENTRY_T`), and similar cases (#268). Semantic tokens let the server, which already has slang’s tokenizer and shallow analysis, drive accurate highlighting.
## Approach (overall roadmap)
**Phase 1 (this PR)**: declaration-aware classification
- Walk existing `SyntaxIndexer::collected` (request path only).
- Lexical map: keyword / number / string / operator / macro.
- Identifiers: `SymbolIndexer` for declarations in-buffer, explicit `SyntaxKind` parent walk as fallback.
- Keep TextMate. Semantic tokens augment (client theme still owns colors).
**Phase 2**: Real semantics on references
- `getSymbolAtToken` for uses (`pkg::thing`, typedef uses, etc.).
- Richer modifiers, optional range/delta, request cancellation if analysis is mid-rebuild.
## Efficiency notes
- Does **not** classify on `onChange`. Analysis is still invalidated as today and rebuilt lazily.
- Token stream is a single linear pass over already-collected tokens + O(1) declaration map lookups.
- Syntax fallback is an enum switch over kinds, not string search on kind names.
## Test plan
- [x] `build/bin/server_unittests SemanticTokens_Phase1`
- [ ] Spot-check in editor: typedef / parameter names pick up semantic colors while TextMate still handles punctuation
- [ ] Confirm typing latency unchanged (tokens only computed on semantic-token requests)
Partially addresses #268