### PR TITLE
Assign neovim plugin a version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
         env:
           SLANG_SERVER_BIN: ../../build/${{ matrix.preset }}/bin/slang-server
         with:
-          luarocks_args: 'clients/neovim/slang-server.nvim-scm-1.rockspec --test-type busted -- -C clients/neovim/'
+          luarocks_args: 'clients/neovim/slang-server.nvim-0.2.1-1.rockspec --test-type busted -- -C clients/neovim/'
 
       - name: Package release artifact
         if: inputs.upload_artifacts && !matrix.skip_upload

--- a/clients/neovim/slang-server.nvim-0.2.1-1.rockspec
+++ b/clients/neovim/slang-server.nvim-0.2.1-1.rockspec
@@ -1,6 +1,6 @@
 rockspec_format = "3.0"
 package = "slang-server.nvim"
-version = "scm-1"
+version = "0.2.1-1"
 source = {
    url = "git+https://github.com/hudson-trading/slang-server.nvim",
 }

--- a/scripts/ci/neovim-sync.py
+++ b/scripts/ci/neovim-sync.py
@@ -3,14 +3,33 @@
 import argparse
 import logging
 import os
+import re
 import subprocess
 import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from git import Repo
 from git.util import Actor
-from tempfile import TemporaryDirectory
 
 logger = logging.getLogger()
+
+ROCKSPEC_PATTERN = re.compile(
+    r"^slang-server\.nvim-(?P<version>\d+(?:\.\d+)*)-\d+\.rockspec$"
+)
+
+
+def rockspec_version(directory):
+    rockspecs = list(Path(directory).glob("slang-server.nvim-*.rockspec"))
+    if len(rockspecs) != 1:
+        raise ValueError(
+            f"Expected one rockspec in {directory}, found {len(rockspecs)}"
+        )
+    rockspec = rockspecs[0]
+    match = ROCKSPEC_PATTERN.match(rockspec.name)
+    if not match:
+        raise ValueError(f"Invalid rockspec filename: {rockspec.name}")
+    return match.group("version")
 
 
 def main():
@@ -51,6 +70,10 @@ https://github.com/hudson-trading/slang-server/commit/{this_commit}
     temp_dir = TemporaryDirectory()
     plugin_repo = Repo.clone_from(clone_url, temp_dir.name)
     plugin_remote = plugin_repo.remote()
+    source_version = rockspec_version("clients/neovim")
+    mirrored_version = rockspec_version(temp_dir.name)
+    version = source_version if source_version != mirrored_version else None
+
     branch_ref = f"origin/{branch}"
     if branch == "main":
         pass
@@ -79,12 +102,21 @@ https://github.com/hudson-trading/slang-server/commit/{this_commit}
 
     plugin_repo.index.commit(commit_message, author=author)
 
+    tag = None
+    if version and branch == "main":
+        tag = f"v{version}"
+        logging.warning(f"Rockspec version changed; creating tag {tag}")
+        plugin_repo.create_tag(tag)
+
     if args.dry_run:
         logging.warning("Dry run, not pushing")
         return
 
     logging.warning(f"Pushing to {branch}")
-    plugin_remote.push(f"HEAD:{branch}")
+    refspecs = [f"HEAD:{branch}"]
+    if tag:
+        refspecs.append(f"refs/tags/{tag}:refs/tags/{tag}")
+    plugin_remote.push(refspecs)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/neovim-sync.py
+++ b/scripts/ci/neovim-sync.py
@@ -19,7 +19,7 @@ ROCKSPEC_PATTERN = re.compile(
 )
 
 
-def rockspec_version(directory):
+def rockspec_version(directory, *, required=True):
     rockspecs = list(Path(directory).glob("slang-server.nvim-*.rockspec"))
     if len(rockspecs) != 1:
         raise ValueError(
@@ -28,7 +28,9 @@ def rockspec_version(directory):
     rockspec = rockspecs[0]
     match = ROCKSPEC_PATTERN.match(rockspec.name)
     if not match:
-        raise ValueError(f"Invalid rockspec filename: {rockspec.name}")
+        if required:
+            raise ValueError(f"Invalid rockspec filename: {rockspec.name}")
+        return None
     return match.group("version")
 
 
@@ -71,7 +73,7 @@ https://github.com/hudson-trading/slang-server/commit/{this_commit}
     plugin_repo = Repo.clone_from(clone_url, temp_dir.name)
     plugin_remote = plugin_repo.remote()
     source_version = rockspec_version("clients/neovim")
-    mirrored_version = rockspec_version(temp_dir.name)
+    mirrored_version = rockspec_version(temp_dir.name, required=False)
     version = source_version if source_version != mirrored_version else None
 
     branch_ref = f"origin/{branch}"


### PR DESCRIPTION
In my own neovim config I'd prefer installing plugins with my package manager (nix).

https://github.com/evanwporter/dotfiles/blob/9e9f3cd8a2f21b49e94038ef0244be988f16c496/nix/home/modules/neovim.nix#L87-L118

Unfortunately because the slang-server.nvim plugin has no versions its not really suitable to be packaged.

Thus this PR assigns the very first version to the neovim plugin (0.2.1) and also it changes the ci script to detect version changes in the rockspec and assign a corresponding tag to the repo:

https://github.com/hudson-trading/slang-server.nvim

The hope is that like the vscode extension, the slang-server plugin can be updated independently of the language server.