### PR TITLE
SymbolIndexer: fix gen array warnings in logs

### DIFF
--- a/include/document/SymbolIndexer.h
+++ b/include/document/SymbolIndexer.h
@@ -64,9 +64,11 @@ public:
     void handle(const slang::ast::InstanceArraySymbol& sym);
 
     void handle(const slang::ast::GenerateBlockSymbol& sym) {
-        if (!sym.isUnnamed) {
-            indexSymbolName(sym);
-        }
+        indexSymbolName(sym, sym.isUnnamed);
+        visitDefault(sym);
+    }
+    void handle(const slang::ast::GenerateBlockArraySymbol& sym) {
+        indexSymbolName(sym, sym.isUnnamed);
         visitDefault(sym);
     }
 
@@ -99,7 +101,7 @@ private:
                              const slang::ast::InstanceBodySymbol& instanceSymbol,
                              const slang::ast::DefinitionSymbol& definition);
 
-    void indexSymbolName(const slang::ast::Symbol& symbol);
+    void indexSymbolName(const slang::ast::Symbol& symbol, bool isUnnamed = false);
 };
 
 } // namespace server

--- a/src/document/SymbolIndexer.cpp
+++ b/src/document/SymbolIndexer.cpp
@@ -154,15 +154,16 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
     }
 }
 
-void SymbolIndexer::indexSymbolName(const slang::ast::Symbol& symbol) {
+void SymbolIndexer::indexSymbolName(const slang::ast::Symbol& symbol, bool isUnnamed) {
     if (symbol.getSyntax() != nullptr) {
         syntex[symbol.getSyntax()] = &symbol;
 
         auto& syntax = *symbol.getSyntax();
-        if (syntax.sourceRange().start().buffer() == m_buffer && !symbol.name.empty()) {
+        if (!isUnnamed && syntax.sourceRange().start().buffer() == m_buffer &&
+            !symbol.name.empty()) {
             SmallVector<const parsing::Token*> tokens;
             findNames(tokens, symbol.name, syntax);
-            if (tokens.size() == 0) {
+            if (tokens.empty()) {
                 // We want to avoid this case, since we may recurse through many layers
                 WARN("No tokens found for symbol '{} : {}' with syntax kind {}", symbol.name,
                      toString(symbol.kind), toString(syntax.kind));

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -543,7 +543,7 @@ macromodule m3;
                                ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\\n\\n\---\n\\n\`i`
 
         if (i == 7) begin
-            ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\\n\\n\---\n\\n\`i`
+            ^ Ref -> **Parameter** `i` in `m3.genblk1`  \n\Type: `integer`  \n\Value: `8`  \n\\n\\n\---\n\\n\`i`
 
         end
 


### PR DESCRIPTION
Stacked PRs:
 * #446
 * #442
 * #441
 * #440
 * __->__#439


--- --- ---

### SymbolIndexer: fix gen array warnings in logs


We still want to index the syntax -> symbol here for scope lookups, just don't need to search for the name token
