### PR TITLE
Add request latency instrumentation and microbench

### DIFF
--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -12,7 +12,6 @@
 #include "lsp/LspTypes.h"
 #include "rfl/Generic.hpp"
 #include "util/Timing.h"
-#include <chrono>
 #include <concepts>
 #include <cstdint>
 #include <fmt/format.h>
@@ -160,7 +159,7 @@ protected:
             // Notification
             auto it = notifications.find(request.method);
             if (it != notifications.end()) {
-                const auto start = std::chrono::steady_clock::now();
+                ScopedElapsedMs elapsed(timing.ms);
                 try {
                     if (request.params.has_value()) {
                         it->second(request.params.value());
@@ -168,11 +167,9 @@ protected:
                     else {
                         it->second(std::nullopt);
                     }
-                    timing.ms = elapsedMs(start);
                     timing.kind = HandlerTiming::Kind::NotificationOk;
                 }
                 catch (const std::exception& e) {
-                    timing.ms = elapsedMs(start);
                     timing.error = e.what();
                     timing.kind = HandlerTiming::Kind::NotificationError;
                 }
@@ -205,7 +202,7 @@ protected:
         auto it = requests.find(request.method);
 
         if (it != requests.end()) {
-            const auto start = std::chrono::steady_clock::now();
+            ScopedElapsedMs elapsed(timing.ms);
             try {
                 rfl::Generic req_response;
                 if (request.params.has_value()) {
@@ -214,12 +211,10 @@ protected:
                 else {
                     req_response = it->second(rfl::Generic{});
                 }
-                timing.ms = elapsedMs(start);
                 timing.kind = HandlerTiming::Kind::RequestOk;
                 return req_response;
             }
             catch (const std::exception& e) {
-                timing.ms = elapsedMs(start);
                 timing.error = e.what();
                 timing.kind = HandlerTiming::Kind::RequestError;
                 return RpcError{.code = 1, .message = e.what()};

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -21,6 +21,7 @@
 #include <rfl/json/write.hpp>
 #include <rfl/visit.hpp>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 
@@ -41,9 +42,13 @@ struct HandlerTiming {
     };
 
     Kind kind = Kind::None;
-    std::string method;
-    std::string id;
+    /// Views into the request still alive in @c handleMessage.
+    std::string_view method;
+    std::string_view id;
+    /// Owned: @c exception::what() does not outlive the catch block.
     std::string error;
+    /// Backing store when the request id is an int.
+    std::string idStorage;
     double ms = 0;
 };
 
@@ -151,7 +156,8 @@ protected:
 
     /// Run the handler with no logging. Caller must hold @c mutex for stdout
     /// sends; format @p timing only after releasing it.
-    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(RpcRequest request,
+    /// @p request must outlive @p timing.method (and logging after unlock).
+    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(const RpcRequest& request,
                                                                         HandlerTiming& timing) {
         timing.method = request.method;
 
@@ -184,14 +190,15 @@ protected:
         }
 
         // Request
-        timing.id = rfl::visit(
-            [&](auto&& id_) -> std::string {
+        rfl::visit(
+            [&](auto&& id_) {
                 using T = typename std::decay_t<decltype(id_)>;
                 if constexpr (std::is_same_v<T, int>) {
-                    return std::to_string(id_);
+                    timing.idStorage = std::to_string(id_);
+                    timing.id = timing.idStorage;
                 }
                 else if constexpr (std::is_same_v<T, std::string>) {
-                    return id_;
+                    timing.id = id_;
                 }
                 else {
                     static_assert(rfl::always_false_v<T>, "Not all cases were covered.");

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -49,32 +49,45 @@ struct HandlerTiming {
 };
 
 inline void logHandlerTiming(const HandlerTiming& timing) {
+    if (timing.kind == HandlerTiming::Kind::None)
+        return;
+
+    std::string body;
+    bool timed = false;
     switch (timing.kind) {
         case HandlerTiming::Kind::None:
-            break;
+            return;
         case HandlerTiming::Kind::NotificationOk:
-            fmt::print(stderr, "<--- {}\n---- {} ({:.3f}ms)\n\n", timing.method, timing.method,
-                       timing.ms);
+            body = fmt::format("<--- {}\n---- {}", timing.method, timing.method);
+            timed = true;
             break;
         case HandlerTiming::Kind::NotificationError:
-            fmt::print(stderr, "<--- {}\n-/-> {} Error: {} ({:.3f}ms)\n\n", timing.method,
-                       timing.method, timing.error, timing.ms);
+            body = fmt::format("<--- {}\n-/-> {} Error: {}", timing.method, timing.method,
+                               timing.error);
+            timed = true;
             break;
         case HandlerTiming::Kind::RequestOk:
-            fmt::print(stderr, "<--- {} {}\n---> {} {} ({:.3f}ms)\n\n", timing.method, timing.id,
-                       timing.method, timing.id, timing.ms);
+            body = fmt::format("<--- {} {}\n---> {} {}", timing.method, timing.id, timing.method,
+                               timing.id);
+            timed = true;
             break;
         case HandlerTiming::Kind::RequestError:
-            fmt::print(stderr, "<--- {} {}\n-/-> {} {} Error: {} ({:.3f}ms)\n\n", timing.method,
-                       timing.id, timing.method, timing.id, timing.error, timing.ms);
+            body = fmt::format("<--- {} {}\n-/-> {} {} Error: {}", timing.method, timing.id,
+                               timing.method, timing.id, timing.error);
+            timed = true;
             break;
         case HandlerTiming::Kind::Ignored:
-            fmt::print(stderr, "<-/- {} (ignoring threaded req)\n\n", timing.method);
+            body = fmt::format("<-/- {} (ignoring threaded req)", timing.method);
             break;
         case HandlerTiming::Kind::NotFound:
-            fmt::print(stderr, "<-/- {} (not found)\n\n", timing.method);
+            body = fmt::format("<-/- {} (not found)", timing.method);
             break;
     }
+
+    if (timed)
+        fmt::print(stderr, "{} ({:.3f}ms)\n\n", body, timing.ms);
+    else
+        fmt::print(stderr, "{}\n\n", body);
 }
 } // namespace
 

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -11,9 +11,12 @@
 #include "JsonRpc.h"
 #include "lsp/LspTypes.h"
 #include "rfl/Generic.hpp"
+#include "util/Timing.h"
+#include <chrono>
 #include <concepts>
+#include <cstdint>
+#include <fmt/format.h>
 #include <functional>
-#include <iostream>
 #include <mutex>
 #include <optional>
 #include <rfl/json/write.hpp>
@@ -23,6 +26,57 @@
 #include <variant>
 
 namespace lsp {
+
+namespace {
+/// Captured under the RPC mutex; formatted only after unlock so logging I/O is
+/// not serialized onto the critical path.
+struct HandlerTiming {
+    enum class Kind : uint8_t {
+        None,
+        NotificationOk,
+        NotificationError,
+        RequestOk,
+        RequestError,
+        Ignored,
+        NotFound,
+    };
+
+    Kind kind = Kind::None;
+    std::string method;
+    std::string id;
+    std::string error;
+    double ms = 0;
+};
+
+inline void logHandlerTiming(const HandlerTiming& timing) {
+    switch (timing.kind) {
+        case HandlerTiming::Kind::None:
+            break;
+        case HandlerTiming::Kind::NotificationOk:
+            fmt::print(stderr, "<--- {}\n---- {} ({:.3f}ms)\n\n", timing.method, timing.method,
+                       timing.ms);
+            break;
+        case HandlerTiming::Kind::NotificationError:
+            fmt::print(stderr, "<--- {}\n-/-> {} Error: {} ({:.3f}ms)\n\n", timing.method,
+                       timing.method, timing.error, timing.ms);
+            break;
+        case HandlerTiming::Kind::RequestOk:
+            fmt::print(stderr, "<--- {} {}\n---> {} {} ({:.3f}ms)\n\n", timing.method, timing.id,
+                       timing.method, timing.id, timing.ms);
+            break;
+        case HandlerTiming::Kind::RequestError:
+            fmt::print(stderr, "<--- {} {}\n-/-> {} {} Error: {} ({:.3f}ms)\n\n", timing.method,
+                       timing.id, timing.method, timing.id, timing.error, timing.ms);
+            break;
+        case HandlerTiming::Kind::Ignored:
+            fmt::print(stderr, "<-/- {} (ignoring threaded req)\n\n", timing.method);
+            break;
+        case HandlerTiming::Kind::NotFound:
+            fmt::print(stderr, "<-/- {} (not found)\n\n", timing.method);
+            break;
+    }
+}
+} // namespace
 
 template<typename Impl>
 class JsonRpcServer {
@@ -83,14 +137,17 @@ protected:
         };
     }
 
-    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(RpcRequest request) {
+    /// Run the handler with no logging. Caller must hold @c mutex for stdout
+    /// sends; format @p timing only after releasing it.
+    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(RpcRequest request,
+                                                                        HandlerTiming& timing) {
+        timing.method = request.method;
+
         if (!request.id) {
             // Notification
             auto it = notifications.find(request.method);
             if (it != notifications.end()) {
-                std::cerr << "<--- " << request.method << std::endl;
-                // std::cerr << rfl::json::write(request.params, rfl::json::pretty) <<
-                // std::endl;
+                const auto start = std::chrono::steady_clock::now();
                 try {
                     if (request.params.has_value()) {
                         it->second(request.params.value());
@@ -98,24 +155,26 @@ protected:
                     else {
                         it->second(std::nullopt);
                     }
-                    std::cerr << "---- " << request.method << " (notification finished)"
-                              << std::endl;
+                    timing.ms = elapsedMs(start);
+                    timing.kind = HandlerTiming::Kind::NotificationOk;
                 }
                 catch (const std::exception& e) {
-                    std::cerr << "-/-> " << request.method << " Error: " << e.what() << '\n';
+                    timing.ms = elapsedMs(start);
+                    timing.error = e.what();
+                    timing.kind = HandlerTiming::Kind::NotificationError;
                 }
             }
             else if (request.method.find("$/") == 0) {
-                std::cerr << "<-/- " << request.method << " (ignoring threaded req)" << '\n';
+                timing.kind = HandlerTiming::Kind::Ignored;
             }
             else {
-                std::cerr << "<-/- " << request.method << " (method not found)" << '\n';
+                timing.kind = HandlerTiming::Kind::NotFound;
             }
             return std::nullopt;
         }
 
         // Request
-        std::string id = rfl::visit(
+        timing.id = rfl::visit(
             [&](auto&& id_) -> std::string {
                 using T = typename std::decay_t<decltype(id_)>;
                 if constexpr (std::is_same_v<T, int>) {
@@ -133,8 +192,8 @@ protected:
         auto it = requests.find(request.method);
 
         if (it != requests.end()) {
+            const auto start = std::chrono::steady_clock::now();
             try {
-                std::cerr << "<--- " << request.method << " " << id << '\n';
                 rfl::Generic req_response;
                 if (request.params.has_value()) {
                     req_response = it->second(request.params.value());
@@ -142,45 +201,50 @@ protected:
                 else {
                     req_response = it->second(rfl::Generic{});
                 }
-                std::cerr << "---> " << request.method << " " << id << '\n';
+                timing.ms = elapsedMs(start);
+                timing.kind = HandlerTiming::Kind::RequestOk;
                 return req_response;
             }
             catch (const std::exception& e) {
-                std::cerr << "-/-> " << request.method << " " << id << " Error: " << e.what()
-                          << "\n\n";
+                timing.ms = elapsedMs(start);
+                timing.error = e.what();
+                timing.kind = HandlerTiming::Kind::RequestError;
                 return RpcError{.code = 1, .message = e.what()};
             }
         }
-        else {
-            std::cerr << "<-/- " << request.method << " (not found)" << '\n';
-        }
 
+        timing.kind = HandlerTiming::Kind::NotFound;
         return std::nullopt;
     }
 
     void handleMessage(RpcRequest req) {
-        std::lock_guard<std::mutex> lock(mutex);
-        auto result = processMessage(req);
-        std::visit(
-            [req](auto&& value) {
-                using T = std::decay_t<decltype(value)>;
-                if constexpr (std::is_same_v<T, rfl::Generic>) {
-                    sendMessage(RpcResponse{
-                        .jsonrpc = "2.0",
-                        .id = req.id,
-                        .result = value,
-                    });
-                }
-                else if constexpr (std::is_same_v<T, RpcError>) {
-                    sendMessage(RpcErrorResponse{
-                        .jsonrpc = "2.0",
-                        .id = req.id,
-                        .error = value,
-                    });
-                }
-            },
-            result);
-        std::cerr << '\n';
+        HandlerTiming timing;
+        {
+            // Mutex serializes stdout (also taken by WCP). Keep only handler +
+            // send under the lock; defer stderr formatting until after unlock.
+            std::lock_guard<std::mutex> lock(mutex);
+            auto result = processMessage(req, timing);
+            std::visit(
+                [req](auto&& value) {
+                    using T = std::decay_t<decltype(value)>;
+                    if constexpr (std::is_same_v<T, rfl::Generic>) {
+                        sendMessage(RpcResponse{
+                            .jsonrpc = "2.0",
+                            .id = req.id,
+                            .result = value,
+                        });
+                    }
+                    else if constexpr (std::is_same_v<T, RpcError>) {
+                        sendMessage(RpcErrorResponse{
+                            .jsonrpc = "2.0",
+                            .id = req.id,
+                            .error = value,
+                        });
+                    }
+                },
+                result);
+        }
+        logHandlerTiming(timing);
     }
 
     std::string line;

--- a/include/util/Logging.h
+++ b/include/util/Logging.h
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include "util/Timing.h"
 #include <chrono>
 #include <fmt/color.h>
 #include <fmt/format.h>
@@ -32,15 +33,10 @@ class ScopedTimer {
 public:
     explicit ScopedTimer(std::string name) : m_name(std::move(name)) {
         INFO("{}...", m_name);
-        m_start = std::chrono::high_resolution_clock::now();
+        m_start = std::chrono::steady_clock::now();
     }
 
-    ~ScopedTimer() {
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - m_start);
-        double seconds = static_cast<double>(duration.count()) / 1000000.0;
-        INFO("{} took {:.3f}s", m_name, seconds);
-    }
+    ~ScopedTimer() { INFO("{} took {:.3f}s", m_name, elapsedMs(m_start) / 1000.0); }
 
     ScopedTimer(const ScopedTimer&) = delete;
     ScopedTimer& operator=(const ScopedTimer&) = delete;
@@ -49,7 +45,7 @@ public:
 
 private:
     std::string m_name;
-    std::chrono::high_resolution_clock::time_point m_start;
+    std::chrono::steady_clock::time_point m_start;
 };
 
 template<>

--- a/include/util/Timing.h
+++ b/include/util/Timing.h
@@ -14,3 +14,20 @@ inline double elapsedMs(std::chrono::steady_clock::time_point start) {
     return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start)
         .count();
 }
+
+/// Writes elapsed milliseconds into @p out on destruction (no logging).
+class ScopedElapsedMs {
+public:
+    explicit ScopedElapsedMs(double& out) : m_out(out), m_start(std::chrono::steady_clock::now()) {}
+
+    ~ScopedElapsedMs() { m_out = elapsedMs(m_start); }
+
+    ScopedElapsedMs(const ScopedElapsedMs&) = delete;
+    ScopedElapsedMs& operator=(const ScopedElapsedMs&) = delete;
+    ScopedElapsedMs(ScopedElapsedMs&&) = delete;
+    ScopedElapsedMs& operator=(ScopedElapsedMs&&) = delete;
+
+private:
+    double& m_out;
+    std::chrono::steady_clock::time_point m_start;
+};

--- a/include/util/Timing.h
+++ b/include/util/Timing.h
@@ -1,0 +1,16 @@
+//------------------------------------------------------------------------------
+// Timing.h
+// Lightweight timing helpers (no logging macros — safe to include from tests).
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <chrono>
+
+/// Elapsed milliseconds since @p start (steady clock).
+inline double elapsedMs(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start)
+        .count();
+}

--- a/tests/cpp/LatencyTests.cpp
+++ b/tests/cpp/LatencyTests.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "util/Timing.h"
+#include "utils/ServerHarness.h"
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct TimedResult {
+    std::string name;
+    double ms = 0;
+    size_t amount = 0; // optional count (tokens, symbols, hints, ...)
+};
+
+std::string makeLargeSv(int moduleCount) {
+    std::string text;
+    text.reserve(static_cast<size_t>(moduleCount) * 280);
+    text += "// Generated latency fixture\n";
+    for (int i = 0; i < moduleCount; i++) {
+        text += fmt::format(R"(
+module m{0} #(
+    parameter int WIDTH_{0} = 8,
+    parameter type T_{0} = logic
+);
+    typedef logic [WIDTH_{0}-1:0] word_{0}_t;
+    word_{0}_t data_{0};
+    word_{0}_t addr_{0};
+
+    function automatic word_{0}_t f_{0}(input word_{0}_t x);
+        return x + WIDTH_{0};
+    endfunction
+
+    initial begin
+        word_{0}_t y = f_{0}(data_{0});
+        $display("%0d", y);
+    end
+endmodule
+)",
+                            i);
+    }
+    return text;
+}
+
+template<typename Fn>
+TimedResult timeIt(std::string name, Fn&& fn) {
+    const auto start = std::chrono::steady_clock::now();
+    size_t amount = static_cast<size_t>(fn());
+    return TimedResult{std::move(name), elapsedMs(start), amount};
+}
+
+// Print on success (Catch INFO only shows on failure unless -s).
+void report(const TimedResult& r) {
+    if (r.amount > 0) {
+        fmt::print(stderr, "LATENCY {}: {:.3f}ms (n={})\n", r.name, r.ms, r.amount);
+    }
+    else {
+        fmt::print(stderr, "LATENCY {}: {:.3f}ms\n", r.name, r.ms);
+    }
+}
+
+double medianMs(std::vector<double> samples) {
+    REQUIRE_FALSE(samples.empty());
+    std::sort(samples.begin(), samples.end());
+    return samples[samples.size() / 2];
+}
+
+} // namespace
+
+TEST_CASE("RequestLatency_LargeDocument", "[latency]") {
+    // ~100 modules → a few thousand lines; large enough to expose whole-document cost,
+    // small enough for CI. Soft upper bounds catch catastrophic regressions only.
+    constexpr int kModules = 100;
+    constexpr int kWarmIters = 5;
+
+    auto text = makeLargeSv(kModules);
+    ServerHarness server;
+
+    // didOpen → updateDoc → issueDiagnosticsTo → getAnalysis. That is the true first-touch
+    // cost; a later getAnalysis() would only measure a warm cache hit.
+    const auto openStart = std::chrono::steady_clock::now();
+    auto hdl = server.openFile("latency_large.sv", std::move(text));
+    const auto openMs = elapsedMs(openStart);
+    REQUIRE(hdl.doc);
+    REQUIRE(hdl.doc->hasAnalysis());
+    auto open = TimedResult{"open_and_analyze", openMs,
+                            hdl.doc->getAnalysis()->syntaxes.collected.size()};
+    report(open);
+    CHECK(open.ms < 5000.0);
+
+    // Invalidate analysis the way an edit does, then rebuild.
+    hdl.append("\n");
+    hdl.publishChanges();
+    auto rebuild = timeIt("shallow_analysis_rebuild", [&] {
+        auto analysis = hdl.doc->getAnalysis();
+        REQUIRE(analysis);
+        return analysis->syntaxes.collected.size();
+    });
+    report(rebuild);
+    CHECK(rebuild.ms < 5000.0);
+
+    auto analysis = hdl.doc->getAnalysis();
+    REQUIRE(analysis);
+    const size_t tokenCount = analysis->syntaxes.collected.size();
+    fmt::print(stderr, "LATENCY document tokens: {}\n", tokenCount);
+    CHECK(tokenCount > 1000);
+
+    // Floor for a full-document token pass (semanticTokens/full will sit above this).
+    auto tokenWalk = timeIt("token_walk", [&] {
+        size_t touched = 0;
+        for (const auto* token : analysis->syntaxes.collected) {
+            if (token) {
+                touched += token->rawText().size();
+            }
+        }
+        return touched;
+    });
+    report(tokenWalk);
+    CHECK(tokenWalk.ms < 1000.0);
+
+    std::vector<double> symbolSamples;
+    symbolSamples.reserve(kWarmIters);
+    size_t symbolCount = 0;
+    for (int i = 0; i < kWarmIters; i++) {
+        auto sample = timeIt("documentSymbol", [&] {
+            auto symbols = hdl.getSymbolTree();
+            return symbols.size();
+        });
+        symbolCount = sample.amount;
+        symbolSamples.push_back(sample.ms);
+    }
+    auto symbolsMedian = TimedResult{"documentSymbol_median", medianMs(symbolSamples), symbolCount};
+    report(symbolsMedian);
+    CHECK(symbolsMedian.ms < 2000.0);
+
+    auto hoverPos = hdl.m_text.find("WIDTH_0");
+    REQUIRE(hoverPos != std::string::npos);
+    std::vector<double> hoverSamples;
+    hoverSamples.reserve(kWarmIters);
+    for (int i = 0; i < kWarmIters; i++) {
+        auto sample = timeIt("hover", [&] {
+            auto hover = hdl.getHoverAt(static_cast<lsp::uint>(hoverPos));
+            return hover ? size_t{1} : size_t{0};
+        });
+        hoverSamples.push_back(sample.ms);
+    }
+    auto hoverMedian = TimedResult{"hover_median", medianMs(hoverSamples), 0};
+    report(hoverMedian);
+    CHECK(hoverMedian.ms < 1000.0);
+
+    std::vector<double> hintSamples;
+    hintSamples.reserve(kWarmIters);
+    size_t hintCount = 0;
+    for (int i = 0; i < kWarmIters; i++) {
+        auto sample = timeIt("inlayHint", [&] {
+            auto hints = hdl.getAllInlayHints();
+            return hints.size();
+        });
+        hintCount = sample.amount;
+        hintSamples.push_back(sample.ms);
+    }
+    auto hintsMedian = TimedResult{"inlayHint_median", medianMs(hintSamples), hintCount};
+    report(hintsMedian);
+    CHECK(hintsMedian.ms < 2000.0);
+
+    fmt::print(stderr,
+               "LATENCY summary: open={:.3f}ms rebuild={:.3f}ms token_walk={:.3f}ms "
+               "documentSymbol={:.3f}ms hover={:.3f}ms inlayHint={:.3f}ms tokens={}\n",
+               open.ms, rebuild.ms, tokenWalk.ms, symbolsMedian.ms, hoverMedian.ms, hintsMedian.ms,
+               tokenCount);
+}


### PR DESCRIPTION
## Summary
- Instrument JSON-RPC request/notification handling with elapsed-ms timing; capture under the RPC mutex, format/log only after unlock so stderr I/O is not on the critical path.
- Centralize `elapsedMs` in `util/Timing.h` (no logging macros) and reuse it from RPC logging and `ScopedTimer`.
- Add a Catch `[latency]` microbench that times true first-touch via `didOpen` (`open_and_analyze`), analysis rebuild after edit, token walk, documentSymbol, hover, and inlayHint.

Semantic tokens (`#436` / `#268`) add a whole-document request path. Review feedback on that work was clear: do not enable it by default until we have **measured latency** and a plan for **threaded/cancellable** requests. Guessing whether `semanticTokens/full` (or any other handler) is “cheap enough” is the wrong bar for this codebase.

This PR is the measurement step of that sequence:

1. **Dogfood in the editor** — every request/notification finish line now includes elapsed ms, so real sessions show which handlers dominate typing/edit latency.
2. **Reproducible baseline in CI** — the microbench locks in numbers for open/analyze, rebuild-after-edit, and common whole-doc paths, so later threading or semantic-token work can be judged against evidence rather than feel.
3. **Decide what to build next** — if whole-doc work stays sub-ms–few-ms on representative sizes, cooperative cancellation may be enough; if open/rebuild or classify is heavy, we have justification for offloading. Threading without these numbers would be premature architecture.

The instrumentation is deliberately low-perturbation: under the RPC mutex we only run the handler, take clock samples, and send the response (stdout still needs the lock for WCP). Formatting to stderr happens **after** unlock so logging I/O does not stretch the critical section.

## Test plan
- [ ] `cmake --build build -j8 --target server_unittests`
- [ ] `build/bin/server_unittests "RequestLatency_LargeDocument"` — look for `LATENCY` lines (`{:.3f}ms`)
- [ ] Point an editor at `build/bin/slang-server` and confirm finish lines like `---> textDocument/hover <id> (0.047ms)`
- [ ] Confirm normal request handling is unchanged when ignoring the new timing logs

## Notes
- First-touch is measured around `openFile` (diags force `getAnalysis`), not a later warm cache hit.
- Soft upper bounds in the microbench are catastrophic-regression guards only, not performance SLOs.
- Follow-ups: semantic-token classify timing once `#436` lands; then cancellation / threading only if the numbers say so.