### PR TITLE
Bump slang with some fixes

### DIFF
--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -287,7 +287,7 @@ void appendSourceLink(markup::Paragraph& paragraph, SourceLocation location,
     if (path.empty())
         return;
 
-    const auto line = sourceManager.getLineNumber(originalLoc);
+    const auto line = sourceManager.getRawLineNumber(originalLoc);
     const auto column = sourceManager.getColumnNumber(originalLoc);
     const auto label = fmt::format("{}:{}:{}", path.filename().string(), line, column);
     const auto target = fmt::format("{}#L{},{}", URI::fromFile(path), line, column);

--- a/src/document/InlayHintCollector.cpp
+++ b/src/document/InlayHintCollector.cpp
@@ -188,7 +188,7 @@ void InlayHintCollector::handle(const HierarchyInstantiationSyntax& syntax) {
                                     FORMATTING_INDENT - 1;
 
                     auto getLine = [&](const auto& loc) {
-                        return m_analysis.m_sourceManager.getLineNumber(loc);
+                        return m_analysis.m_sourceManager.getRawLineNumber(loc);
                     };
 
                     if (getLine(instanceSyntax->openParen.location()) ==

--- a/src/util/Converters.cpp
+++ b/src/util/Converters.cpp
@@ -40,8 +40,10 @@ std::optional<const parsing::Token> findNameToken(const syntax::SyntaxNode* node
 }
 
 lsp::Position toPosition(const SourceLocation& loc, const SourceManager& sourceManager) {
-    auto character = sourceManager.getColumnNumber(loc);
-    return lsp::Position{.line = static_cast<lsp::uint>(sourceManager.getLineNumber(loc) - 1),
+    auto actualLoc = sourceManager.getFullyExpandedLoc(loc);
+    auto character = sourceManager.getColumnNumber(actualLoc);
+    return lsp::Position{.line = static_cast<lsp::uint>(sourceManager.getRawLineNumber(actualLoc) -
+                                                        1),
                          .character = static_cast<lsp::uint>(character > 0 ? character - 1 : 0)};
 }
 
@@ -51,8 +53,9 @@ std::optional<SourceLocation> toSourceLocation(BufferID buffer, const lsp::Posit
 }
 
 lsp::Range toRange(const SourceRange& range, const SourceManager& sourceManager) {
-    return lsp::Range{.start = toPosition(range.start(), sourceManager),
-                      .end = toPosition(range.end(), sourceManager)};
+    auto actualRange = sourceManager.getFullyExpandedRange(range);
+    return lsp::Range{.start = toPosition(actualRange.start(), sourceManager),
+                      .end = toPosition(actualRange.end(), sourceManager)};
 }
 
 lsp::Location toOriginalLocation(const SourceRange& range, const SourceManager& sourceManager) {
@@ -66,9 +69,7 @@ lsp::Location toOriginalLocation(const SourceRange& range, const SourceManager& 
 lsp::Range toRange(const SourceLocation& loc, const SourceManager& sourceManager,
                    const size_t length) {
 
-    auto character = sourceManager.getColumnNumber(loc);
-    lsp::Position start{.line = static_cast<lsp::uint>(sourceManager.getLineNumber(loc) - 1),
-                        .character = static_cast<lsp::uint>(character > 0 ? character - 1 : 0)};
+    auto start = toPosition(loc, sourceManager);
     lsp::Position end{start};
     end.character += length;
     return lsp::Range{.start = start, .end = end};

--- a/tests/cpp/ConverterTests.cpp
+++ b/tests/cpp/ConverterTests.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "util/Converters.h"
+#include <catch2/catch_test_macros.hpp>
+
+#include "slang/text/SourceManager.h"
+
+TEST_CASE("LSP positions use raw source lines") {
+    slang::SourceManager sourceManager;
+    auto buffer = sourceManager.assignText("source.sv", "first\n`line\nthird\n");
+    REQUIRE(buffer);
+
+    auto directive = sourceManager.getSourceLocation(buffer.id, 2, 1);
+    auto location = sourceManager.getSourceLocation(buffer.id, 3, 3);
+    REQUIRE(directive);
+    REQUIRE(location);
+    sourceManager.addLineDirective(*directive, 100, "mapped.sv", 0);
+
+    CHECK(sourceManager.getLineNumber(*location) == 100);
+    auto position = server::toPosition(*location, sourceManager);
+    CHECK(position.line == 2);
+    CHECK(position.character == 2);
+
+    auto range = server::toRange(*location, sourceManager, 2);
+    CHECK(range.start.line == 2);
+    CHECK(range.start.character == 2);
+    CHECK(range.end.line == 2);
+    CHECK(range.end.character == 4);
+}
+
+TEST_CASE("LSP positions resolve macro locations") {
+    slang::SourceManager sourceManager;
+    auto buffer = sourceManager.assignText("source.sv", "first\nmacro(D)\n");
+    REQUIRE(buffer);
+
+    auto location = sourceManager.getSourceLocation(buffer.id, 2, 7);
+    REQUIRE(location);
+    slang::SourceRange expansionRange(*location, *location + 1);
+    auto macroLocation = sourceManager.createExpansionLoc(*location, expansionRange, "M");
+
+    CHECK(sourceManager.getRawLineNumber(macroLocation) == 0);
+    auto position = server::toPosition(macroLocation, sourceManager);
+    CHECK(position.line == 1);
+    CHECK(position.character == 6);
+
+    auto range = server::toRange(slang::SourceRange(macroLocation, macroLocation + 1),
+                                 sourceManager);
+    CHECK(range.start.line == 1);
+    CHECK(range.start.character == 6);
+    CHECK(range.end.line == 1);
+    CHECK(range.end.character == 7);
+
+    auto lengthRange = server::toRange(macroLocation, sourceManager, 1);
+    CHECK(lengthRange.start.line == 1);
+    CHECK(lengthRange.start.character == 6);
+    CHECK(lengthRange.end.line == 1);
+    CHECK(lengthRange.end.character == 7);
+}

--- a/tests/cpp/DiagTests.cpp
+++ b/tests/cpp/DiagTests.cpp
@@ -53,6 +53,21 @@ endmodule
     golden.record(doc.getDiagnostics());
 }
 
+TEST_CASE("LineDirectiveDiagnosticsUseBufferPositions") {
+    ServerHarness server;
+    auto doc = server.openFile("line_directive_diag.sv", R"(`line 100 "mapped.sv" 0
+module top;
+    localparam int value = 1;
+    invalid
+endmodule
+)");
+
+    auto diags = doc.getDiagnostics();
+    REQUIRE_FALSE(diags.empty());
+    for (const auto& diag : diags)
+        CHECK(diag.range.start.line < 5);
+}
+
 TEST_CASE("DiagsPublishedOnOpenCachedDoc") {
     ServerHarness server("cached_dep");
 

--- a/tests/cpp/InlayHintTests.cpp
+++ b/tests/cpp/InlayHintTests.cpp
@@ -4,6 +4,7 @@
 #include "utils/GoldenTest.h"
 #include "utils/InlayHintScanner.h"
 #include "utils/ServerHarness.h"
+#include <algorithm>
 
 using namespace slang;
 
@@ -125,6 +126,34 @@ endmodule
 
     InlayHintScanner scanner;
     scanner.scanDocument(hdl);
+}
+
+TEST_CASE("InlayHintsLineDirectivesUseBufferPositions") {
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_line_directive.sv", R"(module receiver(
+    input logic clk
+);
+endmodule
+
+module top;
+    logic clk;
+    receiver u_rx(
+`line 8 "mapped.sv" 0
+        .*
+    );
+endmodule
+)");
+
+    auto hints = hdl.getAllInlayHints();
+    auto hint = std::ranges::find_if(hints, [](const auto& item) {
+        return item.textEdits && !item.textEdits->empty();
+    });
+    REQUIRE(hint != hints.end());
+    CHECK(hint->position.line == 9);
+
+    const auto& edit = hint->textEdits->front();
+    CHECK(edit.range.start.line == 9);
+    CHECK_FALSE(edit.newText.starts_with('\n'));
 }
 
 TEST_CASE("InlayHintsParameters") {

--- a/tests/cpp/utils/ServerHarness.cpp
+++ b/tests/cpp/utils/ServerHarness.cpp
@@ -481,7 +481,7 @@ std::optional<lsp::Position> DocumentHandle::getLspLocation(lsp::uint offset) {
     auto loc = getLocation(offset);
     if (!loc)
         return std::nullopt;
-    auto line = m_server.sourceManager().getLineNumber(*loc);
+    auto line = m_server.sourceManager().getRawLineNumber(*loc);
     auto col = m_server.sourceManager().getColumnNumber(*loc);
     return lsp::Position{static_cast<lsp::uint>(line - 1), static_cast<lsp::uint>(col - 1)};
 }

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -283,9 +283,9 @@ public:
         for (lsp::uint offset = 0; offset < data.size() - 1; offset++) {
             auto locOpt = hdl.getLocation(offset);
             auto loc = *locOpt;
-            auto line = sm.getLineNumber(loc);
+            auto line = sm.getRawLineNumber(loc);
 
-            bool newLine = line != sm.getLineNumber(prevLoc);
+            bool newLine = line != sm.getRawLineNumber(prevLoc);
 
             // Get current element
             std::optional<std::variant<ElementT, std::string>> currentElement;


### PR DESCRIPTION

- Picks up mimalloc bump to address crash on newer libc - https://github.com/hudson-trading/slang-server/issues/434
- Location/Range conversions now ignore line directives- https://github.com/hudson-trading/slang-server/issues/424
- Picks up fix for diag ranges from macro concat tokens
