### PR TITLE
Cancellable requests + worker offload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ add_library(
   src/lsp/URI.cpp
   src/util/Converters.cpp
   src/util/Formatting.cpp
+  src/util/RequestCancel.cpp
   src/util/SlangExtensions.cpp
   src/util/Markdown.cpp
   src/Config.cpp

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -12,7 +12,6 @@
 #include "lsp/LspTypes.h"
 #include "rfl/Generic.hpp"
 #include "util/Timing.h"
-#include <chrono>
 #include <concepts>
 #include <cstdint>
 #include <fmt/format.h>
@@ -160,7 +159,7 @@ protected:
             // Notification
             auto it = notifications.find(request.method);
             if (it != notifications.end()) {
-                const auto start = std::chrono::steady_clock::now();
+                ScopedElapsedMs elapsed(timing.ms);
                 try {
                     if (request.params.has_value()) {
                         it->second(request.params.value());
@@ -168,11 +167,9 @@ protected:
                     else {
                         it->second(std::nullopt);
                     }
-                    timing.ms = elapsedMs(start);
                     timing.kind = HandlerTiming::Kind::NotificationOk;
                 }
                 catch (const std::exception& e) {
-                    timing.ms = elapsedMs(start);
                     timing.error = e.what();
                     timing.kind = HandlerTiming::Kind::NotificationError;
                 }
@@ -205,7 +202,7 @@ protected:
         auto it = requests.find(request.method);
 
         if (it != requests.end()) {
-            const auto start = std::chrono::steady_clock::now();
+            ScopedElapsedMs elapsed(timing.ms);
             try {
                 rfl::Generic req_response;
                 if (request.params.has_value()) {
@@ -214,12 +211,10 @@ protected:
                 else {
                     req_response = it->second(rfl::Generic{});
                 }
-                timing.ms = elapsedMs(start);
                 timing.kind = HandlerTiming::Kind::RequestOk;
                 return req_response;
             }
             catch (const std::exception& e) {
-                timing.ms = elapsedMs(start);
                 timing.error = e.what();
                 timing.kind = HandlerTiming::Kind::RequestError;
                 return RpcError{.code = 1, .message = e.what()};

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -355,7 +355,9 @@ protected:
 
     void waitForWorkerGate() {
         std::unique_lock lock(m_testGateMutex);
-        m_testGateCv.wait(lock, [this] { return m_testGateOpen; });
+        m_testGateCv.wait(lock, [this] {
+            return m_testGateOpen || m_stop.load(std::memory_order_acquire);
+        });
     }
 
     void enqueueMessage(QueuedMessage msg) {
@@ -373,6 +375,14 @@ protected:
         m_queueCv.notify_one();
     }
 
+    void completeQueuedMessage(QueuedMessage& msg, RpcResult result, const HandlerTiming& timing) {
+        logHandlerTiming(timing);
+        if (msg.resultPromise)
+            msg.resultPromise->set_value(std::move(result));
+        if (msg.donePromise)
+            msg.donePromise->set_value();
+    }
+
     void workerLoop() {
         while (true) {
             QueuedMessage msg;
@@ -388,8 +398,29 @@ protected:
                 m_workerBusy = true;
             }
 
+            struct BusyGuard {
+                JsonRpcServer& self;
+                ~BusyGuard() {
+                    {
+                        std::lock_guard lock(self.m_queueMutex);
+                        self.m_workerBusy = false;
+                    }
+                    self.m_idleCv.notify_all();
+                }
+            } busyGuard{*this};
+
             // Test-only gate: allows deterministic pending-cancel coverage.
             waitForWorkerGate();
+            if (m_stop.load(std::memory_order_acquire)) {
+                // Shutting down after dequeue: finish promises so waiters cannot hang.
+                if (msg.req.id)
+                    cancelState.dropPending(requestIdToString(msg.req.id.value()));
+                HandlerTiming timing;
+                timing.method = msg.req.method;
+                timing.kind = HandlerTiming::Kind::Ignored;
+                completeQueuedMessage(msg, std::nullopt, timing);
+                continue;
+            }
 
             HandlerTiming timing;
             RpcResult result = std::nullopt;
@@ -422,18 +453,7 @@ protected:
                         result);
                 }
             }
-            logHandlerTiming(timing);
-
-            if (msg.resultPromise)
-                msg.resultPromise->set_value(std::move(result));
-            if (msg.donePromise)
-                msg.donePromise->set_value();
-
-            {
-                std::lock_guard lock(m_queueMutex);
-                m_workerBusy = false;
-            }
-            m_idleCv.notify_all();
+            completeQueuedMessage(msg, std::move(result), timing);
         }
     }
 
@@ -470,6 +490,7 @@ public:
     /// Test helper: pause the worker after dequeue, before processMessage.
     void pauseWorkerForTest() { setWorkerGateOpen(false); }
     void resumeWorkerForTest() { setWorkerGateOpen(true); }
+    void waitForIdleForTest() { waitForIdle(); }
 
     /// Enqueue and wait until the worker finishes this message.
     void handleMessageAndWait(RpcRequest req) {

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -21,6 +21,7 @@
 #include <rfl/json/write.hpp>
 #include <rfl/visit.hpp>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 
@@ -41,9 +42,13 @@ struct HandlerTiming {
     };
 
     Kind kind = Kind::None;
-    std::string method;
-    std::string id;
+    /// Views into the request still alive in @c handleMessage.
+    std::string_view method;
+    std::string_view id;
+    /// Owned: @c exception::what() does not outlive the catch block.
     std::string error;
+    /// Backing store when the request id is an int.
+    std::string idStorage;
     double ms = 0;
 };
 
@@ -151,7 +156,8 @@ protected:
 
     /// Run the handler with no logging. Caller must hold @c mutex for stdout
     /// sends; format @p timing only after releasing it.
-    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(RpcRequest request,
+    /// @p request must outlive @p timing.method (and logging after unlock).
+    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(const RpcRequest& request,
                                                                         HandlerTiming& timing) {
         timing.method = request.method;
 
@@ -184,14 +190,15 @@ protected:
         }
 
         // Request
-        timing.id = rfl::visit(
-            [&](auto&& id_) -> std::string {
+        rfl::visit(
+            [&](auto&& id_) {
                 using T = typename std::decay_t<decltype(id_)>;
                 if constexpr (std::is_same_v<T, int>) {
-                    return std::to_string(id_);
+                    timing.idStorage = std::to_string(id_);
+                    timing.id = timing.idStorage;
                 }
                 else if constexpr (std::is_same_v<T, std::string>) {
-                    return id_;
+                    timing.id = id_;
                 }
                 else {
                     static_assert(rfl::always_false_v<T>, "Not all cases were covered.");

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -11,18 +11,26 @@
 #include "JsonRpc.h"
 #include "lsp/LspTypes.h"
 #include "rfl/Generic.hpp"
+#include "util/RequestCancel.h"
 #include "util/Timing.h"
+#include <atomic>
 #include <concepts>
+#include <condition_variable>
 #include <cstdint>
 #include <fmt/format.h>
 #include <functional>
+#include <future>
+#include <memory>
 #include <mutex>
 #include <optional>
+#include <queue>
 #include <rfl/json/write.hpp>
 #include <rfl/visit.hpp>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 
 namespace lsp {
@@ -39,10 +47,11 @@ struct HandlerTiming {
         RequestError,
         Ignored,
         NotFound,
+        Cancelled,
     };
 
     Kind kind = Kind::None;
-    /// Views into the request still alive in @c handleMessage.
+    /// Views into the request still alive in @c handleMessage / worker job.
     std::string_view method;
     std::string_view id;
     /// Owned: @c exception::what() does not outlive the catch block.
@@ -80,6 +89,11 @@ inline void logHandlerTiming(const HandlerTiming& timing) {
                                timing.method, timing.id, timing.error);
             timed = true;
             break;
+        case HandlerTiming::Kind::Cancelled:
+            body = fmt::format("<--- {} {}\n-/-> {} {} (cancelled)", timing.method, timing.id,
+                               timing.method, timing.id);
+            timed = true;
+            break;
         case HandlerTiming::Kind::Ignored:
             body = fmt::format("<-/- {} (ignoring threaded req)", timing.method);
             break;
@@ -93,16 +107,42 @@ inline void logHandlerTiming(const HandlerTiming& timing) {
     else
         fmt::print(stderr, "{}\n\n", body);
 }
+
+inline std::string requestIdToString(const rfl::Variant<int, std::string>& id) {
+    return rfl::visit(
+        [](auto&& id_) -> std::string {
+            using T = std::decay_t<decltype(id_)>;
+            if constexpr (std::is_same_v<T, int>)
+                return std::to_string(id_);
+            else if constexpr (std::is_same_v<T, std::string>)
+                return id_;
+            else
+                static_assert(rfl::always_false_v<T>, "Not all cases were covered.");
+        },
+        id);
+}
+
+inline bool isDocMutationMethod(std::string_view method) {
+    return method == "textDocument/didChange" || method == "textDocument/didOpen" ||
+           method == "textDocument/didClose" || method == "textDocument/didSave" ||
+           method == "workspace/didChangeWatchedFiles";
+}
 } // namespace
 
 template<typename Impl>
 class JsonRpcServer {
+public:
+    using RpcResult = std::variant<rfl::Generic, RpcError, std::nullopt_t>;
+
 protected:
     /// method name -> request handler
     std::unordered_map<std::string, std::function<rfl::Generic(rfl::Generic)>> requests;
 
     /// method name -> notification handler
     std::unordered_map<std::string, std::function<void(rfl::Generic)>> notifications;
+
+    /// Cooperative cancel state; safe to touch from the stdin thread and worker.
+    RequestCancelState cancelState;
 
     /// Register an rpc method with the given Params, Return, and Method (name)
     template<typename P, typename R, auto Method>
@@ -154,6 +194,15 @@ protected:
         };
     }
 
+    void applyCancelRequest(const RpcRequest& request) {
+        if (!request.params.has_value())
+            return;
+        auto params = rfl::from_generic<CancelParams, rfl::UnderlyingEnums>(request.params.value());
+        if (!params)
+            return;
+        cancelState.cancel(requestIdToString(params->id));
+    }
+
     /// Run the handler with no logging. Caller must hold @c mutex for stdout
     /// sends; format @p timing only after releasing it.
     /// @p request must outlive @p timing.method (and logging after unlock).
@@ -163,6 +212,12 @@ protected:
 
         if (!request.id) {
             // Notification
+            if (request.method == "$/cancelRequest") {
+                applyCancelRequest(request);
+                timing.kind = HandlerTiming::Kind::NotificationOk;
+                return std::nullopt;
+            }
+
             auto it = notifications.find(request.method);
             if (it != notifications.end()) {
                 ScopedElapsedMs elapsed(timing.ms);
@@ -174,6 +229,10 @@ protected:
                         it->second(std::nullopt);
                     }
                     timing.kind = HandlerTiming::Kind::NotificationOk;
+                }
+                catch (const RequestCancelledException& e) {
+                    timing.error = e.what();
+                    timing.kind = HandlerTiming::Kind::NotificationError;
                 }
                 catch (const std::exception& e) {
                     timing.error = e.what();
@@ -206,11 +265,20 @@ protected:
             },
             request.id.value());
 
+        cancelState.beginRequest(std::string(timing.id));
+        if (cancelState.isCancelled(std::string(timing.id))) {
+            timing.kind = HandlerTiming::Kind::Cancelled;
+            cancelState.endRequest();
+            return RpcError{.code = static_cast<int>(LSPErrorCodes::RequestCancelled),
+                            .message = "Request cancelled"};
+        }
+
         auto it = requests.find(request.method);
 
         if (it != requests.end()) {
             ScopedElapsedMs elapsed(timing.ms);
             try {
+                cancelState.throwIfCancelled();
                 rfl::Generic req_response;
                 if (request.params.has_value()) {
                     req_response = it->second(request.params.value());
@@ -218,57 +286,224 @@ protected:
                 else {
                     req_response = it->second(rfl::Generic{});
                 }
+                cancelState.throwIfCancelled();
                 timing.kind = HandlerTiming::Kind::RequestOk;
+                cancelState.endRequest();
                 return req_response;
+            }
+            catch (const RequestCancelledException& e) {
+                timing.error = e.what();
+                timing.kind = HandlerTiming::Kind::Cancelled;
+                cancelState.endRequest();
+                return RpcError{.code = static_cast<int>(LSPErrorCodes::RequestCancelled),
+                                .message = e.what()};
             }
             catch (const std::exception& e) {
                 timing.error = e.what();
                 timing.kind = HandlerTiming::Kind::RequestError;
+                cancelState.endRequest();
                 return RpcError{.code = 1, .message = e.what()};
             }
         }
 
         timing.kind = HandlerTiming::Kind::NotFound;
+        cancelState.endRequest();
         return std::nullopt;
     }
 
-    void handleMessage(RpcRequest req) {
-        HandlerTiming timing;
+    struct QueuedMessage {
+        RpcRequest req;
+        bool sendResponse = true;
+        std::shared_ptr<std::promise<RpcResult>> resultPromise;
+        std::shared_ptr<std::promise<void>> donePromise;
+    };
+
+    void ensureWorker() {
+        std::lock_guard lock(m_queueMutex);
+        if (m_worker.joinable())
+            return;
+        m_stop.store(false, std::memory_order_release);
+        m_worker = std::thread([this] { workerLoop(); });
+    }
+
+    void stopWorker() {
         {
-            // Mutex serializes stdout (also taken by WCP). Keep only handler +
-            // send under the lock; defer stderr formatting until after unlock.
-            std::lock_guard<std::mutex> lock(mutex);
-            auto result = processMessage(req, timing);
-            std::visit(
-                [req](auto&& value) {
-                    using T = std::decay_t<decltype(value)>;
-                    if constexpr (std::is_same_v<T, rfl::Generic>) {
-                        sendMessage(RpcResponse{
-                            .jsonrpc = "2.0",
-                            .id = req.id,
-                            .result = value,
-                        });
-                    }
-                    else if constexpr (std::is_same_v<T, RpcError>) {
-                        sendMessage(RpcErrorResponse{
-                            .jsonrpc = "2.0",
-                            .id = req.id,
-                            .error = value,
-                        });
-                    }
-                },
-                result);
+            std::lock_guard lock(m_queueMutex);
+            if (!m_worker.joinable())
+                return;
+            m_stop.store(true, std::memory_order_release);
         }
-        logHandlerTiming(timing);
+        // Ensure a paused test gate cannot deadlock join.
+        setWorkerGateOpen(true);
+        m_queueCv.notify_all();
+        if (m_worker.joinable())
+            m_worker.join();
+    }
+
+    void waitForIdle() {
+        std::unique_lock lock(m_queueMutex);
+        m_idleCv.wait(lock, [this] { return m_queue.empty() && !m_workerBusy; });
+    }
+
+    void setWorkerGateOpen(bool open) {
+        {
+            std::lock_guard lock(m_testGateMutex);
+            m_testGateOpen = open;
+        }
+        m_testGateCv.notify_all();
+    }
+
+    void waitForWorkerGate() {
+        std::unique_lock lock(m_testGateMutex);
+        m_testGateCv.wait(lock, [this] { return m_testGateOpen; });
+    }
+
+    void enqueueMessage(QueuedMessage msg) {
+        ensureWorker();
+        if (isDocMutationMethod(msg.req.method))
+            cancelState.cancelAllPendingAndCurrent();
+        if (msg.req.id) {
+            // Eligible for $/cancelRequest only while pending or in-flight.
+            cancelState.registerPending(requestIdToString(msg.req.id.value()));
+        }
+        {
+            std::lock_guard lock(m_queueMutex);
+            m_queue.push(std::move(msg));
+        }
+        m_queueCv.notify_one();
+    }
+
+    void workerLoop() {
+        while (true) {
+            QueuedMessage msg;
+            {
+                std::unique_lock lock(m_queueMutex);
+                m_queueCv.wait(lock, [this] {
+                    return m_stop.load(std::memory_order_acquire) || !m_queue.empty();
+                });
+                if (m_stop.load(std::memory_order_acquire) && m_queue.empty())
+                    break;
+                msg = std::move(m_queue.front());
+                m_queue.pop();
+                m_workerBusy = true;
+            }
+
+            // Test-only gate: allows deterministic pending-cancel coverage.
+            waitForWorkerGate();
+
+            HandlerTiming timing;
+            RpcResult result = std::nullopt;
+            // Own the request so timing.method/id views remain valid after unlock.
+            RpcRequest req = std::move(msg.req);
+            {
+                // Mutex serializes server state + stdout (also taken by WCP).
+                // Stdin stays free to read $/cancelRequest and enqueue work.
+                std::lock_guard lock(mutex);
+                result = processMessage(req, timing);
+                if (msg.sendResponse) {
+                    std::visit(
+                        [&req](auto&& value) {
+                            using T = std::decay_t<decltype(value)>;
+                            if constexpr (std::is_same_v<T, rfl::Generic>) {
+                                sendMessage(RpcResponse{
+                                    .jsonrpc = "2.0",
+                                    .id = req.id,
+                                    .result = value,
+                                });
+                            }
+                            else if constexpr (std::is_same_v<T, RpcError>) {
+                                sendMessage(RpcErrorResponse{
+                                    .jsonrpc = "2.0",
+                                    .id = req.id,
+                                    .error = value,
+                                });
+                            }
+                        },
+                        result);
+                }
+            }
+            logHandlerTiming(timing);
+
+            if (msg.resultPromise)
+                msg.resultPromise->set_value(std::move(result));
+            if (msg.donePromise)
+                msg.donePromise->set_value();
+
+            {
+                std::lock_guard lock(m_queueMutex);
+                m_workerBusy = false;
+            }
+            m_idleCv.notify_all();
+        }
+    }
+
+    /// Enqueue @p req for the worker. $/cancelRequest is applied immediately on
+    /// this thread so it is never stuck behind the request it cancels.
+    void handleMessage(RpcRequest req) {
+        if (req.method == "$/cancelRequest") {
+            applyCancelRequest(req);
+            return;
+        }
+        enqueueMessage(QueuedMessage{.req = std::move(req)});
     }
 
     std::string line;
     std::string content;
+    /// Serializes handler execution (server state) and stdout; shared with WCP.
     std::mutex mutex;
 
+    std::mutex m_queueMutex;
+    std::condition_variable m_queueCv;
+    std::condition_variable m_idleCv;
+    std::queue<QueuedMessage> m_queue;
+    std::thread m_worker;
+    std::atomic<bool> m_stop{false};
+    bool m_workerBusy = false;
+
+    std::mutex m_testGateMutex;
+    std::condition_variable m_testGateCv;
+    bool m_testGateOpen = true;
+
 public:
+    ~JsonRpcServer() { stopWorker(); }
+
+    /// Test helper: pause the worker after dequeue, before processMessage.
+    void pauseWorkerForTest() { setWorkerGateOpen(false); }
+    void resumeWorkerForTest() { setWorkerGateOpen(true); }
+
+    /// Enqueue and wait until the worker finishes this message.
+    void handleMessageAndWait(RpcRequest req) {
+        if (req.method == "$/cancelRequest") {
+            applyCancelRequest(req);
+            return;
+        }
+        auto done = std::make_shared<std::promise<void>>();
+        auto future = done->get_future();
+        enqueueMessage(QueuedMessage{.req = std::move(req), .donePromise = std::move(done)});
+        future.wait();
+    }
+
+    /// Enqueue without waiting; returns a future for the RPC result (no stdout write).
+    std::future<RpcResult> enqueueForTest(RpcRequest req) {
+        auto resultPromise = std::make_shared<std::promise<RpcResult>>();
+        auto future = resultPromise->get_future();
+        if (req.method == "$/cancelRequest") {
+            applyCancelRequest(req);
+            resultPromise->set_value(std::nullopt);
+            return future;
+        }
+        enqueueMessage(QueuedMessage{.req = std::move(req),
+                                     .sendResponse = false,
+                                     .resultPromise = std::move(resultPromise)});
+        return future;
+    }
+
+    /// Process on the worker without writing to stdout; returns the RPC result.
+    /// Used by unit tests to exercise cancel / offload without a real client.
+    RpcResult handleMessageForTest(RpcRequest req) { return enqueueForTest(std::move(req)).get(); }
+
     void run() {
-        // Handle initialize first
+        // Handle initialize first (must finish before advertising readiness).
         RpcRequest req;
         while (true) {
             req = readJson<RpcRequest>(line, content);
@@ -281,15 +516,21 @@ public:
                                              }});
                 continue;
             }
-            handleMessage(req);
+            handleMessageAndWait(std::move(req));
             break;
         }
 
-        // Run until shutdown
+        // Run until shutdown. Enqueue without waiting so stdin can keep reading
+        // cancels / didChange while a heavy request runs on the worker.
+        std::string lastMethod;
         do {
             req = readJson<RpcRequest>(line, content);
-            handleMessage(req);
-        } while (req.method.compare("shutdown") != 0);
+            lastMethod = req.method;
+            handleMessage(std::move(req));
+        } while (lastMethod.compare("shutdown") != 0);
+
+        waitForIdle();
+        stopWorker();
 
         while (true) {
             req = readJson<RpcRequest>(line, content);

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -49,32 +49,45 @@ struct HandlerTiming {
 };
 
 inline void logHandlerTiming(const HandlerTiming& timing) {
+    if (timing.kind == HandlerTiming::Kind::None)
+        return;
+
+    std::string body;
+    bool timed = false;
     switch (timing.kind) {
         case HandlerTiming::Kind::None:
-            break;
+            return;
         case HandlerTiming::Kind::NotificationOk:
-            fmt::print(stderr, "<--- {}\n---- {} ({:.3f}ms)\n\n", timing.method, timing.method,
-                       timing.ms);
+            body = fmt::format("<--- {}\n---- {}", timing.method, timing.method);
+            timed = true;
             break;
         case HandlerTiming::Kind::NotificationError:
-            fmt::print(stderr, "<--- {}\n-/-> {} Error: {} ({:.3f}ms)\n\n", timing.method,
-                       timing.method, timing.error, timing.ms);
+            body = fmt::format("<--- {}\n-/-> {} Error: {}", timing.method, timing.method,
+                               timing.error);
+            timed = true;
             break;
         case HandlerTiming::Kind::RequestOk:
-            fmt::print(stderr, "<--- {} {}\n---> {} {} ({:.3f}ms)\n\n", timing.method, timing.id,
-                       timing.method, timing.id, timing.ms);
+            body = fmt::format("<--- {} {}\n---> {} {}", timing.method, timing.id, timing.method,
+                               timing.id);
+            timed = true;
             break;
         case HandlerTiming::Kind::RequestError:
-            fmt::print(stderr, "<--- {} {}\n-/-> {} {} Error: {} ({:.3f}ms)\n\n", timing.method,
-                       timing.id, timing.method, timing.id, timing.error, timing.ms);
+            body = fmt::format("<--- {} {}\n-/-> {} {} Error: {}", timing.method, timing.id,
+                               timing.method, timing.id, timing.error);
+            timed = true;
             break;
         case HandlerTiming::Kind::Ignored:
-            fmt::print(stderr, "<-/- {} (ignoring threaded req)\n\n", timing.method);
+            body = fmt::format("<-/- {} (ignoring threaded req)", timing.method);
             break;
         case HandlerTiming::Kind::NotFound:
-            fmt::print(stderr, "<-/- {} (not found)\n\n", timing.method);
+            body = fmt::format("<-/- {} (not found)", timing.method);
             break;
     }
+
+    if (timed)
+        fmt::print(stderr, "{} ({:.3f}ms)\n\n", body, timing.ms);
+    else
+        fmt::print(stderr, "{}\n\n", body);
 }
 } // namespace
 

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -11,9 +11,12 @@
 #include "JsonRpc.h"
 #include "lsp/LspTypes.h"
 #include "rfl/Generic.hpp"
+#include "util/Timing.h"
+#include <chrono>
 #include <concepts>
+#include <cstdint>
+#include <fmt/format.h>
 #include <functional>
-#include <iostream>
 #include <mutex>
 #include <optional>
 #include <rfl/json/write.hpp>
@@ -23,6 +26,57 @@
 #include <variant>
 
 namespace lsp {
+
+namespace {
+/// Captured under the RPC mutex; formatted only after unlock so logging I/O is
+/// not serialized onto the critical path.
+struct HandlerTiming {
+    enum class Kind : uint8_t {
+        None,
+        NotificationOk,
+        NotificationError,
+        RequestOk,
+        RequestError,
+        Ignored,
+        NotFound,
+    };
+
+    Kind kind = Kind::None;
+    std::string method;
+    std::string id;
+    std::string error;
+    double ms = 0;
+};
+
+inline void logHandlerTiming(const HandlerTiming& timing) {
+    switch (timing.kind) {
+        case HandlerTiming::Kind::None:
+            break;
+        case HandlerTiming::Kind::NotificationOk:
+            fmt::print(stderr, "<--- {}\n---- {} ({:.3f}ms)\n\n", timing.method, timing.method,
+                       timing.ms);
+            break;
+        case HandlerTiming::Kind::NotificationError:
+            fmt::print(stderr, "<--- {}\n-/-> {} Error: {} ({:.3f}ms)\n\n", timing.method,
+                       timing.method, timing.error, timing.ms);
+            break;
+        case HandlerTiming::Kind::RequestOk:
+            fmt::print(stderr, "<--- {} {}\n---> {} {} ({:.3f}ms)\n\n", timing.method, timing.id,
+                       timing.method, timing.id, timing.ms);
+            break;
+        case HandlerTiming::Kind::RequestError:
+            fmt::print(stderr, "<--- {} {}\n-/-> {} {} Error: {} ({:.3f}ms)\n\n", timing.method,
+                       timing.id, timing.method, timing.id, timing.error, timing.ms);
+            break;
+        case HandlerTiming::Kind::Ignored:
+            fmt::print(stderr, "<-/- {} (ignoring threaded req)\n\n", timing.method);
+            break;
+        case HandlerTiming::Kind::NotFound:
+            fmt::print(stderr, "<-/- {} (not found)\n\n", timing.method);
+            break;
+    }
+}
+} // namespace
 
 template<typename Impl>
 class JsonRpcServer {
@@ -83,14 +137,17 @@ protected:
         };
     }
 
-    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(RpcRequest request) {
+    /// Run the handler with no logging. Caller must hold @c mutex for stdout
+    /// sends; format @p timing only after releasing it.
+    std::variant<rfl::Generic, RpcError, std::nullopt_t> processMessage(RpcRequest request,
+                                                                        HandlerTiming& timing) {
+        timing.method = request.method;
+
         if (!request.id) {
             // Notification
             auto it = notifications.find(request.method);
             if (it != notifications.end()) {
-                std::cerr << "<--- " << request.method << std::endl;
-                // std::cerr << rfl::json::write(request.params, rfl::json::pretty) <<
-                // std::endl;
+                const auto start = std::chrono::steady_clock::now();
                 try {
                     if (request.params.has_value()) {
                         it->second(request.params.value());
@@ -98,24 +155,26 @@ protected:
                     else {
                         it->second(std::nullopt);
                     }
-                    std::cerr << "---- " << request.method << " (notification finished)"
-                              << std::endl;
+                    timing.ms = elapsedMs(start);
+                    timing.kind = HandlerTiming::Kind::NotificationOk;
                 }
                 catch (const std::exception& e) {
-                    std::cerr << "-/-> " << request.method << " Error: " << e.what() << '\n';
+                    timing.ms = elapsedMs(start);
+                    timing.error = e.what();
+                    timing.kind = HandlerTiming::Kind::NotificationError;
                 }
             }
             else if (request.method.find("$/") == 0) {
-                std::cerr << "<-/- " << request.method << " (ignoring threaded req)" << '\n';
+                timing.kind = HandlerTiming::Kind::Ignored;
             }
             else {
-                std::cerr << "<-/- " << request.method << " (method not found)" << '\n';
+                timing.kind = HandlerTiming::Kind::NotFound;
             }
             return std::nullopt;
         }
 
         // Request
-        std::string id = rfl::visit(
+        timing.id = rfl::visit(
             [&](auto&& id_) -> std::string {
                 using T = typename std::decay_t<decltype(id_)>;
                 if constexpr (std::is_same_v<T, int>) {
@@ -133,8 +192,8 @@ protected:
         auto it = requests.find(request.method);
 
         if (it != requests.end()) {
+            const auto start = std::chrono::steady_clock::now();
             try {
-                std::cerr << "<--- " << request.method << " " << id << '\n';
                 rfl::Generic req_response;
                 if (request.params.has_value()) {
                     req_response = it->second(request.params.value());
@@ -142,45 +201,50 @@ protected:
                 else {
                     req_response = it->second(rfl::Generic{});
                 }
-                std::cerr << "---> " << request.method << " " << id << '\n';
+                timing.ms = elapsedMs(start);
+                timing.kind = HandlerTiming::Kind::RequestOk;
                 return req_response;
             }
             catch (const std::exception& e) {
-                std::cerr << "-/-> " << request.method << " " << id << " Error: " << e.what()
-                          << "\n\n";
+                timing.ms = elapsedMs(start);
+                timing.error = e.what();
+                timing.kind = HandlerTiming::Kind::RequestError;
                 return RpcError{.code = 1, .message = e.what()};
             }
         }
-        else {
-            std::cerr << "<-/- " << request.method << " (not found)" << '\n';
-        }
 
+        timing.kind = HandlerTiming::Kind::NotFound;
         return std::nullopt;
     }
 
     void handleMessage(RpcRequest req) {
-        std::lock_guard<std::mutex> lock(mutex);
-        auto result = processMessage(req);
-        std::visit(
-            [req](auto&& value) {
-                using T = std::decay_t<decltype(value)>;
-                if constexpr (std::is_same_v<T, rfl::Generic>) {
-                    sendMessage(RpcResponse{
-                        .jsonrpc = "2.0",
-                        .id = req.id,
-                        .result = value,
-                    });
-                }
-                else if constexpr (std::is_same_v<T, RpcError>) {
-                    sendMessage(RpcErrorResponse{
-                        .jsonrpc = "2.0",
-                        .id = req.id,
-                        .error = value,
-                    });
-                }
-            },
-            result);
-        std::cerr << '\n';
+        HandlerTiming timing;
+        {
+            // Mutex serializes stdout (also taken by WCP). Keep only handler +
+            // send under the lock; defer stderr formatting until after unlock.
+            std::lock_guard<std::mutex> lock(mutex);
+            auto result = processMessage(req, timing);
+            std::visit(
+                [req](auto&& value) {
+                    using T = std::decay_t<decltype(value)>;
+                    if constexpr (std::is_same_v<T, rfl::Generic>) {
+                        sendMessage(RpcResponse{
+                            .jsonrpc = "2.0",
+                            .id = req.id,
+                            .result = value,
+                        });
+                    }
+                    else if constexpr (std::is_same_v<T, RpcError>) {
+                        sendMessage(RpcErrorResponse{
+                            .jsonrpc = "2.0",
+                            .id = req.id,
+                            .error = value,
+                        });
+                    }
+                },
+                result);
+        }
+        logHandlerTiming(timing);
     }
 
     std::string line;

--- a/include/lsp/JsonRpcServer.h
+++ b/include/lsp/JsonRpcServer.h
@@ -12,6 +12,7 @@
 #include "lsp/LspTypes.h"
 #include "rfl/Generic.hpp"
 #include "util/RequestCancel.h"
+#include "util/StackThread.h"
 #include "util/Timing.h"
 #include <atomic>
 #include <concepts>
@@ -28,7 +29,6 @@
 #include <rfl/visit.hpp>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -323,7 +323,8 @@ protected:
         if (m_worker.joinable())
             return;
         m_stop.store(false, std::memory_order_release);
-        m_worker = std::thread([this] { workerLoop(); });
+        // Explicit stack: musl defaults (~128KiB) overflow in CTRE URI matching.
+        m_worker.start([this] { workerLoop(); });
     }
 
     void stopWorker() {
@@ -476,7 +477,7 @@ protected:
     std::condition_variable m_queueCv;
     std::condition_variable m_idleCv;
     std::queue<QueuedMessage> m_queue;
-    std::thread m_worker;
+    StackThread m_worker;
     std::atomic<bool> m_stop{false};
     bool m_workerBusy = false;
 

--- a/include/util/Logging.h
+++ b/include/util/Logging.h
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include "util/Timing.h"
 #include <chrono>
 #include <fmt/color.h>
 #include <fmt/format.h>
@@ -32,15 +33,10 @@ class ScopedTimer {
 public:
     explicit ScopedTimer(std::string name) : m_name(std::move(name)) {
         INFO("{}...", m_name);
-        m_start = std::chrono::high_resolution_clock::now();
+        m_start = std::chrono::steady_clock::now();
     }
 
-    ~ScopedTimer() {
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - m_start);
-        double seconds = static_cast<double>(duration.count()) / 1000000.0;
-        INFO("{} took {:.3f}s", m_name, seconds);
-    }
+    ~ScopedTimer() { INFO("{} took {:.3f}s", m_name, elapsedMs(m_start) / 1000.0); }
 
     ScopedTimer(const ScopedTimer&) = delete;
     ScopedTimer& operator=(const ScopedTimer&) = delete;
@@ -49,7 +45,7 @@ public:
 
 private:
     std::string m_name;
-    std::chrono::high_resolution_clock::time_point m_start;
+    std::chrono::steady_clock::time_point m_start;
 };
 
 template<>

--- a/include/util/RequestCancel.h
+++ b/include/util/RequestCancel.h
@@ -32,94 +32,39 @@ public:
 class RequestCancelState {
 public:
     /// Record that @p id has been enqueued and is eligible for cancel.
-    void registerPending(const std::string& id) {
-        std::lock_guard lock(m_mutex);
-        m_pending.insert(id);
-    }
+    void registerPending(const std::string& id);
 
     /// Forget a pending id that will never run (e.g. discarded during shutdown).
-    void dropPending(const std::string& id) {
-        std::lock_guard lock(m_mutex);
-        m_pending.erase(id);
-        m_cancelled.erase(id);
-    }
+    void dropPending(const std::string& id);
 
-    void cancel(const std::string& id) {
-        std::lock_guard lock(m_mutex);
-        const bool known = m_pending.contains(id) || (m_currentId && *m_currentId == id);
-        if (!known)
-            return;
+    void cancel(const std::string& id);
 
-        m_cancelled.insert(id);
-        if (m_currentId && *m_currentId == id)
-            m_currentCancelled.store(true, std::memory_order_release);
-    }
-
-    /// Cancel whatever the worker is currently executing (used to preempt on didChange).
-    void cancelCurrent() {
-        std::lock_guard lock(m_mutex);
-        if (!m_currentId)
-            return;
-        m_cancelled.insert(*m_currentId);
-        m_currentCancelled.store(true, std::memory_order_release);
-    }
+    /// Cancel whatever the worker is currently executing.
+    void cancelCurrent();
 
     /// Cancel the in-flight request and every still-queued pending request.
-    void cancelAllPendingAndCurrent() {
-        std::lock_guard lock(m_mutex);
-        for (const auto& id : m_pending)
-            m_cancelled.insert(id);
-        if (m_currentId) {
-            m_cancelled.insert(*m_currentId);
-            m_currentCancelled.store(true, std::memory_order_release);
-        }
-    }
+    void cancelAllPendingAndCurrent();
 
-    void beginRequest(const std::string& id) {
-        std::lock_guard lock(m_mutex);
-        m_pending.erase(id);
-        m_currentId = id;
-        m_currentCancelled.store(m_cancelled.contains(id), std::memory_order_release);
-        t_active = this;
-    }
+    void beginRequest(const std::string& id);
+    void endRequest();
 
-    void endRequest() {
-        std::lock_guard lock(m_mutex);
-        if (m_currentId) {
-            m_cancelled.erase(*m_currentId);
-            m_currentId.reset();
-        }
-        m_currentCancelled.store(false, std::memory_order_release);
-        if (t_active == this)
-            t_active = nullptr;
-    }
+    bool isCancelled(const std::string& id) const;
 
-    bool isCancelled(const std::string& id) const {
-        std::lock_guard lock(m_mutex);
-        return m_cancelled.contains(id);
-    }
-
-    void throwIfCancelled() const {
-        if (m_currentCancelled.load(std::memory_order_acquire))
-            throw RequestCancelledException();
-    }
+    void throwIfCancelled() const;
 
     /// Cooperative checkpoint for code that does not have a RequestCancelState&.
     /// No-op when no request is active on this thread (e.g. harness direct calls).
-    static void throwIfActiveCancelled() {
-        if (t_active)
-            t_active->throwIfCancelled();
-    }
+    static void throwIfActiveCancelled();
 
 private:
+    void installActive();
+    void clearActive();
+
     mutable std::mutex m_mutex;
     std::unordered_set<std::string> m_pending;
     std::unordered_set<std::string> m_cancelled;
     std::optional<std::string> m_currentId;
     std::atomic<bool> m_currentCancelled{false};
-
-    /// Worker-thread active cancel state for deep checkpoints without API plumbing.
-    static inline thread_local RequestCancelState* t_active = nullptr;
 };
 
 } // namespace lsp

--- a/include/util/RequestCancel.h
+++ b/include/util/RequestCancel.h
@@ -1,0 +1,125 @@
+//------------------------------------------------------------------------------
+// RequestCancel.h
+// Cooperative cancellation for in-flight JSON-RPC requests.
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+
+namespace lsp {
+
+/// Thrown by handlers when $/cancelRequest (or a preempting doc mutation) wins.
+class RequestCancelledException : public std::runtime_error {
+public:
+    RequestCancelledException() : std::runtime_error("Request cancelled") {}
+};
+
+/// Tracks pending / in-flight request ids and which of those have been cancelled.
+///
+/// Cancel notifications are applied on the stdin thread without waiting for the
+/// worker; the worker observes @c throwIfCancelled() at cooperative checkpoints.
+///
+/// Unknown or already-finished ids are ignored so a late $/cancelRequest cannot
+/// poison a future request that reuses the same id.
+class RequestCancelState {
+public:
+    /// Record that @p id has been enqueued and is eligible for cancel.
+    void registerPending(const std::string& id) {
+        std::lock_guard lock(m_mutex);
+        m_pending.insert(id);
+    }
+
+    /// Forget a pending id that will never run (e.g. discarded during shutdown).
+    void dropPending(const std::string& id) {
+        std::lock_guard lock(m_mutex);
+        m_pending.erase(id);
+        m_cancelled.erase(id);
+    }
+
+    void cancel(const std::string& id) {
+        std::lock_guard lock(m_mutex);
+        const bool known = m_pending.contains(id) || (m_currentId && *m_currentId == id);
+        if (!known)
+            return;
+
+        m_cancelled.insert(id);
+        if (m_currentId && *m_currentId == id)
+            m_currentCancelled.store(true, std::memory_order_release);
+    }
+
+    /// Cancel whatever the worker is currently executing (used to preempt on didChange).
+    void cancelCurrent() {
+        std::lock_guard lock(m_mutex);
+        if (!m_currentId)
+            return;
+        m_cancelled.insert(*m_currentId);
+        m_currentCancelled.store(true, std::memory_order_release);
+    }
+
+    /// Cancel the in-flight request and every still-queued pending request.
+    void cancelAllPendingAndCurrent() {
+        std::lock_guard lock(m_mutex);
+        for (const auto& id : m_pending)
+            m_cancelled.insert(id);
+        if (m_currentId) {
+            m_cancelled.insert(*m_currentId);
+            m_currentCancelled.store(true, std::memory_order_release);
+        }
+    }
+
+    void beginRequest(const std::string& id) {
+        std::lock_guard lock(m_mutex);
+        m_pending.erase(id);
+        m_currentId = id;
+        m_currentCancelled.store(m_cancelled.contains(id), std::memory_order_release);
+        t_active = this;
+    }
+
+    void endRequest() {
+        std::lock_guard lock(m_mutex);
+        if (m_currentId) {
+            m_cancelled.erase(*m_currentId);
+            m_currentId.reset();
+        }
+        m_currentCancelled.store(false, std::memory_order_release);
+        if (t_active == this)
+            t_active = nullptr;
+    }
+
+    bool isCancelled(const std::string& id) const {
+        std::lock_guard lock(m_mutex);
+        return m_cancelled.contains(id);
+    }
+
+    void throwIfCancelled() const {
+        if (m_currentCancelled.load(std::memory_order_acquire))
+            throw RequestCancelledException();
+    }
+
+    /// Cooperative checkpoint for code that does not have a RequestCancelState&.
+    /// No-op when no request is active on this thread (e.g. harness direct calls).
+    static void throwIfActiveCancelled() {
+        if (t_active)
+            t_active->throwIfCancelled();
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    std::unordered_set<std::string> m_pending;
+    std::unordered_set<std::string> m_cancelled;
+    std::optional<std::string> m_currentId;
+    std::atomic<bool> m_currentCancelled{false};
+
+    /// Worker-thread active cancel state for deep checkpoints without API plumbing.
+    static inline thread_local RequestCancelState* t_active = nullptr;
+};
+
+} // namespace lsp

--- a/include/util/StackThread.h
+++ b/include/util/StackThread.h
@@ -1,0 +1,123 @@
+//------------------------------------------------------------------------------
+// StackThread.h
+// std::thread-like helper with an explicit stack size (needed on musl).
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <system_error>
+#include <thread>
+#include <utility>
+
+#ifndef _WIN32
+#    include <pthread.h>
+#endif
+
+namespace lsp {
+
+/// Joinable thread with a configurable stack size on POSIX.
+///
+/// musl's default pthread stack is ~128KiB, which is too small for CTRE's
+/// recursive URI matcher and deep analysis. Main threads typically get 8MiB.
+class StackThread {
+public:
+    static constexpr std::size_t kDefaultStackSize = 8 * 1024 * 1024;
+
+    StackThread() = default;
+
+    template<typename F>
+    explicit StackThread(F&& f, std::size_t stackSize = kDefaultStackSize) {
+        start(std::forward<F>(f), stackSize);
+    }
+
+    StackThread(const StackThread&) = delete;
+    StackThread& operator=(const StackThread&) = delete;
+
+    StackThread(StackThread&& other) noexcept { *this = std::move(other); }
+
+    StackThread& operator=(StackThread&& other) noexcept {
+        if (this == &other)
+            return *this;
+        if (joinable())
+            join();
+#ifdef _WIN32
+        m_thread = std::move(other.m_thread);
+#else
+        m_thread = other.m_thread;
+        m_joinable = other.m_joinable;
+        other.m_joinable = false;
+#endif
+        return *this;
+    }
+
+    ~StackThread() {
+        if (joinable())
+            join();
+    }
+
+    template<typename F>
+    void start(F&& f, std::size_t stackSize = kDefaultStackSize) {
+        if (joinable())
+            throw std::system_error(std::make_error_code(std::errc::device_or_resource_busy),
+                                    "StackThread already started");
+
+#ifdef _WIN32
+        (void)stackSize;
+        m_thread = std::thread(std::forward<F>(f));
+#else
+        auto* fn = new std::function<void()>(std::forward<F>(f));
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        // Round up to page size requirements; ignore failure and keep default.
+        (void)pthread_attr_setstacksize(&attr, stackSize);
+        const int rc = pthread_create(&m_thread, &attr, &StackThread::trampoline, fn);
+        pthread_attr_destroy(&attr);
+        if (rc != 0) {
+            delete fn;
+            throw std::system_error(rc, std::generic_category(), "pthread_create");
+        }
+        m_joinable = true;
+#endif
+    }
+
+    bool joinable() const {
+#ifdef _WIN32
+        return m_thread.joinable();
+#else
+        return m_joinable;
+#endif
+    }
+
+    void join() {
+#ifdef _WIN32
+        if (m_thread.joinable())
+            m_thread.join();
+#else
+        if (!m_joinable)
+            return;
+        pthread_join(m_thread, nullptr);
+        m_joinable = false;
+#endif
+    }
+
+private:
+#ifndef _WIN32
+    static void* trampoline(void* p) {
+        std::unique_ptr<std::function<void()>> fn(static_cast<std::function<void()>*>(p));
+        (*fn)();
+        return nullptr;
+    }
+
+    pthread_t m_thread{};
+    bool m_joinable = false;
+#else
+    std::thread m_thread;
+#endif
+};
+
+} // namespace lsp

--- a/include/util/Timing.h
+++ b/include/util/Timing.h
@@ -14,3 +14,20 @@ inline double elapsedMs(std::chrono::steady_clock::time_point start) {
     return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start)
         .count();
 }
+
+/// Writes elapsed milliseconds into @p out on destruction (no logging).
+class ScopedElapsedMs {
+public:
+    explicit ScopedElapsedMs(double& out) : m_out(out), m_start(std::chrono::steady_clock::now()) {}
+
+    ~ScopedElapsedMs() { m_out = elapsedMs(m_start); }
+
+    ScopedElapsedMs(const ScopedElapsedMs&) = delete;
+    ScopedElapsedMs& operator=(const ScopedElapsedMs&) = delete;
+    ScopedElapsedMs(ScopedElapsedMs&&) = delete;
+    ScopedElapsedMs& operator=(ScopedElapsedMs&&) = delete;
+
+private:
+    double& m_out;
+    std::chrono::steady_clock::time_point m_start;
+};

--- a/include/util/Timing.h
+++ b/include/util/Timing.h
@@ -1,0 +1,16 @@
+//------------------------------------------------------------------------------
+// Timing.h
+// Lightweight timing helpers (no logging macros — safe to include from tests).
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <chrono>
+
+/// Elapsed milliseconds since @p start (steady clock).
+inline double elapsedMs(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start)
+        .count();
+}

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -20,6 +20,7 @@
 #include "util/Formatting.h"
 #include "util/Logging.h"
 #include "util/Markdown.h"
+#include "util/RequestCancel.h"
 #include <memory>
 #include <queue>
 #include <string_view>
@@ -874,6 +875,7 @@ std::optional<std::vector<lsp::Location>> ServerDriver::getDocReferences(
     // Helper to process referencing files with a given finder function
     auto processReferencingFiles = [&](std::string_view name, auto&& finder) {
         for (const auto& filePath : m_indexer.getFilesReferencingSymbol(name)) {
+            lsp::RequestCancelState::throwIfActiveCancelled();
             if (filePath == targetDoc->getURI().getPath()) {
                 continue;
             }

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -91,6 +91,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
 
     // LSP Lifecycle
     registerInitialized();
+    registerCancelRequest();
 
     INFO("Server started with pid: {}", OS::getpid());
 
@@ -652,6 +653,7 @@ std::optional<std::vector<lsp::DocumentLink>> SlangServer::getDocDocumentLink(
 
 rfl::Variant<std::vector<lsp::SymbolInformation>, std::vector<lsp::DocumentSymbol>, std ::monostate>
 SlangServer::getDocDocumentSymbol(const lsp::DocumentSymbolParams& params) {
+    cancelState.throwIfCancelled();
     auto doc = m_driver->getDocument(params.textDocument.uri);
     if (doc) {
         return doc->getSymbols();
@@ -760,6 +762,7 @@ SlangServer::getWorkspaceSymbol(const lsp::WorkspaceSymbolParams& params) {
     std::vector<lsp::WorkspaceSymbol> result;
 
     m_indexer.forEachSymbol([&](const std::string& name, const Indexer::GlobalSymbolLoc& entry) {
+        cancelState.throwIfCancelled();
         if (!params.query.empty() && !fuzzyMatch(params.query, name))
             return;
         result.emplace_back(
@@ -816,6 +819,7 @@ lsp::CompletionItem SlangServer::getCompletionItemResolve(const lsp::CompletionI
 
 std::optional<std::vector<lsp::InlayHint>> SlangServer::getDocInlayHint(
     const lsp::InlayHintParams& params) {
+    cancelState.throwIfCancelled();
     auto doc = m_driver->getDocument(params.textDocument.uri);
     if (!doc) {
         return {};
@@ -827,11 +831,13 @@ std::optional<std::vector<lsp::InlayHint>> SlangServer::getDocInlayHint(
 
 std::optional<std::vector<lsp::Location>> SlangServer::getDocReferences(
     const lsp::ReferenceParams& params) {
+    cancelState.throwIfCancelled();
     return m_driver->getDocReferences(params.textDocument.uri, params.position,
                                       params.context.includeDeclaration);
 }
 
 std::optional<lsp::WorkspaceEdit> SlangServer::getDocRename(const lsp::RenameParams& params) {
+    cancelState.throwIfCancelled();
     return m_driver->getDocRename(params.textDocument.uri, params.position, params.newName);
 }
 

--- a/src/document/InlayHintCollector.cpp
+++ b/src/document/InlayHintCollector.cpp
@@ -8,6 +8,7 @@
 #include "util/Converters.h"
 #include "util/Formatting.h"
 #include "util/Logging.h"
+#include "util/RequestCancel.h"
 
 #include "slang/ast/Symbol.h"
 #include "slang/ast/symbols/ClassSymbols.h"
@@ -380,6 +381,7 @@ void InlayHintCollector::collectHints() {
     }
 
     for (auto it = start; it != end; ++it) {
+        lsp::RequestCancelState::throwIfActiveCancelled();
         switch (it->second->kind) {
             case syntax::SyntaxKind::HierarchyInstantiation:
                 handle(it->second->as<HierarchyInstantiationSyntax>());

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -12,6 +12,7 @@
 #include "lsp/LspTypes.h"
 #include "util/Converters.h"
 #include "util/Logging.h"
+#include "util/RequestCancel.h"
 #include "util/SlangExtensions.h"
 #include <fmt/format.h>
 #include <memory>
@@ -492,6 +493,7 @@ void ShallowAnalysis::addLocalReferences(std::vector<lsp::Location>& references,
     const ast::Symbol* targetSymbol = nullptr;
     // First loop: find the target symbol by matching the token location
     for (; it != end; ++it) {
+        lsp::RequestCancelState::throwIfActiveCancelled();
         const auto* token = *it;
         if (token->valueText() != targetName) {
             continue;
@@ -516,6 +518,7 @@ void ShallowAnalysis::addLocalReferences(std::vector<lsp::Location>& references,
     // Second loop: continue from where we left off to find all references
     auto path = m_sourceManager.getFullPath(m_buffer);
     for (; it != end; ++it) {
+        lsp::RequestCancelState::throwIfActiveCancelled();
         const auto* token = *it;
         if (token->valueText() != targetName) {
             continue;

--- a/src/document/SymbolTreeVisitor.cpp
+++ b/src/document/SymbolTreeVisitor.cpp
@@ -10,6 +10,7 @@
 
 #include "lsp/LspTypes.h"
 #include "util/Converters.h"
+#include "util/RequestCancel.h"
 #include <memory>
 #include <optional>
 #include <string>
@@ -31,11 +32,13 @@ SymbolTreeVisitor::SymbolTreeVisitor(const SourceManager& sourceManager) :
 std::vector<lsp::DocumentSymbol> SymbolTreeVisitor::get_symbols(std::shared_ptr<SyntaxTree> tree,
                                                                 const bool macros = true) {
     if (m_symbols.empty()) {
+        lsp::RequestCancelState::throwIfActiveCancelled();
         visit(tree->root());
 
         if (macros) {
             auto tree_macros = tree->getDefinedMacros();
             for (const DefineDirectiveSyntax* const macro : tree_macros) {
+                lsp::RequestCancelState::throwIfActiveCancelled();
                 if (macro && macro->name.range().start() != slang::SourceLocation::NoLocation) {
                     lsp::DocumentSymbol symbol{.kind = lsp::SymbolKind::Constant};
                     bool ok = extract_range(macro->name, symbol);

--- a/src/util/RequestCancel.cpp
+++ b/src/util/RequestCancel.cpp
@@ -1,0 +1,99 @@
+//------------------------------------------------------------------------------
+// RequestCancel.cpp
+// Cooperative cancellation for in-flight JSON-RPC requests.
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+
+#include "util/RequestCancel.h"
+
+namespace lsp {
+namespace {
+// Single definition for all TUs — a header `thread_local` is unsafe across DSO/musl.
+thread_local RequestCancelState* g_activeCancelState = nullptr;
+} // namespace
+
+void RequestCancelState::registerPending(const std::string& id) {
+    std::lock_guard lock(m_mutex);
+    m_pending.insert(id);
+}
+
+void RequestCancelState::dropPending(const std::string& id) {
+    std::lock_guard lock(m_mutex);
+    m_pending.erase(id);
+    m_cancelled.erase(id);
+}
+
+void RequestCancelState::cancel(const std::string& id) {
+    std::lock_guard lock(m_mutex);
+    const bool known = m_pending.contains(id) || (m_currentId && *m_currentId == id);
+    if (!known)
+        return;
+
+    m_cancelled.insert(id);
+    if (m_currentId && *m_currentId == id)
+        m_currentCancelled.store(true, std::memory_order_release);
+}
+
+void RequestCancelState::cancelCurrent() {
+    std::lock_guard lock(m_mutex);
+    if (!m_currentId)
+        return;
+    m_cancelled.insert(*m_currentId);
+    m_currentCancelled.store(true, std::memory_order_release);
+}
+
+void RequestCancelState::cancelAllPendingAndCurrent() {
+    std::lock_guard lock(m_mutex);
+    for (const auto& id : m_pending)
+        m_cancelled.insert(id);
+    if (m_currentId) {
+        m_cancelled.insert(*m_currentId);
+        m_currentCancelled.store(true, std::memory_order_release);
+    }
+}
+
+void RequestCancelState::beginRequest(const std::string& id) {
+    std::lock_guard lock(m_mutex);
+    m_pending.erase(id);
+    m_currentId = id;
+    m_currentCancelled.store(m_cancelled.contains(id), std::memory_order_release);
+    installActive();
+}
+
+void RequestCancelState::endRequest() {
+    std::lock_guard lock(m_mutex);
+    if (m_currentId) {
+        m_cancelled.erase(*m_currentId);
+        m_currentId.reset();
+    }
+    m_currentCancelled.store(false, std::memory_order_release);
+    clearActive();
+}
+
+bool RequestCancelState::isCancelled(const std::string& id) const {
+    std::lock_guard lock(m_mutex);
+    return m_cancelled.contains(id);
+}
+
+void RequestCancelState::throwIfCancelled() const {
+    if (m_currentCancelled.load(std::memory_order_acquire))
+        throw RequestCancelledException();
+}
+
+void RequestCancelState::throwIfActiveCancelled() {
+    if (g_activeCancelState)
+        g_activeCancelState->throwIfCancelled();
+}
+
+void RequestCancelState::installActive() {
+    g_activeCancelState = this;
+}
+
+void RequestCancelState::clearActive() {
+    if (g_activeCancelState == this)
+        g_activeCancelState = nullptr;
+}
+
+} // namespace lsp

--- a/tests/cpp/CancelRequestTests.cpp
+++ b/tests/cpp/CancelRequestTests.cpp
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "lsp/JsonRpc.h"
+#include "lsp/LspTypes.h"
+#include "util/RequestCancel.h"
+#include "utils/ServerHarness.h"
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace lsp;
+
+namespace {
+
+using ServerRpcResult = server::SlangServer::RpcResult;
+
+RpcRequest makeRequest(std::string method, int id, rfl::Generic params) {
+    return RpcRequest{
+        .jsonrpc = "2.0",
+        .id = id,
+        .method = std::move(method),
+        .params = std::move(params),
+    };
+}
+
+RpcRequest makeCancel(int id) {
+    CancelParams params{.id = id};
+    return RpcRequest{
+        .jsonrpc = "2.0",
+        .id = std::nullopt,
+        .method = "$/cancelRequest",
+        .params = rfl::to_generic<rfl::UnderlyingEnums>(params),
+    };
+}
+
+RpcRequest makeDidChange(const URI& uri) {
+    DidChangeTextDocumentParams params{
+        .textDocument = VersionedTextDocumentIdentifier{.version = 2, .uri = uri},
+        .contentChanges = {TextDocumentContentChangeEvent{
+            TextDocumentContentChangeWholeDocument{.text = "module m; endmodule\n"}}},
+    };
+    return RpcRequest{
+        .jsonrpc = "2.0",
+        .id = std::nullopt,
+        .method = "textDocument/didChange",
+        .params = rfl::to_generic<rfl::UnderlyingEnums>(params),
+    };
+}
+
+bool isCancelledError(const ServerRpcResult& result) {
+    return std::holds_alternative<RpcError>(result) &&
+           std::get<RpcError>(result).code == static_cast<int>(LSPErrorCodes::RequestCancelled);
+}
+
+} // namespace
+
+TEST_CASE("RequestCancelState_Basic", "[cancel]") {
+    RequestCancelState state;
+    state.beginRequest("1");
+    REQUIRE_NOTHROW(state.throwIfCancelled());
+
+    state.cancel("1");
+    REQUIRE_THROWS_AS(state.throwIfCancelled(), RequestCancelledException);
+
+    state.endRequest();
+    state.beginRequest("2");
+    REQUIRE_NOTHROW(state.throwIfCancelled());
+    state.endRequest();
+}
+
+TEST_CASE("RequestCancelState_CancelCurrent", "[cancel]") {
+    RequestCancelState state;
+    state.beginRequest("7");
+    state.cancelCurrent();
+    REQUIRE_THROWS_AS(state.throwIfCancelled(), RequestCancelledException);
+    state.endRequest();
+}
+
+TEST_CASE("RequestCancelState_IgnoresUnknownId", "[cancel]") {
+    RequestCancelState state;
+
+    // Late / unknown cancel must not poison a future request that reuses the id.
+    state.cancel("1");
+    state.beginRequest("1");
+    REQUIRE_NOTHROW(state.throwIfCancelled());
+    state.endRequest();
+}
+
+TEST_CASE("RequestCancelState_PendingIdCanBeCancelled", "[cancel]") {
+    RequestCancelState state;
+    state.registerPending("9");
+    state.cancel("9");
+    state.beginRequest("9");
+    REQUIRE_THROWS_AS(state.throwIfCancelled(), RequestCancelledException);
+    state.endRequest();
+}
+
+TEST_CASE("CancelRequest_UnknownIdDoesNotPoisonReuse", "[cancel]") {
+    ServerHarness server;
+    auto doc = server.openFile("cancel_ws.sv", "module top; endmodule\n");
+    doc.save();
+
+    // Cancel id 10 before any such request exists — must be ignored.
+    server.handleMessageForTest(makeCancel(10));
+
+    WorkspaceSymbolParams params{.query = ""};
+    auto result = server.handleMessageForTest(
+        makeRequest("workspace/symbol", 10, rfl::to_generic<rfl::UnderlyingEnums>(params)));
+
+    // Must not return -32800; a late/unknown cancel must not poison id reuse.
+    REQUIRE(std::holds_alternative<rfl::Generic>(result));
+}
+
+TEST_CASE("CancelRequest_PendingRequest_ReturnsCancelled", "[cancel]") {
+    ServerHarness server;
+    auto doc = server.openFile("pend.sv", "module top; endmodule\n");
+    doc.save();
+
+    WorkspaceSymbolParams params{.query = ""};
+    auto target = makeRequest("workspace/symbol", 10, rfl::to_generic<rfl::UnderlyingEnums>(params));
+
+    // Pause after dequeue so the request stays pending (registered) until we cancel.
+    server.pauseWorkerForTest();
+    auto future = server.enqueueForTest(std::move(target));
+    server.handleMessageForTest(makeCancel(10));
+    server.resumeWorkerForTest();
+
+    REQUIRE(isCancelledError(future.get()));
+}
+
+TEST_CASE("RequestCancelState_CancelAllPendingAndCurrent", "[cancel]") {
+    RequestCancelState state;
+    state.registerPending("1");
+    state.registerPending("2");
+    state.beginRequest("1");
+    state.registerPending("3");
+
+    state.cancelAllPendingAndCurrent();
+
+    REQUIRE_THROWS_AS(state.throwIfCancelled(), RequestCancelledException);
+    state.endRequest();
+
+    state.beginRequest("2");
+    REQUIRE_THROWS_AS(state.throwIfCancelled(), RequestCancelledException);
+    state.endRequest();
+
+    state.beginRequest("3");
+    REQUIRE_THROWS_AS(state.throwIfCancelled(), RequestCancelledException);
+    state.endRequest();
+}
+
+TEST_CASE("CancelRequest_DidChangePreemptsQueuedRequest", "[cancel]") {
+    ServerHarness server;
+    auto doc = server.openFile("preempt.sv", "module top; logic a; endmodule\n");
+
+    DocumentSymbolParams symParams{.textDocument = TextDocumentIdentifier{.uri = doc.m_uri}};
+
+    // Pause so documentSymbol stays pending; didChange must cancel it without an
+    // explicit $/cancelRequest.
+    server.pauseWorkerForTest();
+    auto future = server.enqueueForTest(makeRequest(
+        "textDocument/documentSymbol", 20, rfl::to_generic<rfl::UnderlyingEnums>(symParams)));
+    // Enqueue mutation while worker is gated; this marks pending ids cancelled.
+    auto didChangeFut = server.enqueueForTest(makeDidChange(doc.m_uri));
+    server.resumeWorkerForTest();
+
+    REQUIRE(isCancelledError(future.get()));
+    REQUIRE(std::holds_alternative<std::nullopt_t>(didChangeFut.get()));
+}
+
+TEST_CASE("CancelRequest_HandleMessageDoesNotBlockOnCancel", "[cancel]") {
+    ServerHarness server;
+    auto doc = server.openFile("noblock.sv", "module top; endmodule\n");
+    doc.save();
+
+    // Inflate the index so workspace/symbol has something to walk.
+    for (int i = 0; i < 40; ++i) {
+        auto d = server.openFile(fmt::format("mod_{}.sv", i),
+                                 fmt::format("module m_{0}; logic x_{0}; endmodule\n", i));
+        d.save();
+    }
+
+    WorkspaceSymbolParams params{.query = ""};
+    auto heavy = makeRequest("workspace/symbol", 30, rfl::to_generic<rfl::UnderlyingEnums>(params));
+
+    std::atomic<bool> done{false};
+    std::thread runner([&] {
+        (void)server.handleMessageForTest(std::move(heavy));
+        done.store(true);
+    });
+
+    // Wait until the heavy request is likely running (or at least queued).
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+
+    const auto t0 = std::chrono::steady_clock::now();
+    server.handleMessageForTest(makeCancel(30));
+    const auto ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0)
+                        .count();
+    runner.join();
+
+    // Cancel must be applied on the calling thread, not stuck behind workspace/symbol.
+    REQUIRE(ms < 50.0);
+    REQUIRE(done.load());
+}
+
+TEST_CASE("CancelRequest_WorkspaceSymbolRespectsCancelFlag", "[cancel]") {
+    ServerHarness server;
+    for (int i = 0; i < 20; ++i) {
+        auto d = server.openFile(fmt::format("sym_{}.sv", i),
+                                 fmt::format("module s_{0}; endmodule\n", i));
+        d.save();
+    }
+
+    // Pause after dequeue so beginRequest has not run yet; cancel while pending,
+    // then resume — processMessage must observe the flag and return -32800.
+    server.pauseWorkerForTest();
+    auto future = server.enqueueForTest(
+        makeRequest("workspace/symbol", 42,
+                    rfl::to_generic<rfl::UnderlyingEnums>(WorkspaceSymbolParams{.query = ""})));
+    server.handleMessageForTest(makeCancel(42));
+    server.resumeWorkerForTest();
+    REQUIRE(isCancelledError(future.get()));
+}

--- a/tests/cpp/CancelRequestTests.cpp
+++ b/tests/cpp/CancelRequestTests.cpp
@@ -118,7 +118,8 @@ TEST_CASE("CancelRequest_PendingRequest_ReturnsCancelled", "[cancel]") {
     doc.save();
 
     WorkspaceSymbolParams params{.query = ""};
-    auto target = makeRequest("workspace/symbol", 10, rfl::to_generic<rfl::UnderlyingEnums>(params));
+    auto target = makeRequest("workspace/symbol", 10,
+                              rfl::to_generic<rfl::UnderlyingEnums>(params));
 
     // Pause after dequeue so the request stays pending (registered) until we cancel.
     server.pauseWorkerForTest();
@@ -165,8 +166,13 @@ TEST_CASE("CancelRequest_DidChangePreemptsQueuedRequest", "[cancel]") {
     auto didChangeFut = server.enqueueForTest(makeDidChange(doc.m_uri));
     server.resumeWorkerForTest();
 
-    REQUIRE(isCancelledError(future.get()));
-    REQUIRE(std::holds_alternative<std::nullopt_t>(didChangeFut.get()));
+    auto symResult = future.get();
+    auto changeResult = didChangeFut.get();
+    server.waitForIdleForTest();
+
+    REQUIRE(isCancelledError(symResult));
+    // Notification result is nullopt / empty — must not be an RPC error.
+    REQUIRE_FALSE(std::holds_alternative<RpcError>(changeResult));
 }
 
 TEST_CASE("CancelRequest_HandleMessageDoesNotBlockOnCancel", "[cancel]") {
@@ -195,8 +201,8 @@ TEST_CASE("CancelRequest_HandleMessageDoesNotBlockOnCancel", "[cancel]") {
 
     const auto t0 = std::chrono::steady_clock::now();
     server.handleMessageForTest(makeCancel(30));
-    const auto ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0)
-                        .count();
+    const auto ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
     runner.join();
 
     // Cancel must be applied on the calling thread, not stuck behind workspace/symbol.

--- a/tests/cpp/LatencyTests.cpp
+++ b/tests/cpp/LatencyTests.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "util/Timing.h"
+#include "utils/ServerHarness.h"
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct TimedResult {
+    std::string name;
+    double ms = 0;
+    size_t amount = 0; // optional count (tokens, symbols, hints, ...)
+};
+
+std::string makeLargeSv(int moduleCount) {
+    std::string text;
+    text.reserve(static_cast<size_t>(moduleCount) * 280);
+    text += "// Generated latency fixture\n";
+    for (int i = 0; i < moduleCount; i++) {
+        text += fmt::format(R"(
+module m{0} #(
+    parameter int WIDTH_{0} = 8,
+    parameter type T_{0} = logic
+);
+    typedef logic [WIDTH_{0}-1:0] word_{0}_t;
+    word_{0}_t data_{0};
+    word_{0}_t addr_{0};
+
+    function automatic word_{0}_t f_{0}(input word_{0}_t x);
+        return x + WIDTH_{0};
+    endfunction
+
+    initial begin
+        word_{0}_t y = f_{0}(data_{0});
+        $display("%0d", y);
+    end
+endmodule
+)",
+                            i);
+    }
+    return text;
+}
+
+template<typename Fn>
+TimedResult timeIt(std::string name, Fn&& fn) {
+    const auto start = std::chrono::steady_clock::now();
+    size_t amount = static_cast<size_t>(fn());
+    return TimedResult{std::move(name), elapsedMs(start), amount};
+}
+
+// Print on success (Catch INFO only shows on failure unless -s).
+void report(const TimedResult& r) {
+    if (r.amount > 0) {
+        fmt::print(stderr, "LATENCY {}: {:.3f}ms (n={})\n", r.name, r.ms, r.amount);
+    }
+    else {
+        fmt::print(stderr, "LATENCY {}: {:.3f}ms\n", r.name, r.ms);
+    }
+}
+
+double medianMs(std::vector<double> samples) {
+    REQUIRE_FALSE(samples.empty());
+    std::sort(samples.begin(), samples.end());
+    return samples[samples.size() / 2];
+}
+
+} // namespace
+
+TEST_CASE("RequestLatency_LargeDocument", "[latency]") {
+    // ~100 modules → a few thousand lines; large enough to expose whole-document cost,
+    // small enough for CI. Soft upper bounds catch catastrophic regressions only.
+    constexpr int kModules = 100;
+    constexpr int kWarmIters = 5;
+
+    auto text = makeLargeSv(kModules);
+    ServerHarness server;
+
+    // didOpen → updateDoc → issueDiagnosticsTo → getAnalysis. That is the true first-touch
+    // cost; a later getAnalysis() would only measure a warm cache hit.
+    const auto openStart = std::chrono::steady_clock::now();
+    auto hdl = server.openFile("latency_large.sv", std::move(text));
+    const auto openMs = elapsedMs(openStart);
+    REQUIRE(hdl.doc);
+    REQUIRE(hdl.doc->hasAnalysis());
+    auto open = TimedResult{"open_and_analyze", openMs,
+                            hdl.doc->getAnalysis()->syntaxes.collected.size()};
+    report(open);
+    CHECK(open.ms < 5000.0);
+
+    // Invalidate analysis the way an edit does, then rebuild.
+    hdl.append("\n");
+    hdl.publishChanges();
+    auto rebuild = timeIt("shallow_analysis_rebuild", [&] {
+        auto analysis = hdl.doc->getAnalysis();
+        REQUIRE(analysis);
+        return analysis->syntaxes.collected.size();
+    });
+    report(rebuild);
+    CHECK(rebuild.ms < 5000.0);
+
+    auto analysis = hdl.doc->getAnalysis();
+    REQUIRE(analysis);
+    const size_t tokenCount = analysis->syntaxes.collected.size();
+    fmt::print(stderr, "LATENCY document tokens: {}\n", tokenCount);
+    CHECK(tokenCount > 1000);
+
+    // Floor for a full-document token pass (semanticTokens/full will sit above this).
+    auto tokenWalk = timeIt("token_walk", [&] {
+        size_t touched = 0;
+        for (const auto* token : analysis->syntaxes.collected) {
+            if (token) {
+                touched += token->rawText().size();
+            }
+        }
+        return touched;
+    });
+    report(tokenWalk);
+    CHECK(tokenWalk.ms < 1000.0);
+
+    std::vector<double> symbolSamples;
+    symbolSamples.reserve(kWarmIters);
+    size_t symbolCount = 0;
+    for (int i = 0; i < kWarmIters; i++) {
+        auto sample = timeIt("documentSymbol", [&] {
+            auto symbols = hdl.getSymbolTree();
+            return symbols.size();
+        });
+        symbolCount = sample.amount;
+        symbolSamples.push_back(sample.ms);
+    }
+    auto symbolsMedian = TimedResult{"documentSymbol_median", medianMs(symbolSamples), symbolCount};
+    report(symbolsMedian);
+    CHECK(symbolsMedian.ms < 2000.0);
+
+    auto hoverPos = hdl.m_text.find("WIDTH_0");
+    REQUIRE(hoverPos != std::string::npos);
+    std::vector<double> hoverSamples;
+    hoverSamples.reserve(kWarmIters);
+    for (int i = 0; i < kWarmIters; i++) {
+        auto sample = timeIt("hover", [&] {
+            auto hover = hdl.getHoverAt(static_cast<lsp::uint>(hoverPos));
+            return hover ? size_t{1} : size_t{0};
+        });
+        hoverSamples.push_back(sample.ms);
+    }
+    auto hoverMedian = TimedResult{"hover_median", medianMs(hoverSamples), 0};
+    report(hoverMedian);
+    CHECK(hoverMedian.ms < 1000.0);
+
+    std::vector<double> hintSamples;
+    hintSamples.reserve(kWarmIters);
+    size_t hintCount = 0;
+    for (int i = 0; i < kWarmIters; i++) {
+        auto sample = timeIt("inlayHint", [&] {
+            auto hints = hdl.getAllInlayHints();
+            return hints.size();
+        });
+        hintCount = sample.amount;
+        hintSamples.push_back(sample.ms);
+    }
+    auto hintsMedian = TimedResult{"inlayHint_median", medianMs(hintSamples), hintCount};
+    report(hintsMedian);
+    CHECK(hintsMedian.ms < 2000.0);
+
+    fmt::print(stderr,
+               "LATENCY summary: open={:.3f}ms rebuild={:.3f}ms token_walk={:.3f}ms "
+               "documentSymbol={:.3f}ms hover={:.3f}ms inlayHint={:.3f}ms tokens={}\n",
+               open.ms, rebuild.ms, tokenWalk.ms, symbolsMedian.ms, hoverMedian.ms, hintsMedian.ms,
+               tokenCount);
+}


### PR DESCRIPTION
## Summary
- Cooperative `$/cancelRequest`: applied on the stdin thread, pending/in-flight tracking, unknown ids ignored, cancelled requests return LSP `-32800`.
- Single-worker offload: handlers run on a background worker so stdin stays free; document mutations preempt pending and in-flight requests.
- Mid-work cancel checkpoints in workspace/symbol, documentSymbol, inlay hints, and references/rename paths.
- Unit coverage in `CancelRequestTests`.

## Context
**Depends on #444** (latency instrumentation). Branched from `feat/lsp-request-latency`; please merge #444 first. Until then this PR’s diff also includes those commits.

Also related: semantic tokens #436.

## Test plan
- [ ] `cmake --build build -j8 --target server_unittests`
- [ ] `build/bin/server_unittests "[cancel]"`
- [ ] `build/bin/server_unittests "[latency]"`
- [ ] Dogfood: trigger workspace/symbol or documentSymbol, send `$/cancelRequest`, confirm `-32800`; confirm typing/`didChange` is not stuck behind a long request