### PR TITLE
Hovers/Gotos: Support multiple symbols

### DIFF
--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -176,6 +176,10 @@ private:
     /// Parse config flags and build files, load sources, create documents
     void parseAndLoadSources(const std::vector<std::string>& buildfiles);
 
+    std::optional<DefinitionInfo> getMacroDefinitionInfo(const ShallowAnalysis& analysis,
+                                                         const parsing::Token& token,
+                                                         const syntax::SyntaxNode& referenceSyntax);
+
     /// Set of URIs for documents that are explicitly opened by the client
     flat_hash_set<URI> m_openDocs;
 

--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -11,6 +11,7 @@
 #include "document/ShallowAnalysis.h"
 #include "lsp/LspTypes.h"
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -32,12 +33,6 @@ class Document;
 }
 
 struct DefinitionInfo {
-    enum class Kind {
-        Symbol,
-        Macro,
-        SystemSubroutine,
-    };
-
     struct SyntaxTarget {
         // The syntax that the token refers to.
         const slang::syntax::SyntaxNode* node;
@@ -61,18 +56,35 @@ struct DefinitionInfo {
     };
 
     struct SymbolTarget {
-        SyntaxTarget syntax;
+        // A semantic symbol can have more than one declaration site that is useful to display.
+        // For example, a modport port has both its directional declaration and the declaration of
+        // the underlying typed symbol.
+        std::vector<SyntaxTarget> syntaxes;
         const slang::ast::Symbol* symbol;
         std::shared_ptr<ShallowAnalysis> analysis;
 
-        const slang::parsing::Token& nameToken() const { return syntax.nameToken; }
+        const slang::parsing::Token& nameToken() const { return syntaxes.front().nameToken; }
 
         bool operator==(const SymbolTarget& other) const {
-            return syntax == other.syntax && symbol == other.symbol;
+            return syntaxes == other.syntaxes && symbol == other.symbol;
         }
 
-        lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
-                                    const Config::HoverConfig& hovers) const;
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
+
+        std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
+    };
+
+    struct PortConnectionTarget {
+        SymbolTarget outer;
+        SymbolTarget inner;
+
+        const slang::parsing::Token& nameToken() const { return outer.nameToken(); }
+
+        bool operator==(const PortConnectionTarget&) const = default;
+
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
 
         std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
     };
@@ -95,6 +107,9 @@ struct DefinitionInfo {
         // Expanded text for macro usages (what the macro expands to at this call site).
         std::string macroExpansionText;
 
+        MacroTarget(Definition definition, const slang::syntax::SyntaxNode& referenceSyntax,
+                    const ShallowAnalysis& analysis);
+
         const slang::parsing::Token& nameToken() const {
             return std::visit([](const auto& definition)
                                   -> const slang::parsing::Token& { return definition.nameToken; },
@@ -111,8 +126,8 @@ struct DefinitionInfo {
             return definition == other.definition && macroExpansionText == other.macroExpansionText;
         }
 
-        lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
-                                    const Config::HoverConfig& hovers) const;
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
 
         std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
     };
@@ -129,62 +144,47 @@ struct DefinitionInfo {
                    isTask == other.isTask;
         }
 
-        lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
-                                    const Config::HoverConfig& hovers) const;
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
 
         std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
     };
 
-    using Target = std::variant<SymbolTarget, MacroTarget, SystemSubroutineTarget>;
+    using Target =
+        std::variant<SymbolTarget, PortConnectionTarget, MacroTarget, SystemSubroutineTarget>;
 
-    // The thing this token resolves to.
-    Target target;
+    // The things this token resolves to, in semantic / elaboration order.
+    std::vector<Target> targets;
 
-    Kind kind() const {
-        switch (target.index()) {
-            case 0:
-                return Kind::Symbol;
-            case 1:
-                return Kind::Macro;
-            default:
-                return Kind::SystemSubroutine;
-        }
-    }
+    explicit DefinitionInfo(Target target) { targets.push_back(std::move(target)); }
+    explicit DefinitionInfo(std::vector<Target> targets) : targets(std::move(targets)) {}
+
+    const Target& primaryTarget() const { return targets.front(); }
+    Target& primaryTarget() { return targets.front(); }
 
     const slang::parsing::Token& nameToken() const {
         return std::visit(
             [](const auto& target) -> const slang::parsing::Token& { return target.nameToken(); },
-            target);
+            primaryTarget());
     }
-
-    const SyntaxTarget* syntaxTarget() const {
-        if (auto* sym = std::get_if<SymbolTarget>(&target)) {
-            return &sym->syntax;
-        }
-        if (auto* macro = std::get_if<MacroTarget>(&target)) {
-            return macro->syntaxTarget();
-        }
-        return nullptr;
-    }
-
-    const SymbolTarget* symbolTarget() const { return std::get_if<SymbolTarget>(&target); }
 
     const slang::ast::Symbol* symbol() const {
-        if (auto* sym = symbolTarget()) {
-            return sym->symbol;
-        }
+        if (auto* symbol = std::get_if<SymbolTarget>(&primaryTarget()))
+            return symbol->symbol;
+        if (auto* port = std::get_if<PortConnectionTarget>(&primaryTarget()))
+            return port->outer.symbol;
         return nullptr;
     }
 
-    MacroTarget* macro() { return std::get_if<MacroTarget>(&target); }
+    MacroTarget* macro() { return std::get_if<MacroTarget>(&primaryTarget()); }
 
-    const MacroTarget* macro() const { return std::get_if<MacroTarget>(&target); }
+    const MacroTarget* macro() const { return std::get_if<MacroTarget>(&primaryTarget()); }
 
     const SystemSubroutineTarget* systemSubroutine() const {
-        return std::get_if<SystemSubroutineTarget>(&target);
+        return std::get_if<SystemSubroutineTarget>(&primaryTarget());
     }
 
-    bool operator==(const DefinitionInfo& other) const { return target == other.target; }
+    bool operator==(const DefinitionInfo& other) const { return targets == other.targets; }
 
     bool operator!=(const DefinitionInfo& other) const { return !(*this == other); }
 
@@ -192,8 +192,7 @@ struct DefinitionInfo {
     lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
                                 const Config::HoverConfig& hovers) const;
 
-    /// Resolve goto-definition links for this definition. May return multiple in the future
-    /// (e.g. for symbols with several declarations).
+    /// Resolve and deduplicate goto-definition links for every target and declaration site.
     std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
 };
 

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -120,6 +120,11 @@ public:
     /// @brief Gets the AST symbol that a declared token refers to, if any
     const slang::ast::Symbol* getSymbolAtToken(const slang::parsing::Token* node) const;
 
+    /// @brief Gets all AST symbols that a token refers to. A source token can denote multiple
+    /// elaborated symbols, or both sides of an implicit connection.
+    slang::SmallVector<const slang::ast::Symbol*, 2> getSymbolsAtToken(
+        const slang::parsing::Token* node) const;
+
     /// Syntax finder for location->syntax mapping
     SyntaxIndexer syntaxes;
 

--- a/include/document/SymbolIndexer.h
+++ b/include/document/SymbolIndexer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
@@ -22,11 +23,14 @@
 #include "slang/ast/types/AllTypes.h"
 #include "slang/syntax/SyntaxNode.h"
 #include "slang/text/SourceLocation.h"
+#include "slang/util/SmallVector.h"
 
 namespace server {
 
-using Symdex = std::unordered_map<const slang::parsing::Token*, const slang::ast::Symbol*>;
-using Syntex = std::unordered_map<const slang::syntax::SyntaxNode*, const slang::ast::Symbol*>;
+using SymbolList = slang::SmallVector<const slang::ast::Symbol*, 2>;
+
+using Symdex = std::unordered_map<const slang::parsing::Token*, SymbolList>;
+using Syntex = std::unordered_map<const slang::syntax::SyntaxNode*, SymbolList>;
 
 struct SymbolIndexer
     : public slang::ast::ASTVisitor<SymbolIndexer, slang::ast::VisitFlags::Symbols> {
@@ -45,7 +49,12 @@ public:
 
     const slang::ast::Symbol* getSymbol(const slang::syntax::SyntaxNode* node) const;
 
+    std::span<const slang::ast::Symbol* const> getSymbols(const slang::parsing::Token* node) const;
+
     const slang::ast::Scope* getScopeForSyntax(const slang::syntax::SyntaxNode& syntax) const;
+
+    slang::SmallVector<const slang::ast::Scope*, 2> getScopesForSyntax(
+        const slang::syntax::SyntaxNode& syntax) const;
 
     // These are not in the buffer, but should be visited
     void handle(const slang::ast::RootSymbol& sym);
@@ -99,9 +108,14 @@ private:
     /// Helper to index instance syntax (shared by InstanceSymbol and InstanceArraySymbol)
     void indexInstanceSyntax(const slang::syntax::HierarchicalInstanceSyntax& instSyntax,
                              const slang::ast::InstanceBodySymbol& instanceSymbol,
-                             const slang::ast::DefinitionSymbol& definition);
+                             const slang::ast::DefinitionSymbol& definition,
+                             const slang::ast::InstanceSymbol* instance,
+                             const slang::ast::Scope* parentScope);
 
     void indexSymbolName(const slang::ast::Symbol& symbol, bool isUnnamed = false);
+
+    void addSymbol(const slang::parsing::Token* token, const slang::ast::Symbol& symbol);
+    void addSymbol(const slang::syntax::SyntaxNode* syntax, const slang::ast::Symbol& symbol);
 };
 
 } // namespace server

--- a/include/util/Markdown.h
+++ b/include/util/Markdown.h
@@ -31,11 +31,16 @@ public:
     /// Add a line break within the paragraph
     Paragraph& newLine();
 
+    /// Append an already rendered paragraph fragment
+    Paragraph& append(Paragraph paragraph);
+
     /// Check if the paragraph has any content
     bool isEmpty() const { return buffer.empty(); }
 
     /// Get the markdown content
     std::string_view asMarkdown() const { return buffer; }
+
+    bool operator==(const Paragraph&) const = default;
 
 private:
     std::string buffer;
@@ -49,6 +54,14 @@ public:
 
     /// Add an existing paragraph to the document
     void addParagraph(Paragraph para);
+
+    /// Append all paragraphs from another document
+    void append(Document doc);
+
+    /// Check if the document has any rendered content
+    bool isEmpty() const;
+
+    bool operator==(const Document&) const = default;
 
     /// Build and return LSP MarkupContent
     lsp::MarkupContent build() const;

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -20,6 +20,8 @@
 #include "util/Formatting.h"
 #include "util/Logging.h"
 #include "util/Markdown.h"
+#include <algorithm>
+#include <filesystem>
 #include <memory>
 #include <queue>
 #include <string_view>
@@ -485,6 +487,85 @@ bool ServerDriver::createCompilation() {
     return true;
 }
 
+std::optional<DefinitionInfo> ServerDriver::getMacroDefinitionInfo(
+    const ShallowAnalysis& analysis, const parsing::Token& token,
+    const syntax::SyntaxNode& referenceSyntax) {
+    std::vector<const syntax::DefineDirectiveSyntax*> macroDefs;
+    auto addMacroDef = [&](const syntax::DefineDirectiveSyntax* definition) {
+        if (definition && std::ranges::find(macroDefs, definition) == macroDefs.end())
+            macroDefs.push_back(definition);
+    };
+    if (referenceSyntax.kind == syntax::SyntaxKind::MacroUsage ||
+        referenceSyntax.kind == syntax::SyntaxKind::UndefDirective) {
+        auto it = analysis.macroUsageDefinitions.find(&referenceSyntax);
+        if (it != analysis.macroUsageDefinitions.end())
+            addMacroDef(it->second);
+    }
+
+    // A macro usage in a define body has no direct usage mapping. The workspace index also
+    // supplies definitions that are not part of the current shallow compilation.
+    if (macroDefs.empty()) {
+        auto macroName = token.kind == parsing::TokenKind::Directive ? token.rawText().substr(1)
+                                                                     : token.valueText();
+        auto macro = analysis.macros.find(macroName);
+        if (macro != analysis.macros.end()) {
+            addMacroDef(macro->second);
+        }
+        else {
+            std::vector<std::filesystem::path> visited;
+            for (const auto& path : m_indexer.getFilesForMacro(macroName)) {
+                if (std::ranges::find(visited, path) != visited.end())
+                    continue;
+                visited.push_back(path);
+
+                auto macroDoc = getDocument(URI::fromFile(path));
+                if (!macroDoc)
+                    continue;
+                auto macroAnalysis = macroDoc->getAnalysis();
+                auto indexedMacro = macroAnalysis->macros.find(macroName);
+                if (indexedMacro != macroAnalysis->macros.end())
+                    addMacroDef(indexedMacro->second);
+            }
+        }
+        if (macroDefs.empty())
+            return {};
+    }
+
+    std::vector<DefinitionInfo::Target> targets;
+    for (auto* macroDef : macroDefs) {
+        auto nameToken = macroDef->name;
+        auto macroUsageRange = SourceRange::NoLocation;
+        if (sm.isMacroLoc(nameToken.location())) {
+            auto tokenRange = SourceRange(nameToken.location(),
+                                          nameToken.location() + nameToken.rawText().length());
+            auto expansionRange = sm.getFullyExpandedRange(tokenRange);
+            if (sm.getSourceText(expansionRange).empty()) {
+                ERROR("Couldn't get original range for macro {}", nameToken.valueText());
+            }
+            else {
+                macroUsageRange = expansionRange;
+            }
+        }
+
+        DefinitionInfo::SyntaxTarget syntaxTarget{macroDef, nameToken, macroUsageRange};
+        DefinitionInfo::MacroTarget::Definition macroDefinition = syntaxTarget;
+
+        const auto defPath = sm.getFullPath(nameToken.location().buffer());
+        const auto defPathStr = defPath.filename().string();
+        if (defPathStr.empty() || defPathStr[0] == '<') {
+            std::string defineSourceFile;
+            const auto srcIt = m_defineSources.find(std::string(nameToken.valueText()));
+            if (srcIt != m_defineSources.end())
+                defineSourceFile = srcIt->second.string();
+            macroDefinition = DefinitionInfo::CommandLineDefineTarget{nameToken, defineSourceFile};
+        }
+
+        targets.emplace_back(
+            DefinitionInfo::MacroTarget{std::move(macroDefinition), referenceSyntax, analysis});
+    }
+    return DefinitionInfo{std::move(targets)};
+}
+
 std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
                                                                 const lsp::Position& position) {
     auto doc = getDocument(uri);
@@ -507,10 +588,6 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         return {};
     }
 
-    std::optional<parsing::Token> nameToken;
-    const syntax::SyntaxNode* symSyntax = nullptr;
-    const ast::Symbol* symbol = nullptr;
-
     auto isMacroRef = [&]() {
         // Normal macro usage (`FOO) or usage inside a `define body
         return declTok->kind == parsing::TokenKind::Directive &&
@@ -528,46 +605,10 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
                declSyntax->kind == syntax::SyntaxKind::NamedConditionalDirectiveExpression;
     };
 
-    if (isMacroRef() || isUndefRef() || isIfdefRef()) {
+    if (isMacroRef() || isUndefRef() || isIfdefRef())
+        return getMacroDefinitionInfo(*analysis, *declTok, *declSyntax);
 
-        // For macro usages and undefs, look up the definition that was
-        // active at the time (handles undef/redefine correctly)
-        const syntax::DefineDirectiveSyntax* macroDef = nullptr;
-        if (declSyntax->kind == syntax::SyntaxKind::MacroUsage ||
-            declSyntax->kind == syntax::SyntaxKind::UndefDirective) {
-            auto it = analysis->macroUsageDefinitions.find(declSyntax);
-            if (it != analysis->macroUsageDefinitions.end())
-                macroDef = it->second;
-        }
-
-        // Fall back to the macros map
-        // if we're looking at a macro usage in a define body, or macro isn't found but indexed
-        if (!macroDef) {
-            // For directive tokens (`FOO), valueText strips the backtick.
-            // For identifier tokens (FOO in `undef), valueText is the name.
-            auto macroName = declTok->kind == parsing::TokenKind::Directive
-                                 ? declTok->rawText().substr(1)
-                                 : declTok->valueText();
-            auto macro = analysis->macros.find(macroName);
-            if (macro == analysis->macros.end()) {
-                auto files = m_indexer.getFilesForMacro(macroName);
-                if (files.empty())
-                    return {};
-                auto macroDoc = getDocument(URI::fromFile(files[0].string()));
-                if (!macroDoc)
-                    return {};
-                auto macroAnalysis = macroDoc->getAnalysis();
-                macro = macroAnalysis->macros.find(macroName);
-                if (macro == macroAnalysis->macros.end())
-                    return {};
-            }
-            macroDef = macro->second;
-        }
-
-        symSyntax = macroDef;
-        nameToken = macroDef->name;
-    }
-    else if (declTok->kind == parsing::TokenKind::SystemIdentifier) {
+    if (declTok->kind == parsing::TokenKind::SystemIdentifier) {
         auto knownName = declTok->systemName();
         if (knownName == parsing::KnownSystemName::Unknown)
             return {};
@@ -580,93 +621,185 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         return DefinitionInfo{DefinitionInfo::SystemSubroutineTarget{
             *declTok, sysDoc, sub->kind == ast::SubroutineKind::Task}};
     }
-    else {
-        symbol = analysis->getSymbolAtToken(declTok);
-        if (!symbol) {
-            // check the index
-            auto symbols = m_indexer.getFilesForSymbol(declTok->rawText());
-            if (symbols.empty()) {
-                return {};
-            }
-            auto symDoc = getDocument(URI::fromFile(symbols[0].string()));
-            if (!symDoc) {
-                return {};
-            }
-            auto symAnalysis = symDoc->getAnalysis();
-            auto result = symAnalysis->getCompilation()->tryGetDefinition(
-                declTok->rawText(), symAnalysis->getCompilation()->getRoot());
-            if (!result.definition) {
-                return {};
-            }
-            symbol = result.definition;
-        }
-        symSyntax = symbol->getSyntax();
+    std::vector<std::pair<const ast::Symbol*, std::shared_ptr<ShallowAnalysis>>> symbols;
+    auto addSymbol = [&](const ast::Symbol* symbol,
+                         const std::shared_ptr<ShallowAnalysis>& symbolAnalysis) {
+        if (!symbol)
+            return;
+        auto duplicate = std::ranges::any_of(symbols, [&](const auto& existing) {
+            return (existing.first == symbol && existing.second == symbolAnalysis) ||
+                   (existing.second != symbolAnalysis && existing.first->kind == symbol->kind &&
+                    existing.first->location == symbol->location);
+        });
+        if (!duplicate)
+            symbols.emplace_back(symbol, symbolAnalysis);
+    };
 
+    auto localSymbols = analysis->getSymbolsAtToken(declTok);
+    for (auto* symbol : localSymbols)
+        addSymbol(symbol, analysis);
+
+    bool hasTopLevelResolution = std::ranges::any_of(localSymbols, [](const ast::Symbol* symbol) {
+        return symbol->kind == ast::SymbolKind::Definition ||
+               symbol->kind == ast::SymbolKind::Package;
+    });
+    bool hasLocalTopLevelResolution =
+        std::ranges::any_of(localSymbols, [&](const ast::Symbol* symbol) {
+            return (symbol->kind == ast::SymbolKind::Definition ||
+                    symbol->kind == ast::SymbolKind::Package) &&
+                   sm.getFullyExpandedLoc(symbol->location).buffer() == doc->getBuffer();
+        });
+
+    // A declaration in the queried document is authoritative. Externally resolved top-level
+    // names still use the index to retain other possible definitions.
+    bool searchIndex = localSymbols.empty() ||
+                       (hasTopLevelResolution && !hasLocalTopLevelResolution);
+    if (searchIndex) {
+        auto matchesResolvedKind = [&](const ast::Symbol* candidate) {
+            if (localSymbols.empty())
+                return true;
+            return std::ranges::any_of(localSymbols, [&](const ast::Symbol* resolved) {
+                if (resolved->kind != candidate->kind)
+                    return false;
+                if (auto* resolvedDef = resolved->as_if<ast::DefinitionSymbol>()) {
+                    auto* candidateDef = candidate->as_if<ast::DefinitionSymbol>();
+                    return candidateDef &&
+                           candidateDef->definitionKind == resolvedDef->definitionKind;
+                }
+                return true;
+            });
+        };
+
+        std::vector<std::filesystem::path> visited;
+        for (const auto& path : m_indexer.getFilesForSymbol(declTok->valueText())) {
+            if (std::ranges::find(visited, path) != visited.end())
+                continue;
+            visited.push_back(path);
+
+            auto symbolDoc = getDocument(URI::fromFile(path));
+            if (!symbolDoc)
+                continue;
+            auto symbolAnalysis = symbolDoc->getAnalysis();
+            auto addGlobalDefinition = [&](const ast::Symbol* symbol) {
+                if (symbol && symbol->name == declTok->valueText() &&
+                    sm.getFullyExpandedLoc(symbol->location).buffer() == symbolDoc->getBuffer() &&
+                    matchesResolvedKind(symbol)) {
+                    addSymbol(symbol, symbolAnalysis);
+                }
+            };
+
+            for (auto* definition : symbolAnalysis->getCompilation()->getDefinitions())
+                addGlobalDefinition(definition);
+
+            for (auto* unit : symbolAnalysis->getCompilation()->getCompilationUnits()) {
+                for (auto& member : unit->members()) {
+                    if (member.kind == ast::SymbolKind::Package)
+                        addGlobalDefinition(&member);
+                }
+            }
+        }
+    }
+
+    auto makeSyntaxTarget =
+        [&](const ast::Symbol* symbol) -> std::optional<DefinitionInfo::SyntaxTarget> {
+        auto* symSyntax = symbol->getSyntax();
         if (!symSyntax) {
             ERROR("Failed to get syntax for symbol {} of kind {}", symbol->name,
                   toString(symbol->kind));
             return {};
         }
 
-        // For some symbols we want to return the parent to get the data type
-        if (symbol->kind == ast::SymbolKind::Modport ||
-            symbol->kind == ast::SymbolKind::ModportPort) {
+        // Modports have a directional declaration around their name syntax.
+        if ((symbol->kind == ast::SymbolKind::Modport ||
+             symbol->kind == ast::SymbolKind::ModportPort) &&
+            symSyntax->parent) {
             symSyntax = symSyntax->parent;
         }
-        nameToken = findNameToken(symSyntax, symbol->name);
-        if (!nameToken) {
+
+        auto foundNameToken = findNameToken(symSyntax, symbol->name);
+        if (!foundNameToken) {
             ERROR("Failed to find name token for symbol '{}' of kind {} = {}", symbol->name,
                   toString(symbol->kind), symSyntax->toString());
-
-            // TODO: figure out why this fails sometimes with all generates
-            nameToken = symSyntax->getFirstToken();
         }
-    }
+        parsing::Token nameToken = foundNameToken ? *foundNameToken : symSyntax->getFirstToken();
 
-    auto macroUsageRange = SourceRange::NoLocation;
-    if (nameToken && sm.isMacroLoc(nameToken->location())) {
-        auto tokenRange = SourceRange(nameToken->location(),
-                                      nameToken->location() + nameToken->rawText().length());
-        auto expansionRange = sm.getFullyExpandedRange(tokenRange);
-        auto text = sm.getSourceText(expansionRange);
-        if (text.empty()) {
-            ERROR("Couldn't get original range for symbol {}", nameToken->valueText());
+        auto macroUsageRange = SourceRange::NoLocation;
+        if (sm.isMacroLoc(nameToken.location())) {
+            auto tokenRange = SourceRange(nameToken.location(),
+                                          nameToken.location() + nameToken.rawText().length());
+            auto expansionRange = sm.getFullyExpandedRange(tokenRange);
+            if (sm.getSourceText(expansionRange).empty()) {
+                ERROR("Couldn't get original range for symbol {}", nameToken.valueText());
+            }
+            else {
+                macroUsageRange = expansionRange;
+            }
         }
-        else {
-            macroUsageRange = expansionRange;
-        }
-    }
 
-    std::string macroExpansionText;
-    if (declSyntax->kind == syntax::SyntaxKind::MacroUsage) {
-        auto it = analysis->syntaxes.macroExpansions.find(declSyntax);
-        if (it != analysis->syntaxes.macroExpansions.end())
-            macroExpansionText = it->second.getText();
-    }
-
-    auto makeSyntaxTarget = [&]() {
-        return DefinitionInfo::SyntaxTarget{symSyntax, *nameToken, macroUsageRange};
+        return DefinitionInfo::SyntaxTarget{symSyntax, nameToken, macroUsageRange};
     };
 
-    auto makeTarget = [&]() -> DefinitionInfo::Target {
-        if (symbol)
-            return DefinitionInfo::SymbolTarget{makeSyntaxTarget(), symbol, analysis};
+    auto makeSymbolTarget = [&](const ast::Symbol* symbol,
+                                const std::shared_ptr<ShallowAnalysis>& symbolAnalysis)
+        -> std::optional<DefinitionInfo::SymbolTarget> {
+        if (!symbol)
+            return {};
+        auto syntaxTarget = makeSyntaxTarget(symbol);
+        if (!syntaxTarget)
+            return {};
 
-        DefinitionInfo::MacroTarget::Definition macroDefinition = makeSyntaxTarget();
-
-        const auto defPath = sm.getFullPath(nameToken->location().buffer());
-        const auto defPathStr = defPath.filename().string();
-        if (defPathStr.empty() || defPathStr[0] == '<') {
-            std::string defineSourceFile;
-            const auto srcIt = m_defineSources.find(std::string(nameToken->valueText()));
-            if (srcIt != m_defineSources.end())
-                defineSourceFile = srcIt->second.string();
-            macroDefinition = DefinitionInfo::CommandLineDefineTarget{*nameToken, defineSourceFile};
+        std::vector<DefinitionInfo::SyntaxTarget> syntaxes;
+        syntaxes.push_back(std::move(*syntaxTarget));
+        if (auto* modportPort = symbol->as_if<ast::ModportPortSymbol>()) {
+            if (modportPort->internalSymbol) {
+                if (auto internalSyntax = makeSyntaxTarget(modportPort->internalSymbol))
+                    syntaxes.push_back(std::move(*internalSyntax));
+            }
         }
-
-        return DefinitionInfo::MacroTarget{macroDefinition, macroExpansionText};
+        return DefinitionInfo::SymbolTarget{std::move(syntaxes), symbol, symbolAnalysis};
     };
-    return DefinitionInfo{makeTarget()};
+
+    if (declSyntax && declSyntax->kind == syntax::SyntaxKind::NamedPortConnection &&
+        !declSyntax->as<syntax::NamedPortConnectionSyntax>().openParen && localSymbols.size() > 1) {
+        std::vector<DefinitionInfo::Target> targets;
+        for (size_t i = 0; i + 1 < localSymbols.size(); i += 2) {
+            auto outer = makeSymbolTarget(localSymbols[i], analysis);
+            auto inner = makeSymbolTarget(localSymbols[i + 1], analysis);
+            if (outer && inner) {
+                targets.emplace_back(
+                    DefinitionInfo::PortConnectionTarget{std::move(*outer), std::move(*inner)});
+            }
+            else if (outer) {
+                targets.emplace_back(std::move(*outer));
+            }
+            else if (inner) {
+                targets.emplace_back(std::move(*inner));
+            }
+        }
+        if (!targets.empty())
+            return DefinitionInfo{std::move(targets)};
+    }
+
+    std::vector<DefinitionInfo::Target> targets;
+    std::vector<const ast::Symbol*> foldedSymbols;
+    for (const auto& [symbol, symbolAnalysis] : symbols) {
+        if (std::ranges::find(foldedSymbols, symbol) != foldedSymbols.end())
+            continue;
+
+        auto target = makeSymbolTarget(symbol, symbolAnalysis);
+        if (!target)
+            continue;
+
+        if (auto* modportPort = symbol->as_if<ast::ModportPortSymbol>()) {
+            if (modportPort->internalSymbol)
+                foldedSymbols.push_back(modportPort->internalSymbol);
+        }
+        targets.emplace_back(std::move(*target));
+    }
+
+    if (targets.empty())
+        return {};
+    return DefinitionInfo{std::move(targets)};
 }
 
 std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::Position& position) {

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -15,6 +15,7 @@
 #include "util/Markdown.h"
 #include <algorithm>
 #include <filesystem>
+#include <type_traits>
 
 #include "slang/analysis/ValueDriver.h"
 #include "slang/ast/Expression.h"
@@ -80,7 +81,13 @@ std::string_view getPortDirectionHeader(ast::ArgumentDirection direction) {
     }
 }
 
-void renderSymbolHeaderName(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
+void renderSymbolHeaderName(markup::Paragraph& infoPg, const ast::Symbol& symbol,
+                            std::string_view kindOverride = {}) {
+    if (!kindOverride.empty()) {
+        infoPg.appendBold(kindOverride).appendCode(symbol.name);
+        return;
+    }
+
     if (auto* definition = symbol.as_if<ast::DefinitionSymbol>()) {
         infoPg.appendBold(toString(definition->definitionKind)).appendCode(symbol.name);
         return;
@@ -390,9 +397,11 @@ void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
     }
 }
 
-void renderSymbolHeader(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
+void renderSymbolHeader(markup::Paragraph& infoPg, const ast::Symbol& symbol,
+                        bool renderType = true, bool renderValue = true,
+                        std::string_view kindOverride = {}) {
     // <Kind/Type> <Name> in <Scope>
-    renderSymbolHeaderName(infoPg, symbol);
+    renderSymbolHeaderName(infoPg, symbol, kindOverride);
 
     auto& parentSym = symbol.getParentScope()->asSymbol();
     auto lexicalPath = parentSym.getLexicalPath();
@@ -411,8 +420,149 @@ void renderSymbolHeader(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
         infoPg.appendText(" in ").appendCode(lexicalPath);
     infoPg.newLine();
 
-    renderSymbolType(infoPg, symbol);
-    renderSymbolValue(infoPg, symbol);
+    if (renderType)
+        renderSymbolType(infoPg, symbol);
+    if (renderValue)
+        renderSymbolValue(infoPg, symbol);
+}
+
+void renderSymbolTargetHeader(markup::Paragraph& infoPg, const DefinitionInfo::SymbolTarget& target,
+                              std::string_view label = {}, bool renderType = true,
+                              bool renderValue = true) {
+    if (!label.empty())
+        infoPg.appendBold(label);
+    renderSymbolHeader(infoPg, *target.symbol, renderType, renderValue);
+}
+
+const ast::Symbol& getDriverSymbol(const DefinitionInfo::SymbolTarget& target) {
+    if (auto* modportPort = target.symbol->as_if<ast::ModportPortSymbol>()) {
+        if (modportPort->internalSymbol)
+            return *modportPort->internalSymbol;
+    }
+    return *target.symbol;
+}
+
+void renderSymbolSyntaxes(markup::Document& doc, const DefinitionInfo::SymbolTarget& target,
+                          const SourceManager& sm, const Config::HoverConfig& hovers) {
+    std::vector<DefinitionInfo::SyntaxTarget> rendered;
+    for (const auto& syntax : target.syntaxes) {
+        if (std::ranges::find(rendered, syntax) != rendered.end())
+            continue;
+        syntax.renderCode(doc, sm, hovers);
+        rendered.push_back(syntax);
+    }
+}
+
+struct RenderedSymbolHover {
+    markup::Paragraph header;
+    markup::Paragraph type;
+    markup::Paragraph value;
+    markup::Document syntaxes;
+    markup::Document drivers;
+    bool renderType = true;
+    bool renderValue = true;
+    bool renderDrivers = true;
+
+    bool operator==(const RenderedSymbolHover& other) const {
+        return header == other.header && type == other.type && value == other.value &&
+               syntaxes == other.syntaxes && drivers == other.drivers;
+    }
+
+    void appendTo(markup::Document& doc) {
+        if (renderType)
+            header.append(std::move(type));
+        if (renderValue)
+            header.append(std::move(value));
+        doc.addParagraph(std::move(header));
+        doc.append(std::move(syntaxes));
+        if (renderDrivers)
+            doc.append(std::move(drivers));
+    }
+};
+
+RenderedSymbolHover renderSymbolHover(const DefinitionInfo::SymbolTarget& target,
+                                      std::string_view label, const SourceManager& sm,
+                                      const Config::HoverConfig& hovers) {
+    RenderedSymbolHover result;
+    renderSymbolTargetHeader(result.header, target, label, false, false);
+    renderSymbolType(result.type, *target.symbol);
+    renderSymbolValue(result.value, *target.symbol);
+    renderSymbolSyntaxes(result.syntaxes, target, sm, hovers);
+    renderDrivers(result.drivers, getDriverSymbol(target), *target.analysis, sm);
+    result.renderType = !result.type.isEmpty();
+    result.renderValue = !result.value.isEmpty();
+    result.renderDrivers = !result.drivers.isEmpty();
+    return result;
+}
+
+void deduplicateSymbolHoverParts(const std::vector<RenderedSymbolHover*>& hovers) {
+    for (size_t i = 0; i < hovers.size(); i++) {
+        auto& current = *hovers[i];
+        for (size_t j = 0; j < i; j++) {
+            const auto& previous = *hovers[j];
+            if (current.renderType && previous.renderType && current.type == previous.type)
+                current.renderType = false;
+            if (current.renderValue && previous.renderValue && current.value == previous.value)
+                current.renderValue = false;
+            if (current.renderDrivers && previous.renderDrivers &&
+                current.drivers == previous.drivers) {
+                current.renderDrivers = false;
+            }
+        }
+    }
+}
+
+std::optional<lsp::MarkupContent> renderGenvarRange(
+    const std::vector<DefinitionInfo::Target>& targets, const SourceManager& sm,
+    const Config::HoverConfig& hovers) {
+    if (targets.size() < 2)
+        return {};
+
+    std::vector<const DefinitionInfo::SymbolTarget*> genvars;
+    const ConstantValue* minValue = nullptr;
+    const ConstantValue* maxValue = nullptr;
+    for (const auto& target : targets) {
+        auto* symbolTarget = std::get_if<DefinitionInfo::SymbolTarget>(&target);
+        if (!symbolTarget)
+            return {};
+
+        auto* parameter = symbolTarget->symbol->as_if<ast::ParameterSymbol>();
+        if (!parameter || !parameter->isFromGenvar())
+            return {};
+
+        const auto& value = parameter->getValue();
+        if (value.bad())
+            return {};
+
+        if (!minValue || value < *minValue)
+            minValue = &value;
+        if (!maxValue || value > *maxValue)
+            maxValue = &value;
+        genvars.push_back(symbolTarget);
+    }
+
+    if (*minValue == *maxValue)
+        return {};
+
+    markup::Document doc;
+    auto& header = doc.addParagraph();
+    renderSymbolHeader(header, *genvars.front()->symbol, true, false, "Genvar");
+    header.appendText("Value range: ")
+        .appendCode(formatConstantValue(*minValue))
+        .appendText(" through ")
+        .appendCode(formatConstantValue(*maxValue))
+        .newLine();
+
+    std::vector<DefinitionInfo::SyntaxTarget> renderedSyntaxes;
+    for (const auto* target : genvars) {
+        for (const auto& syntax : target->syntaxes) {
+            if (std::ranges::find(renderedSyntaxes, syntax) != renderedSyntaxes.end())
+                continue;
+            syntax.renderCode(doc, sm, hovers);
+            renderedSyntaxes.push_back(syntax);
+        }
+    }
+    return doc.build();
 }
 
 void renderMacroHeader(markup::Paragraph& infoPg, const DefinitionInfo::MacroTarget& macro,
@@ -472,19 +622,44 @@ void DefinitionInfo::SyntaxTarget::renderCode(markup::Document& doc, const Sourc
     }
 }
 
-lsp::MarkupContent DefinitionInfo::SymbolTarget::getHover(const SourceManager& sm,
-                                                          BufferID /*docBuffer*/,
-                                                          const Config::HoverConfig& hovers) const {
-    markup::Document doc;
-    renderSymbolHeader(doc.addParagraph(), *symbol);
-    syntax.renderCode(doc, sm, hovers);
-    renderDrivers(doc, *symbol, *analysis, sm);
-    return doc.build();
+DefinitionInfo::MacroTarget::MacroTarget(Definition definition,
+                                         const syntax::SyntaxNode& referenceSyntax,
+                                         const ShallowAnalysis& analysis) :
+    definition(std::move(definition)) {
+    if (referenceSyntax.kind != syntax::SyntaxKind::MacroUsage)
+        return;
+
+    auto it = analysis.syntaxes.macroExpansions.find(&referenceSyntax);
+    if (it != analysis.syntaxes.macroExpansions.end())
+        macroExpansionText = it->second.getText();
 }
 
-lsp::MarkupContent DefinitionInfo::MacroTarget::getHover(const SourceManager& sm,
-                                                         BufferID docBuffer,
-                                                         const Config::HoverConfig& hovers) const {
+markup::Document DefinitionInfo::SymbolTarget::getHover(const SourceManager& sm,
+                                                        BufferID /*docBuffer*/,
+                                                        const Config::HoverConfig& hovers) const {
+    markup::Document doc;
+    renderSymbolHover(*this, {}, sm, hovers).appendTo(doc);
+    return doc;
+}
+
+markup::Document DefinitionInfo::PortConnectionTarget::getHover(
+    const SourceManager& sm, BufferID /*docBuffer*/, const Config::HoverConfig& hovers) const {
+    std::vector<RenderedSymbolHover> hoversToRender;
+    hoversToRender.push_back(renderSymbolHover(outer, "Outer", sm, hovers));
+    hoversToRender.push_back(renderSymbolHover(inner, "Inner", sm, hovers));
+    std::vector<RenderedSymbolHover*> hoverPointers;
+    for (auto& hover : hoversToRender)
+        hoverPointers.push_back(&hover);
+    deduplicateSymbolHoverParts(hoverPointers);
+
+    markup::Document result;
+    for (auto& hover : hoversToRender)
+        hover.appendTo(result);
+    return result;
+}
+
+markup::Document DefinitionInfo::MacroTarget::getHover(const SourceManager& sm, BufferID docBuffer,
+                                                       const Config::HoverConfig& hovers) const {
     markup::Document doc;
     renderMacroHeader(doc.addParagraph(), *this, sm, docBuffer);
 
@@ -500,10 +675,10 @@ lsp::MarkupContent DefinitionInfo::MacroTarget::getHover(const SourceManager& sm
             .appendText(svCodeBlockString(macroExpansionText));
     }
 
-    return doc.build();
+    return doc;
 }
 
-lsp::MarkupContent DefinitionInfo::SystemSubroutineTarget::getHover(
+markup::Document DefinitionInfo::SystemSubroutineTarget::getHover(
     const SourceManager& /*sm*/, BufferID /*docBuffer*/,
     const Config::HoverConfig& /*hovers*/) const {
     markup::Document md;
@@ -519,7 +694,7 @@ lsp::MarkupContent DefinitionInfo::SystemSubroutineTarget::getHover(
     if (!doc->description.empty()) {
         md.addParagraph().appendText(doc->description);
     }
-    return md.build();
+    return md;
 }
 
 std::vector<lsp::LocationLink> DefinitionInfo::SyntaxTarget::getDefinition(
@@ -540,7 +715,32 @@ std::vector<lsp::LocationLink> DefinitionInfo::SyntaxTarget::getDefinition(
 
 std::vector<lsp::LocationLink> DefinitionInfo::SymbolTarget::getDefinition(
     const SourceManager& sm) const {
-    return syntax.getDefinition(sm);
+    std::vector<lsp::LocationLink> result;
+    for (const auto& syntax : syntaxes) {
+        for (auto& link : syntax.getDefinition(sm)) {
+            auto duplicate = std::ranges::any_of(result, [&](const auto& existing) {
+                return existing.targetUri == link.targetUri &&
+                       existing.targetSelectionRange == link.targetSelectionRange;
+            });
+            if (!duplicate)
+                result.push_back(std::move(link));
+        }
+    }
+    return result;
+}
+
+std::vector<lsp::LocationLink> DefinitionInfo::PortConnectionTarget::getDefinition(
+    const SourceManager& sm) const {
+    auto result = outer.getDefinition(sm);
+    for (auto& link : inner.getDefinition(sm)) {
+        auto duplicate = std::ranges::any_of(result, [&](const auto& existing) {
+            return existing.targetUri == link.targetUri &&
+                   existing.targetSelectionRange == link.targetSelectionRange;
+        });
+        if (!duplicate)
+            result.push_back(std::move(link));
+    }
+    return result;
 }
 
 std::vector<lsp::LocationLink> DefinitionInfo::MacroTarget::getDefinition(
@@ -599,11 +799,57 @@ std::vector<lsp::LocationLink> DefinitionInfo::SystemSubroutineTarget::getDefini
 
 lsp::MarkupContent DefinitionInfo::getHover(const SourceManager& sm, BufferID docBuffer,
                                             const Config::HoverConfig& hovers) const {
-    return std::visit([&](const auto& t) { return t.getHover(sm, docBuffer, hovers); }, target);
+    if (auto genvarRange = renderGenvarRange(targets, sm, hovers))
+        return std::move(*genvarRange);
+
+    using RenderedTargetHover = std::variant<RenderedSymbolHover, markup::Document>;
+    std::vector<RenderedTargetHover> renderedTargets;
+    for (const auto& target : targets) {
+        auto rendered = std::visit(
+            [&](const auto& concreteTarget) -> RenderedTargetHover {
+                using T = std::decay_t<decltype(concreteTarget)>;
+                if constexpr (std::is_same_v<T, SymbolTarget>)
+                    return renderSymbolHover(concreteTarget, {}, sm, hovers);
+                else
+                    return concreteTarget.getHover(sm, docBuffer, hovers);
+            },
+            target);
+        if (std::ranges::find(renderedTargets, rendered) != renderedTargets.end())
+            continue;
+        renderedTargets.push_back(std::move(rendered));
+    }
+
+    std::vector<RenderedSymbolHover*> symbolHovers;
+    for (auto& rendered : renderedTargets) {
+        if (auto* symbol = std::get_if<RenderedSymbolHover>(&rendered))
+            symbolHovers.push_back(symbol);
+    }
+    deduplicateSymbolHoverParts(symbolHovers);
+
+    markup::Document result;
+    for (auto& rendered : renderedTargets) {
+        if (auto* symbol = std::get_if<RenderedSymbolHover>(&rendered))
+            symbol->appendTo(result);
+        else
+            result.append(std::move(std::get<markup::Document>(rendered)));
+    }
+    return result.build();
 }
 
 std::vector<lsp::LocationLink> DefinitionInfo::getDefinition(const SourceManager& sm) const {
-    return std::visit([&](const auto& t) { return t.getDefinition(sm); }, target);
+    std::vector<lsp::LocationLink> result;
+    for (const auto& target : targets) {
+        auto links = std::visit([&](const auto& t) { return t.getDefinition(sm); }, target);
+        for (auto& link : links) {
+            auto duplicate = std::ranges::any_of(result, [&](const auto& existing) {
+                return existing.targetUri == link.targetUri &&
+                       existing.targetSelectionRange == link.targetSelectionRange;
+            });
+            if (!duplicate)
+                result.push_back(std::move(link));
+        }
+    }
+    return result;
 }
 
 } // namespace server

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -13,6 +13,7 @@
 #include "util/Converters.h"
 #include "util/Logging.h"
 #include "util/SlangExtensions.h"
+#include <algorithm>
 #include <fmt/format.h>
 #include <memory>
 #include <string_view>
@@ -23,6 +24,7 @@
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/ast/symbols/PortSymbols.h"
+#include "slang/ast/symbols/SubroutineSymbols.h"
 #include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/ast/types/AllTypes.h"
 #include "slang/ast/types/Type.h"
@@ -273,15 +275,60 @@ struct OffsetFinder {
     const parsing::Token* foundToken = nullptr;
 };
 
-const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declTok) const {
+slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
+    const parsing::Token* declTok) const {
+    slang::SmallVector<const ast::Symbol*, 2> symbols;
+    auto addSymbol = [&](const ast::Symbol* symbol) {
+        auto addOne = [&](const ast::Symbol* candidate) {
+            if (candidate && std::ranges::find(symbols, candidate) == symbols.end())
+                symbols.push_back(candidate);
+        };
+
+        if (!symbol)
+            return;
+
+        switch (symbol->kind) {
+            case ast::SymbolKind::InstanceBody:
+                addOne(&symbol->as<ast::InstanceBodySymbol>().getDefinition());
+                break;
+            case ast::SymbolKind::Port: {
+                // The internal symbol carries the declared type and is the symbol used by
+                // references inside the instance.
+                auto& port = symbol->as<ast::PortSymbol>();
+                addOne(port.internalSymbol ? port.internalSymbol : symbol);
+                break;
+            }
+            case ast::SymbolKind::ModportPort: {
+                // A named modport port has both an underlying typed symbol and a directional
+                // declaration in the modport.
+                auto& port = symbol->as<ast::ModportPortSymbol>();
+                addOne(symbol);
+                addOne(port.internalSymbol);
+                break;
+            }
+            case ast::SymbolKind::MethodPrototype: {
+                auto& prototype = symbol->as<ast::MethodPrototypeSymbol>();
+                addOne(symbol);
+                if (symbol->getSyntax() &&
+                    symbol->getSyntax()->kind == syntax::SyntaxKind::ModportSubroutinePort) {
+                    addOne(prototype.getSubroutine());
+                }
+                break;
+            }
+            default:
+                addOne(symbol);
+                break;
+        }
+    };
+
     if (!declTok) {
-        return nullptr;
+        return symbols;
     }
 
     auto syntax = syntaxes.getTokenParent(declTok);
     // Note: SuperHandle nodes can cause issues in symbol lookup
     if (!syntax || syntax->kind == syntax::SyntaxKind::SuperHandle) {
-        return nullptr;
+        return symbols;
     }
 
     // Handle macro args
@@ -321,41 +368,62 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
              syntax->kind == syntax::SyntaxKind::PackageImportItem) {
         auto pkg = m_compilation->getPackage(syntax->getFirstToken().valueText());
         if (!pkg) {
-            return {};
+            return symbols;
         }
         if (syntax->getFirstToken() == *declTok) {
-            return pkg;
+            addSymbol(pkg);
         }
-        return pkg->find(declTok->valueText());
+        else {
+            addSymbol(pkg->find(declTok->valueText()));
+        }
+        return symbols;
     }
-    else if (auto sym = m_symbolIndexer.getSymbol(declTok)) {
-        switch (sym->kind) {
-            case ast::SymbolKind::InstanceBody:
-                // Module declarations get indexed to their body. We do want to keep the body
-                // as the indexed sym for use in the future though with hdl features.
-                return &sym->as<ast::InstanceBodySymbol>().getDefinition();
-            case ast::SymbolKind::Port: {
-                // Named port connections get indexed to the port symbol. Return the internal
-                // symbol so that references work across instance boundaries.
-                auto& port = sym->as<ast::PortSymbol>();
-                if (port.internalSymbol) {
-                    return port.internalSymbol;
-                }
-                return sym;
+    else if (auto indexed = m_symbolIndexer.getSymbols(declTok); !indexed.empty()) {
+        if (syntax->kind == syntax::SyntaxKind::NamedPortConnection &&
+            !syntax->as<syntax::NamedPortConnectionSyntax>().openParen) {
+            if (indexed.size() > 1) {
+                symbols.append(indexed.begin(), indexed.end());
             }
-            default:
-                return sym;
+            else {
+                for (auto* scope : m_symbolIndexer.getScopesForSyntax(*syntax))
+                    addSymbol(scope->lookupName(declTok->valueText()));
+                addSymbol(indexed.front());
+            }
+            return symbols;
         }
+
+        // Keep the selected facade kind while retaining distinct elaborations of that kind.
+        auto legacyKind = indexed.back()->kind;
+        for (auto* symbol : indexed) {
+            if (symbol->kind == legacyKind)
+                addSymbol(symbol);
+        }
+        return symbols;
     }
 
-    auto scope = m_symbolIndexer.getScopeForSyntax(*syntax);
-    if (!scope) {
+    auto scopes = m_symbolIndexer.getScopesForSyntax(*syntax);
+    if (scopes.empty()) {
         INFO("No scope found for syntax {}, using root scope", syntax->toString());
-        scope = &m_compilation->getRoot().as<ast::Scope>();
+        scopes.push_back(&m_compilation->getRoot().as<ast::Scope>());
     }
 
-    // Perform name lookup; this should be most gotos
-    if (auto nameSyntax = findNameSyntax(*syntax)) {
+    auto resolveInScope = [&](const ast::Scope* scope) -> const ast::Symbol* {
+        // Perform name lookup; this should be most gotos.
+        auto nameSyntax = findNameSyntax(*syntax);
+        if (!nameSyntax) {
+            if (declTok->kind != parsing::TokenKind::Identifier ||
+                syntax->kind == syntax::SyntaxKind::AttributeSpec) {
+                return nullptr;
+            }
+            if (syntax->kind == syntax::SyntaxKind::DotMemberClause)
+                return handleInterfacePortHeader(declTok, syntax, scope);
+            if (auto def = m_compilation->tryGetDefinition(declTok->valueText(), *scope);
+                def.definition) {
+                return def.definition;
+            }
+            return m_compilation->getPackage(declTok->valueText());
+        }
+
         auto scopedName = nameSyntax->as_if<slang::syntax::ScopedNameSyntax>();
         if (scopedName && scopedName->separator == *declTok) {
             return nullptr;
@@ -394,7 +462,7 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
                             type = &cur->as<ast::ValueSymbol>().getType();
                         }
 
-                        if (type->isArray()) {
+                        if (type && type->isArray()) {
                             cur = type->getArrayElementType();
                         }
                         else {
@@ -428,28 +496,48 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
         if (auto scopedResult = handleScopedNameLookup(nameSyntax, context, scope)) {
             return scopedResult;
         }
-    }
 
-    if (declTok->kind != parsing::TokenKind::Identifier ||
-        syntax->kind == syntax::SyntaxKind::AttributeSpec) {
-        return nullptr;
-    }
+        if (declTok->kind != parsing::TokenKind::Identifier ||
+            syntax->kind == syntax::SyntaxKind::AttributeSpec) {
+            return nullptr;
+        }
 
-    if (syntax->kind == syntax::SyntaxKind::DotMemberClause) {
-        return handleInterfacePortHeader(declTok, syntax, scope);
-    }
-    // Try getting a definition as a last resort
-    auto def = m_compilation->tryGetDefinition(declTok->valueText(), *scope);
-    if (def.definition) {
-        return def.definition;
-    }
+        if (syntax->kind == syntax::SyntaxKind::DotMemberClause) {
+            return handleInterfacePortHeader(declTok, syntax, scope);
+        }
+        // Try getting a definition as a last resort.
+        auto def = m_compilation->tryGetDefinition(declTok->valueText(), *scope);
+        if (def.definition) {
+            return def.definition;
+        }
 
-    auto pkg = m_compilation->getPackage(declTok->valueText());
-    if (pkg) {
-        return pkg;
-    }
+        return m_compilation->getPackage(declTok->valueText());
+    };
 
-    return nullptr;
+    for (auto* scope : scopes)
+        addSymbol(resolveInScope(scope));
+    return symbols;
+}
+
+const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declTok) const {
+    auto symbols = getSymbolsAtToken(declTok);
+    if (declTok) {
+        auto* syntaxNode = syntaxes.getTokenParent(declTok);
+        if (syntaxNode && syntaxNode->kind == syntax::SyntaxKind::NamedPortConnection &&
+            !syntaxNode->as<syntax::NamedPortConnectionSyntax>().openParen) {
+            if (symbols.size() > 1)
+                return symbols[1];
+            return symbols.empty() ? nullptr : symbols.front();
+        }
+    }
+    if (auto it = std::ranges::find_if(symbols,
+                                       [](const ast::Symbol* symbol) {
+                                           return symbol->kind == ast::SymbolKind::ModportPort;
+                                       });
+        it != symbols.end()) {
+        return *it;
+    }
+    return symbols.empty() ? nullptr : symbols.back();
 }
 
 const ast::Symbol* ShallowAnalysis::getDefinition(std::string_view name) const {

--- a/src/document/SymbolIndexer.cpp
+++ b/src/document/SymbolIndexer.cpp
@@ -9,6 +9,7 @@
 #include "document/SymbolIndexer.h"
 
 #include "util/Logging.h"
+#include <algorithm>
 
 #include "slang/ast/Scope.h"
 #include "slang/ast/Symbol.h"
@@ -53,11 +54,11 @@ SymbolIndexer::SymbolIndexer(slang::BufferID buffer) : m_buffer(buffer) {
 }
 
 const slang::ast::Symbol* SymbolIndexer::getSymbol(const slang::parsing::Token* node) const {
-    auto it = symdex.find(node);
-    if (it == symdex.end()) {
+    auto symbols = getSymbols(node);
+    if (symbols.empty()) {
         return nullptr;
     }
-    return it->second;
+    return symbols.back();
 }
 
 const slang::ast::Symbol* SymbolIndexer::getSymbol(const slang::syntax::SyntaxNode* node) const {
@@ -65,35 +66,72 @@ const slang::ast::Symbol* SymbolIndexer::getSymbol(const slang::syntax::SyntaxNo
     if (it == syntex.end()) {
         return nullptr;
     }
-    return it->second;
+    return it->second.back();
+}
+
+std::span<const slang::ast::Symbol* const> SymbolIndexer::getSymbols(
+    const slang::parsing::Token* node) const {
+    auto it = symdex.find(node);
+    if (it == symdex.end()) {
+        return {};
+    }
+    return {it->second.data(), it->second.size()};
+}
+
+void SymbolIndexer::addSymbol(const slang::parsing::Token* token,
+                              const slang::ast::Symbol& symbol) {
+    auto& symbols = symdex[token];
+    if (std::ranges::find(symbols, &symbol) == symbols.end())
+        symbols.push_back(&symbol);
+}
+
+void SymbolIndexer::addSymbol(const slang::syntax::SyntaxNode* syntax,
+                              const slang::ast::Symbol& symbol) {
+    auto& symbols = syntex[syntax];
+    if (std::ranges::find(symbols, &symbol) == symbols.end())
+        symbols.push_back(&symbol);
 }
 
 const slang::ast::Scope* SymbolIndexer::getScopeForSyntax(
+    const slang::syntax::SyntaxNode& syntax) const {
+
+    auto scopes = getScopesForSyntax(syntax);
+    return scopes.empty() ? nullptr : scopes.back();
+}
+
+slang::SmallVector<const slang::ast::Scope*, 2> SymbolIndexer::getScopesForSyntax(
     const slang::syntax::SyntaxNode& syntax) const {
 
     const slang::syntax::SyntaxNode* current = &syntax;
     while (current != nullptr) {
         auto it = syntex.find(current);
         if (it != syntex.end()) {
-            const slang::ast::Symbol* symbol = it->second;
-            if (symbol) {
+            slang::SmallVector<const slang::ast::Scope*, 2> result;
+            for (const auto* symbol : it->second) {
+                const slang::ast::Scope* scope = nullptr;
                 if (symbol->isScope()) {
-                    return &symbol->as<slang::ast::Scope>();
+                    scope = &symbol->as<slang::ast::Scope>();
                 }
-                else {
-                    return symbol->getParentScope();
-                }
+                else
+                    scope = symbol->getParentScope();
+
+                if (scope && std::ranges::find(result, scope) == result.end())
+                    result.push_back(scope);
             }
+            if (!result.empty())
+                return result;
         }
         current = current->parent;
     }
 
-    return nullptr;
+    return {};
 }
 
 void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanceSyntax& instSyntax,
                                         const slang::ast::InstanceBodySymbol& body,
-                                        const slang::ast::DefinitionSymbol& definition) {
+                                        const slang::ast::DefinitionSymbol& definition,
+                                        const slang::ast::InstanceSymbol* instance,
+                                        const slang::ast::Scope* parentScope) {
 
     // Mark ports
     for (auto port : instSyntax.connections) {
@@ -109,7 +147,82 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
                     continue;
                 }
 
-                symdex[&portSyntax.name] = maybePortSym;
+                // `.name` is shorthand for `.name(name)`, so its single token denotes both the
+                // formal port and the value in the instance's parent scope.
+                if (!portSyntax.openParen) {
+                    auto addConnection = [&](const slang::ast::Symbol* outer,
+                                             const slang::ast::Symbol* inner) {
+                        if (!outer || !inner)
+                            return false;
+
+                        auto& symbols = symdex[&portSyntax.name];
+                        for (size_t i = 0; i + 1 < symbols.size(); i += 2) {
+                            if (symbols[i] == outer && symbols[i + 1] == inner)
+                                return true;
+                        }
+                        symbols.push_back(outer);
+                        symbols.push_back(inner);
+                        return true;
+                    };
+
+                    bool indexedConnection = false;
+                    if (instance && instance->getSyntax()) {
+                        for (auto* connection : instance->getPortConnections()) {
+                            bool matchesFormal = &connection->port == maybePortSym;
+                            if (auto* multiPort =
+                                    maybePortSym->as_if<slang::ast::MultiPortSymbol>()) {
+                                matchesFormal = std::ranges::find(multiPort->ports,
+                                                                  &connection->port) !=
+                                                multiPort->ports.end();
+                            }
+                            if (!matchesFormal)
+                                continue;
+
+                            const slang::ast::Symbol* outer = nullptr;
+                            if (parentScope) {
+                                outer = parentScope->lookupName(
+                                    name, slang::ast::LookupLocation::after(*instance));
+                            }
+                            if (!outer) {
+                                if (auto* expression = connection->getExpression())
+                                    outer = expression->getSymbolReference();
+                            }
+                            if (!outer &&
+                                connection->port.kind == slang::ast::SymbolKind::InterfacePort) {
+                                outer = connection->getIfaceConn().first;
+                            }
+
+                            const slang::ast::Symbol* inner = &connection->port;
+                            if (auto* port = connection->port.as_if<slang::ast::PortSymbol>();
+                                port && port->internalSymbol) {
+                                inner = port->internalSymbol;
+                            }
+                            indexedConnection |= addConnection(outer, inner);
+                        }
+                    }
+                    else {
+                        const slang::ast::Symbol* connected = nullptr;
+                        if (parentScope) {
+                            auto location = instance && instance->getParentScope() == parentScope
+                                                ? slang::ast::LookupLocation::after(*instance)
+                                                : slang::ast::LookupLocation::max;
+                            connected = parentScope->lookupName(name, location);
+                        }
+
+                        const slang::ast::Symbol* inner = maybePortSym;
+                        if (auto* port = maybePortSym->as_if<slang::ast::PortSymbol>();
+                            port && port->internalSymbol) {
+                            inner = port->internalSymbol;
+                        }
+                        indexedConnection = addConnection(connected, inner);
+                    }
+
+                    if (indexedConnection)
+                        continue;
+                }
+
+                // Keep the formal last because single-symbol lookup selects the last entry.
+                addSymbol(&portSyntax.name, *maybePortSym);
 
             } break;
             default:
@@ -121,14 +234,10 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
         return;
     }
 
-    // Mark module type and param if we haven't already
+    // Mark module type and parameters. The definition is normally shared, while elaborated
+    // parameter symbols can differ for each instance that shares this syntax.
     auto& paramInst = instSyntax.parent->as<slang::syntax::HierarchyInstantiationSyntax>();
-    if (symdex.find(&paramInst.type) != symdex.end()) {
-        return;
-    }
-
-    // Mark instance type
-    symdex[&paramInst.type] = &definition;
+    addSymbol(&paramInst.type, definition);
 
     if (paramInst.parameters == nullptr) {
         return;
@@ -144,7 +253,7 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
                     const slang::ast::Symbol* paramSym = body.lookupName(
                         paramSyntax.name.valueText());
                     if (paramSym) {
-                        symdex[&paramSyntax.name] = paramSym;
+                        addSymbol(&paramSyntax.name, *paramSym);
                     }
                 }
             } break;
@@ -156,7 +265,7 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
 
 void SymbolIndexer::indexSymbolName(const slang::ast::Symbol& symbol, bool isUnnamed) {
     if (symbol.getSyntax() != nullptr) {
-        syntex[symbol.getSyntax()] = &symbol;
+        addSymbol(symbol.getSyntax(), symbol);
 
         auto& syntax = *symbol.getSyntax();
         if (!isUnnamed && syntax.sourceRange().start().buffer() == m_buffer &&
@@ -170,7 +279,7 @@ void SymbolIndexer::indexSymbolName(const slang::ast::Symbol& symbol, bool isUnn
             }
 
             for (auto* tok : tokens) {
-                symdex[tok] = &symbol;
+                addSymbol(tok, symbol);
             }
         }
     }
@@ -184,13 +293,14 @@ void SymbolIndexer::handle(const slang::ast::InstanceArraySymbol& sym) {
     }
 
     auto& instSyntax = sym.getSyntax()->as<slang::syntax::HierarchicalInstanceSyntax>();
-    symdex[&instSyntax.decl->name] = &sym;
+    addSymbol(&instSyntax.decl->name, sym);
 
     // Get definition and body - either from first element or by lookup
     if (!sym.elements.empty() && sym.elements[0]->kind == slang::ast::SymbolKind::Instance) {
         // Use first element if available
         auto& firstInst = sym.elements[0]->as<slang::ast::InstanceSymbol>();
-        indexInstanceSyntax(instSyntax, firstInst.body, firstInst.getDefinition());
+        indexInstanceSyntax(instSyntax, firstInst.body, firstInst.getDefinition(), &firstInst,
+                            firstInst.getParentScope());
     }
     else if (instSyntax.parent != nullptr &&
              instSyntax.parent->kind == slang::syntax::SyntaxKind::HierarchyInstantiation) {
@@ -208,7 +318,7 @@ void SymbolIndexer::handle(const slang::ast::InstanceArraySymbol& sym) {
         auto& definition = result.definition->as<slang::ast::DefinitionSymbol>();
         auto& inst = slang::ast::InstanceSymbol::createInvalid(parentScope->getCompilation(),
                                                                definition);
-        indexInstanceSyntax(instSyntax, inst.body, definition);
+        indexInstanceSyntax(instSyntax, inst.body, definition, &inst, sym.getParentScope());
     }
 }
 
@@ -218,7 +328,7 @@ void SymbolIndexer::handle(const slang::ast::InstanceSymbol& sym) {
         // This means it's the top level- just index the module name
         auto& modName =
             sym.getDefinition().getSyntax()->as<slang::syntax::ModuleDeclarationSyntax>();
-        symdex[&modName.header->name] = &sym.getDefinition();
+        addSymbol(&modName.header->name, sym.getDefinition());
         visitDefault(sym);
         return;
     }
@@ -231,8 +341,9 @@ void SymbolIndexer::handle(const slang::ast::InstanceSymbol& sym) {
     switch (sym.getSyntax()->kind) {
         case slang::syntax::SyntaxKind::HierarchicalInstance: {
             auto& instSyntax = sym.getSyntax()->as<slang::syntax::HierarchicalInstanceSyntax>();
-            symdex[&instSyntax.decl->name] = &sym;
-            indexInstanceSyntax(instSyntax, sym.body, sym.getDefinition());
+            addSymbol(&instSyntax.decl->name, sym);
+            indexInstanceSyntax(instSyntax, sym.body, sym.getDefinition(), &sym,
+                                sym.getParentScope());
         } break;
         default: {
             WARN("Unknown instance symbol kind: {}", toString(sym.getSyntax()->kind));
@@ -247,7 +358,7 @@ void SymbolIndexer::handle(const slang::ast::InstanceSymbol& sym) {
 void SymbolIndexer::handle(const slang::ast::EnumValueSymbol& sym) {
     auto& syntax = sym.getSyntax()->as<slang::syntax::DeclaratorSyntax>();
     if (syntax.dimensions.empty()) {
-        symdex[&syntax.name] = &sym;
+        addSymbol(&syntax.name, sym);
     }
 }
 

--- a/src/util/Markdown.cpp
+++ b/src/util/Markdown.cpp
@@ -107,6 +107,14 @@ Paragraph& Paragraph::newLine() {
     return *this;
 }
 
+Paragraph& Paragraph::append(Paragraph paragraph) {
+    if (buffer.empty())
+        buffer = std::move(paragraph.buffer);
+    else
+        buffer += paragraph.buffer;
+    return *this;
+}
+
 // Document implementation
 
 Paragraph& Document::addParagraph() {
@@ -116,6 +124,16 @@ Paragraph& Document::addParagraph() {
 
 void Document::addParagraph(Paragraph para) {
     paragraphs.push_back(std::move(para));
+}
+
+void Document::append(Document doc) {
+    paragraphs.reserve(paragraphs.size() + doc.paragraphs.size());
+    for (auto& paragraph : doc.paragraphs)
+        paragraphs.push_back(std::move(paragraph));
+}
+
+bool Document::isEmpty() const {
+    return std::ranges::all_of(paragraphs, &Paragraph::isEmpty);
 }
 
 lsp::MarkupContent Document::build() const {

--- a/tests/cpp/GotoTests.cpp
+++ b/tests/cpp/GotoTests.cpp
@@ -41,6 +41,23 @@ TEST_CASE("FindSymbolRefMacro") {
     scanner.scanDocument(hdl);
 }
 
+TEST_CASE("FindMultiSymbolRef") {
+    ServerHarness server("multi_symbol");
+    auto first = server.openFile("first.sv");
+    first.save();
+    auto second = server.openFile("second.sv");
+    second.save();
+    auto hdl = server.openFile("use.sv");
+
+    SymbolRefScanner scanner(
+        {hdl.after("import features::").m_offset, hdl.after("export features::").m_offset,
+         hdl.after("modport endpoint(output ").m_offset, hdl.after("import task ").m_offset,
+         hdl.after("module top;\n    import ").m_offset, hdl.after("leaf u(.").m_offset,
+         hdl.before("duplicate d").m_offset, hdl.before("VALUE =").m_offset,
+         hdl.after("VALUE = ").m_offset, hdl.after("`ifdef ").m_offset});
+    scanner.scanDocument(hdl);
+}
+
 TEST_CASE("GotoDefinition_UndefDirective") {
     ServerHarness server;
 
@@ -109,6 +126,193 @@ TEST_CASE("GotoDefinition_IfdefUndefinedMacro") {
     auto cursor = doc.after("`ifdef ");
     auto defs = cursor.getDefinitions();
     CHECK(defs.empty());
+}
+
+TEST_CASE("GotoDefinition_AllIndexedModuleDefinitions") {
+    ServerHarness server;
+
+    auto first = server.openFile("first.sv", R"(
+module duplicate #(parameter int FIRST_VALUE = 1);
+endmodule
+)");
+    first.save();
+    auto second = server.openFile("second.sv", R"(
+module duplicate #(parameter int SECOND_VALUE = 2);
+endmodule
+)");
+    second.save();
+
+    auto use = server.openFile("use.sv", R"(
+module top;
+    duplicate u();
+endmodule
+)");
+    auto cursor = use.before("duplicate u");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("FIRST_VALUE") != std::string::npos);
+    CHECK(content.find("SECOND_VALUE") != std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_SemanticDefinitionExcludesWorkspaceNamesake") {
+    ServerHarness server;
+
+    auto indexed = server.openFile("indexed.sv", R"(
+interface chosen_if #(parameter int INDEXED_VALUE = 1);
+endinterface
+)");
+    indexed.save();
+
+    auto use = server.openFile("use.sv", R"(
+interface chosen_if #(parameter int LOCAL_VALUE = 2);
+endinterface
+
+module top(chosen_if port);
+endmodule
+)");
+    auto cursor = use.after("module top(");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 1);
+    CHECK(defs[0].targetUri == use.m_uri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("LOCAL_VALUE") != std::string::npos);
+    CHECK(content.find("INDEXED_VALUE") == std::string::npos);
+}
+
+TEST_CASE("HoverDeduplicatesIdenticalIndexedDefinitions") {
+    ServerHarness server;
+
+    auto first = server.openFile("first.sv", R"(
+interface duplicate_iface;
+endinterface
+)");
+    first.save();
+    auto second = server.openFile("second.sv", R"(
+interface duplicate_iface;
+endinterface
+)");
+    second.save();
+
+    auto use = server.openFile("use.sv", R"(
+module top;
+    duplicate_iface instance();
+endmodule
+)");
+    auto cursor = use.before("duplicate_iface instance");
+
+    CHECK(cursor.getDefinitions().size() == 2);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    auto declaration = content.find("interface duplicate_iface;");
+    REQUIRE(declaration != std::string::npos);
+    CHECK(content.find("interface duplicate_iface;", declaration + 1) == std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_MacroGeneratedModuleDefinition") {
+    ServerHarness server;
+
+    auto generated = server.openFile("generated.sv", R"(
+`define DECLARE_DUPLICATE module duplicate #(parameter int MACRO_VALUE = 1); endmodule
+`DECLARE_DUPLICATE
+)");
+    generated.save();
+    auto declared = server.openFile("declared.sv", R"(
+module duplicate #(parameter int DECLARED_VALUE = 2);
+endmodule
+)");
+    declared.save();
+
+    auto use = server.openFile("use.sv", R"(
+module top;
+    duplicate u();
+endmodule
+)");
+    auto cursor = use.before("duplicate u");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("MACRO_VALUE") != std::string::npos);
+    CHECK(content.find("DECLARED_VALUE") != std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_AllIndexedPackageDefinitions") {
+    ServerHarness server;
+
+    auto first = server.openFile("first_pkg.sv", R"(
+package automatic duplicate_pkg;
+    localparam int FIRST_VALUE = 1;
+endpackage
+)");
+    first.save();
+    auto second = server.openFile("second_pkg.sv", R"(
+package static duplicate_pkg;
+    localparam int SECOND_VALUE = 2;
+endpackage
+)");
+    second.save();
+
+    auto use = server.openFile("use_pkg.sv", R"(
+module top;
+    import duplicate_pkg::*;
+endmodule
+)");
+    auto cursor = use.before("duplicate_pkg");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("package automatic duplicate_pkg") != std::string::npos);
+    CHECK(content.find("package static duplicate_pkg") != std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_AllIndexedMacroDefinitions") {
+    ServerHarness server;
+
+    auto first = server.openFile("first_macro.sv", R"(
+`define DUPLICATE_MACRO FIRST_VALUE
+)");
+    first.save();
+    auto second = server.openFile("second_macro.sv", R"(
+`define DUPLICATE_MACRO SECOND_VALUE
+)");
+    second.save();
+
+    auto use = server.openFile("use_macro.sv", R"(
+`ifdef DUPLICATE_MACRO
+`endif
+)");
+    auto cursor = use.after("`ifdef ");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("FIRST_VALUE") != std::string::npos);
+    CHECK(content.find("SECOND_VALUE") != std::string::npos);
 }
 
 TEST_CASE("LoadTransitivePackages") {

--- a/tests/cpp/HoverTests.cpp
+++ b/tests/cpp/HoverTests.cpp
@@ -5,6 +5,15 @@
 #include "utils/ServerHarness.h"
 #include <cstdlib>
 
+static size_t countSubstring(std::string_view text, std::string_view substring) {
+    size_t count = 0;
+    for (size_t pos = 0; (pos = text.find(substring, pos)) != std::string_view::npos;
+         pos += substring.size()) {
+        count++;
+    }
+    return count;
+}
+
 TEST_CASE("HoverMacroExpansion") {
     ServerHarness server;
 
@@ -127,6 +136,227 @@ endmodule
     CAPTURE(content.value);
     CHECK(content.value.find("**TypeAlias** `T`") != std::string::npos);
     CHECK(content.value.find("Value: `byte`") != std::string::npos);
+}
+
+TEST_CASE("HoverAndGotoImplicitPortShowBothSides") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module leaf(input logic [7:0] shared);
+endmodule
+
+module top;
+    logic [7:0] shared;
+    leaf u(.shared);
+endmodule
+)");
+
+    auto cursor = doc.after("u(.");
+    auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+    REQUIRE(info);
+    REQUIRE(info->targets.size() == 1);
+    auto* portTarget = std::get_if<server::DefinitionInfo::PortConnectionTarget>(
+        &info->targets.front());
+    REQUIRE(portTarget);
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetSelectionRange.start.line > defs[1].targetSelectionRange.start.line);
+
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("input logic [7:0] shared") != std::string::npos);
+    CHECK(content.find("logic [7:0] shared") != std::string::npos);
+    CHECK(countSubstring(content, "Type: `logic[7:0]`") == 1);
+    CHECK(countSubstring(content, "Width: `8`") == 1);
+    auto outerLabel = content.find("**Outer**");
+    auto innerLabel = content.find("**Inner**");
+    CHECK(outerLabel != std::string::npos);
+    CHECK(innerLabel != std::string::npos);
+    CHECK(outerLabel < innerLabel);
+}
+
+TEST_CASE("HoverAndGotoForwardedInterfacePortShowBothSides") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+interface bus;
+    logic data;
+endinterface
+
+module leaf(bus shared);
+endmodule
+
+module top(bus shared);
+    leaf u(.shared);
+endmodule
+)");
+
+    auto cursor = doc.after("u(.");
+    auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+    REQUIRE(info);
+    REQUIRE(info->targets.size() == 1);
+    auto* portTarget = std::get_if<server::DefinitionInfo::PortConnectionTarget>(
+        &info->targets.front());
+    REQUIRE(portTarget);
+    CHECK(portTarget->outer.symbol->kind == slang::ast::SymbolKind::InterfacePort);
+    CHECK(portTarget->inner.symbol->kind == slang::ast::SymbolKind::InterfacePort);
+
+    auto location = doc.getLocation(cursor.m_offset);
+    REQUIRE(location);
+    auto analysis = doc.doc->getAnalysis();
+    auto* token = analysis->getWordTokenAt(*location);
+    REQUIRE(token);
+    CHECK(analysis->getSymbolAtToken(token) == portTarget->inner.symbol);
+
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(countSubstring(content, "**Outer**") == 1);
+    CHECK(countSubstring(content, "**Inner**") == 1);
+}
+
+TEST_CASE("HoverAndGotoModportShowTypeAndDirection") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+interface bus;
+    logic [7:0] data;
+    assign data = '0;
+    modport initiator(output data);
+endinterface
+
+module top;
+    bus b();
+endmodule
+)");
+
+    auto cursor = doc.before("data);");
+    auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+    REQUIRE(info);
+    REQUIRE(info->targets.size() == 1);
+    auto* symbolTarget = std::get_if<server::DefinitionInfo::SymbolTarget>(&info->primaryTarget());
+    REQUIRE(symbolTarget);
+    CHECK(symbolTarget->symbol->kind == slang::ast::SymbolKind::ModportPort);
+    CHECK(symbolTarget->syntaxes.size() == 2);
+
+    auto defs = cursor.getDefinitions();
+    CHECK(defs.size() == 2);
+
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("logic [7:0] data") != std::string::npos);
+    CHECK(content.find("output data") != std::string::npos);
+    CHECK(countSubstring(content, "**ModportPort** `data`") == 1);
+    CHECK(countSubstring(content, "Type: `logic[7:0]`") == 1);
+    CHECK(countSubstring(content, "Width: `8`") == 1);
+    CHECK(countSubstring(content, "Driven by continuous assignment") == 1);
+}
+
+TEST_CASE("HoverAndGotoExplicitModportPrototypeRetainsDeclaration") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+interface bus;
+    task transfer(input logic value);
+    endtask
+    modport matching(import task transfer(input logic value));
+    modport mismatched(import task transfer(input int value));
+endinterface
+)");
+
+    auto matching = doc.after("matching(import task ");
+    auto matchingInfo = doc.getDefinitionInfoAt(matching.m_offset);
+    REQUIRE(matchingInfo);
+    REQUIRE(matchingInfo->targets.size() == 2);
+    CHECK(std::get<server::DefinitionInfo::SymbolTarget>(matchingInfo->targets[0]).symbol->kind ==
+          slang::ast::SymbolKind::MethodPrototype);
+    CHECK(std::get<server::DefinitionInfo::SymbolTarget>(matchingInfo->targets[1]).symbol->kind ==
+          slang::ast::SymbolKind::Subroutine);
+    auto matchingLocation = doc.getLocation(matching.m_offset);
+    REQUIRE(matchingLocation);
+    auto analysis = doc.doc->getAnalysis();
+    auto* matchingToken = analysis->getWordTokenAt(*matchingLocation);
+    REQUIRE(matchingToken);
+    CHECK(analysis->getSymbolAtToken(matchingToken) ==
+          std::get<server::DefinitionInfo::SymbolTarget>(matchingInfo->targets[1]).symbol);
+
+    auto matchingDefs = matching.getDefinitions();
+    REQUIRE(matchingDefs.size() == 2);
+    CHECK(matchingDefs[0].targetSelectionRange.start.line == 4);
+    CHECK(matchingDefs[1].targetSelectionRange.start.line == 2);
+
+    auto matchingHover = doc.getHoverAt(matching.m_offset);
+    REQUIRE(matchingHover);
+    auto matchingContent = rfl::get<lsp::MarkupContent>(matchingHover->contents).value;
+    CHECK(matchingContent.find("**MethodPrototype** `transfer` in `bus.matching`") !=
+          std::string::npos);
+    CHECK(matchingContent.find("**Subroutine** `transfer` in `bus`") != std::string::npos);
+    CHECK(matchingContent.find("task transfer(input logic value);") != std::string::npos);
+
+    auto mismatched = doc.after("mismatched(import task ");
+    auto mismatchedInfo = doc.getDefinitionInfoAt(mismatched.m_offset);
+    REQUIRE(mismatchedInfo);
+    REQUIRE(mismatchedInfo->targets.size() == 1);
+    CHECK(std::get<server::DefinitionInfo::SymbolTarget>(mismatchedInfo->targets[0]).symbol->kind ==
+          slang::ast::SymbolKind::MethodPrototype);
+    auto mismatchedLocation = doc.getLocation(mismatched.m_offset);
+    REQUIRE(mismatchedLocation);
+    auto* mismatchedToken = analysis->getWordTokenAt(*mismatchedLocation);
+    REQUIRE(mismatchedToken);
+    CHECK(analysis->getSymbolAtToken(mismatchedToken) ==
+          std::get<server::DefinitionInfo::SymbolTarget>(mismatchedInfo->targets[0]).symbol);
+
+    auto mismatchedDefs = mismatched.getDefinitions();
+    REQUIRE(mismatchedDefs.size() == 1);
+    CHECK(mismatchedDefs[0].targetSelectionRange.start.line == 5);
+
+    auto mismatchedHover = doc.getHoverAt(mismatched.m_offset);
+    REQUIRE(mismatchedHover);
+    auto mismatchedContent = rfl::get<lsp::MarkupContent>(mismatchedHover->contents).value;
+    CHECK(mismatchedContent.find("**MethodPrototype** `transfer` in `bus.mismatched`") !=
+          std::string::npos);
+    CHECK(mismatchedContent.find("task transfer(input int value)") != std::string::npos);
+}
+
+TEST_CASE("HoverGeneratedSymbolsShowsEveryValue") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module top;
+    for (genvar i = 0; i < 3; i++) begin : g
+        localparam int VALUE = i;
+        logic [VALUE:0] data;
+    end
+endmodule
+)");
+
+    auto checkAllValues = [&](Cursor cursor) {
+        auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+        REQUIRE(info);
+        CHECK(info->targets.size() == 3);
+
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+        CHECK(content.find("Value: `0`") != std::string::npos);
+        CHECK(content.find("Value: `1`") != std::string::npos);
+        CHECK(content.find("Value: `2`") != std::string::npos);
+
+        // All elaborated symbols share the same source declaration.
+        CHECK(cursor.getDefinitions().size() == 1);
+    };
+
+    checkAllValues(doc.before("VALUE ="));
+    checkAllValues(doc.before("VALUE:0"));
+
+    auto genvarHover = doc.getHoverAt(doc.after("VALUE = ").m_offset);
+    REQUIRE(genvarHover);
+    auto genvarContent = rfl::get<lsp::MarkupContent>(genvarHover->contents).value;
+    CHECK(genvarContent.find("Value range: `0` through `2`") != std::string::npos);
+    CHECK(genvarContent.find("Value: `0`") == std::string::npos);
 }
 
 TEST_CASE("HoverPlaintextDocComments") {

--- a/tests/cpp/MarkupTests.cpp
+++ b/tests/cpp/MarkupTests.cpp
@@ -1,5 +1,6 @@
 #include "catch2/catch_test_macros.hpp"
 #include "util/Markdown.h"
+#include <utility>
 
 static std::string escapeMultilineMarkdown(std::string_view text) {
     std::string escaped;
@@ -84,4 +85,27 @@ TEST_CASE("AppendCode_NoBackticks") {
 
     // Should use single backticks without spaces (no backticks in content)
     CHECK(result == "`int variable = 42`");
+}
+
+TEST_CASE("ComposeAndCompareMarkup") {
+    using namespace server::markup;
+
+    Paragraph header;
+    header.appendText("header");
+    Paragraph detail;
+    detail.appendText(" detail");
+    header.append(std::move(detail));
+
+    Paragraph expected;
+    expected.appendText("header detail");
+    CHECK(header == expected);
+
+    Document first;
+    CHECK(first.isEmpty());
+    first.addParagraph(std::move(header));
+
+    Document second;
+    second.addParagraph(std::move(expected));
+    CHECK(first == second);
+    CHECK_FALSE(first.isEmpty());
 }

--- a/tests/cpp/golden/FindMultiSymbolRef.out
+++ b/tests/cpp/golden/FindMultiSymbolRef.out
@@ -1,0 +1,126 @@
+
+package features;
+
+    localparam int ITEM = 4;
+
+endpackage
+
+package forwarded;
+
+    import features::ITEM;
+                     ^^^^ Ref -> **Parameter** `ITEM` in `features`  \n\Type: `int`  \n\Value: `4`  \n\\n\\n\---\n\\n\`localparam int ITEM = 4`
+
+    export features::ITEM;
+                     ^^^^ Ref -> **Parameter** `ITEM` in `features`  \n\Type: `int`  \n\Value: `4`  \n\\n\\n\---\n\\n\`localparam int ITEM = 4`
+
+endpackage
+
+interface bus;
+
+    logic [3:0] data;
+
+    task run(input logic value);
+
+    endtask
+
+    modport endpoint(output data, import task run(input logic value));
+                            ^^^^ Ref ->
+    | **ModportPort** `data` in `bus.endpoint`
+    | Type: `logic[3:0]`
+    | Width: `4`
+    | ---
+    | `output data`
+    | ---
+    | `logic [3:0] data;`
+                                              ^^^ Ref ->
+    | **MethodPrototype** `run` in `bus.endpoint`
+    | ---
+    | `task run(input logic value)`
+    | ---
+    | **Subroutine** `run` in `bus`
+    | ---
+    | `task run(input logic value);
+    | endtask`
+
+endinterface
+
+module leaf(input logic [3:0] shared);
+
+endmodule
+
+module top;
+
+    import duplicate_pkg::*;
+           ^^^^^^^^^^^^^ Ref ->
+    | **Package** `duplicate_pkg`
+    | ---
+    | `package automatic duplicate_pkg;`
+    | ---
+    | **Package** `duplicate_pkg`
+    | ---
+    | `package static duplicate_pkg;`
+
+    logic [3:0] shared;
+
+    leaf u(.shared);
+            ^^^^^^ Ref ->
+    | **Outer** **Variable** `shared` in `top`
+    | Type: `logic[3:0]`
+    | Width: `4`
+    | ---
+    | `logic [3:0] shared;`
+    | ---
+    | **Inner** **Input Net** `shared` in `leaf`
+    | ---
+    | `input logic [3:0] shared`
+
+    bus b();
+
+    duplicate d();
+    ^^^^^^^^^ Ref ->
+    | **Module** `duplicate`
+    | ---
+    | `module duplicate #(parameter int FIRST_MODULE = 1);`
+    | ---
+    | **Module** `duplicate`
+    | ---
+    | `module duplicate #(parameter int SECOND_MODULE = 2);`
+
+    for (genvar i = 0; i < 2; i++) begin : g
+
+        localparam int VALUE = i;
+                       ^^^^^ Ref ->
+    | **Parameter** `VALUE` in `top.g`
+    | Type: `int`
+    | Value: `0`
+    | ---
+    | `localparam int VALUE = i`
+    | ---
+    | **Parameter** `VALUE` in `top.g`
+    | Value: `1`
+    | ---
+    | `localparam int VALUE = i`
+                               ^ Ref ->
+    | **Genvar** `i` in `top.g`
+    | Type: `integer`
+    | Value range: `0` through `1`
+    | ---
+    | `i`
+
+    end
+
+endmodule
+
+`ifdef MULTI_MACRO
+       ^^^^^^^^^^^ Ref ->
+    | DefineDirective MULTI_MACRO
+    | From `macro_second.svh`
+    | ---
+    | ``define MULTI_MACRO SECOND_MACRO`
+    | ---
+    | DefineDirective MULTI_MACRO
+    | From `macro_first.svh`
+    | ---
+    | ``define MULTI_MACRO FIRST_MACRO`
+
+`endif

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -543,7 +543,7 @@ macromodule m3;
                                ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\\n\\n\---\n\\n\`i`
 
         if (i == 7) begin
-            ^ Ref -> **Parameter** `i` in `m3.genblk1`  \n\Type: `integer`  \n\Value: `8`  \n\\n\\n\---\n\\n\`i`
+            ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\Type: `integer`  \n\Value range: `0` through `8`  \n\\n\\n\---\n\\n\`i`
 
         end
 
@@ -829,14 +829,14 @@ interface Iface;
     modport m(export foo, function void bar(int, logic), task baz, export func);
             ^ Sym m : Modport
                      ^^^ Sym foo : MethodPrototype
-                                        ^^^ Sym bar : Subroutine
-                                                              ^^^ Sym baz : Subroutine
+                                        ^^^ Sym bar : MethodPrototype
+                                                              ^^^ Sym baz : MethodPrototype
                                                                           ^^^^ Sym func : MethodPrototype
 
     modport n(import function void func(int), import task t2);
             ^ Sym n : Modport
-                                   ^^^^ Sym func : Subroutine
-                                                          ^^ Sym t2 : Subroutine
+                                   ^^^^ Sym func : MethodPrototype
+                                                          ^^ Sym t2 : MethodPrototype
 
     modport o(export t2);
             ^ Sym o : Modport

--- a/tests/cpp/golden/FindSymbolRefHdl.out
+++ b/tests/cpp/golden/FindSymbolRefHdl.out
@@ -504,7 +504,7 @@ module TestModule #(
 
             bus_follower.ready <= 1'b0;
             ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`
+                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`\n\\n\---\n\\n\`logic ready;`
 
         end else begin
 
@@ -512,18 +512,18 @@ module TestModule #(
 
             bus_follower.ready <= 1'b1;
             ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`
+                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`\n\\n\---\n\\n\`logic ready;`
 
             if (bus_follower.valid && bus_follower.write_enable) begin
                 ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                             ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`
+                             ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`\n\\n\---\n\\n\`logic valid;`
                                       ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                                                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`
+                                                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`\n\\n\---\n\\n\`logic write_enable;`
 
                 data_out <= bus_follower.data[7:0]; // Convert to data_t size
                 ^^^^^^^^ Ref -> **Output Variable** `data_out` in `TestModule`  \n\Type: `data_t` (aka `logic[7:0]`)  \n\Width: `8`  \n\\n\\n\---\n\\n\`output test_pkg::data_t data_out`
                             ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                                         ^^^^ Ref -> **ModportPort** `data` in `bus_if.follower`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`
+                                         ^^^^ Ref -> **ModportPort** `data` in `bus_if.follower`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`\n\\n\---\n\\n\`data_t data;`
 
             end
 
@@ -539,25 +539,25 @@ module TestModule #(
 
         bus_master.valid <= 1'b0;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`logic valid;`
 
         bus_master.write_enable <= 1'b0;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`logic write_enable;`
 
         bus_master.addr = width_port[0];
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^ Ref -> **ModportPort** `addr` in `bus_if.master`  \n\Type: `logic[31:0]`  \n\Width: `32`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^ Ref -> **ModportPort** `addr` in `bus_if.master`  \n\Type: `logic[31:0]`  \n\Width: `32`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`logic [ADDR_WIDTH-1:0] addr;`
                           ^^^^^^^^^^ Ref -> **Input Net** `width_port` in `TestModule`  \n\Type: `logic[31:0]`  \n\Width: `32`  \n\\n\\n\---\n\\n\some useful info  \n\  \n\\n\\n\---\n\\n\`input logic [test_pkg::WIDTH-1:0] width_port`
 
         bus_master.data <= state;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`data_t data;`
                            ^^^^^ Ref -> **Variable** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`\n\\n\---\n\\n\Driven by always_ff at [hdl_test.sv:132:5](<file:///tests/data/hdl_test.sv#L132,5>)  \n\`always_ff @(posedge clk) begin\n\    if (rst) begin\n\        state   <= test_pkg::STATE_A;\n\        counter <= '0;\n\    end else begin\n\        state   <= state_next;\n\        counter <= counter + 1'b1;\n\        if (thing) begin\n\            $display("Do this thing");\n\        end\n\    end\n\end`
 
         bus_master.data <= pkt_array[0].id;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`data_t data;`
                            ^^^^^^^^^ Ref -> **Input Net** `pkt_array` in `TestModule`  \n\Type: `packet_t$[2]`  \n\\n\\n\---\n\\n\`input test_pkg::packet_t pkt_array[2]`
                                         ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
 

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -360,12 +360,30 @@ protected:
 
 class SymbolRefScanner : public DocumentScanner<server::DefinitionInfo> {
 public:
-    SymbolRefScanner() : DocumentScanner<server::DefinitionInfo>() {}
+    explicit SymbolRefScanner(std::vector<lsp::uint> selectedOffsets = {}) :
+        DocumentScanner<server::DefinitionInfo>(), selectedOffsets(std::move(selectedOffsets)) {}
 
 protected:
+    std::vector<lsp::uint> selectedOffsets;
+
     std::optional<server::DefinitionInfo> getElementAt(DocumentHandle* hdl,
                                                        lsp::uint offset) override {
-        return hdl->getDefinitionInfoAt(offset);
+        auto info = hdl->getDefinitionInfoAt(offset);
+        if (!info || selectedOffsets.empty())
+            return info;
+
+        auto doc = hdl->doc;
+        auto token = doc->getWordTokenAt(slang::SourceLocation(doc->getBuffer(), offset));
+        if (!token)
+            return {};
+
+        for (auto selectedOffset : selectedOffsets) {
+            auto selectedToken = doc->getWordTokenAt(
+                slang::SourceLocation(doc->getBuffer(), selectedOffset));
+            if (selectedToken && selectedToken->location() == token->location())
+                return info;
+        }
+        return {};
     }
 
     void processElementTransition(DocumentHandle* hdl, SourceManager&, lsp::uint offset) override {
@@ -375,7 +393,16 @@ protected:
 
         auto pElem = std::get<server::DefinitionInfo>(*prevElement);
         auto& nameToken = pElem.nameToken();
-        if (tok && nameToken.location() == tok->location()) {
+        bool multilineHover =
+            !selectedOffsets.empty() &&
+            (pElem.targets.size() > 1 || std::ranges::any_of(pElem.targets, [](const auto& target) {
+                 if (std::holds_alternative<server::DefinitionInfo::PortConnectionTarget>(target))
+                     return true;
+                 if (auto* symbol = std::get_if<server::DefinitionInfo::SymbolTarget>(&target))
+                     return symbol->syntaxes.size() > 1;
+                 return false;
+             }));
+        if (tok && nameToken.location() == tok->location() && !multilineHover) {
             auto symbol = pElem.symbol();
             auto kindStr = symbol ? toString(symbol->kind)
                            : pElem.macro() && pElem.macro()->syntaxTarget()
@@ -385,9 +412,7 @@ protected:
             test.record(fmt::format(" Sym {} : {}\n", nameToken.valueText(), kindStr));
         }
         else {
-            test.record(fmt::format(" Ref -> "));
-            // Print hover, but turn newlines into \n
-            // auto maybeHover = doc->getAnalysis().getDocHover(hdl->getPosition(offset), true);
+            test.record(multilineHover ? " Ref ->\n" : " Ref -> ");
             auto maybeHover = hdl->getHoverAt(offset);
             if (!maybeHover) {
                 test.record(" No Hover\n");
@@ -406,6 +431,23 @@ protected:
             replace(hoverText, "````systemverilog\n", "`");
             replace(hoverText, "\n````", "`");
             replace(hoverText, URI::fromFile(findSlangRoot()).str(), "file://");
+            if (multilineHover) {
+                size_t start = 0;
+                while (start <= hoverText.size()) {
+                    auto end = hoverText.find('\n', start);
+                    if (end == std::string::npos)
+                        end = hoverText.size();
+                    auto line = std::string_view(hoverText).substr(start, end - start);
+                    while (line.ends_with(' '))
+                        line.remove_suffix(1);
+                    if (!line.empty())
+                        test.record(fmt::format("    | {}\n", line));
+                    if (end == hoverText.size())
+                        break;
+                    start = end + 1;
+                }
+                return;
+            }
             std::string singleLine;
             for (char c : hoverText) {
                 if (c == '\n' || c == '\r') {

--- a/tests/data/multi_symbol/first.sv
+++ b/tests/data/multi_symbol/first.sv
@@ -1,0 +1,6 @@
+module duplicate #(parameter int FIRST_MODULE = 1);
+endmodule
+
+package automatic duplicate_pkg;
+    localparam int FIRST_PACKAGE = 1;
+endpackage

--- a/tests/data/multi_symbol/macro_first.svh
+++ b/tests/data/multi_symbol/macro_first.svh
@@ -1,0 +1,1 @@
+`define MULTI_MACRO FIRST_MACRO

--- a/tests/data/multi_symbol/macro_second.svh
+++ b/tests/data/multi_symbol/macro_second.svh
@@ -1,0 +1,1 @@
+`define MULTI_MACRO SECOND_MACRO

--- a/tests/data/multi_symbol/second.sv
+++ b/tests/data/multi_symbol/second.sv
@@ -1,0 +1,6 @@
+module duplicate #(parameter int SECOND_MODULE = 2);
+endmodule
+
+package static duplicate_pkg;
+    localparam int SECOND_PACKAGE = 2;
+endpackage

--- a/tests/data/multi_symbol/use.sv
+++ b/tests/data/multi_symbol/use.sv
@@ -1,0 +1,27 @@
+package features;
+    localparam int ITEM = 4;
+endpackage
+package forwarded;
+    import features::ITEM;
+    export features::ITEM;
+endpackage
+interface bus;
+    logic [3:0] data;
+    task run(input logic value);
+    endtask
+    modport endpoint(output data, import task run(input logic value));
+endinterface
+module leaf(input logic [3:0] shared);
+endmodule
+module top;
+    import duplicate_pkg::*;
+    logic [3:0] shared;
+    leaf u(.shared);
+    bus b();
+    duplicate d();
+    for (genvar i = 0; i < 2; i++) begin : g
+        localparam int VALUE = i;
+    end
+endmodule
+`ifdef MULTI_MACRO
+`endif


### PR DESCRIPTION
This is useful for:
- implicit port connections
- multiple syms in the index
- Modports (separate type / direction syntaxes)
- package imports/exports
- gen loops
- probably some more things



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>