### PR TITLE
add support for `textdocument/typeDefinition`

### DIFF
--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -115,12 +115,6 @@ public:
     /// @return Vector of location links to definitions
     std::vector<lsp::LocationLink> getDocDefinition(const URI& uri, const lsp::Position& position);
 
-    /// @brief Gets LSP definition links for a position in a document
-    /// @param uri The URI of the document
-    /// @param position The LSP position to query
-    /// @return Vector of location links to definitions
-    std::vector<lsp::LocationLink> getDocDefinition(const URI& uri, const lsp::Position& position);
-
     /// @brief Gets LSP type definition links for a symbol at a position
     std::vector<lsp::LocationLink> getDocTypeDefinition(const URI& uri,
                                                         const lsp::Position& position);

--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -109,6 +109,22 @@ public:
     std::optional<DefinitionInfo> getDefinitionInfoAt(const URI& uri,
                                                       const lsp::Position& position);
 
+    /// @brief Gets LSP definition links for a position in a document
+    /// @param uri The URI of the document
+    /// @param position The LSP position to query
+    /// @return Vector of location links to definitions
+    std::vector<lsp::LocationLink> getDocDefinition(const URI& uri, const lsp::Position& position);
+
+    /// @brief Gets LSP definition links for a position in a document
+    /// @param uri The URI of the document
+    /// @param position The LSP position to query
+    /// @return Vector of location links to definitions
+    std::vector<lsp::LocationLink> getDocDefinition(const URI& uri, const lsp::Position& position);
+
+    /// @brief Gets LSP type definition links for a symbol at a position
+    std::vector<lsp::LocationLink> getDocTypeDefinition(const URI& uri,
+                                                        const lsp::Position& position);
+
     /// @brief Gets hover information for a symbol at an LSP position
     /// @param uri The URI of the document
     /// @param position The LSP position to query

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -197,6 +197,10 @@ public:
     rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate>
     getDocDefinition(const lsp::DefinitionParams&) override;
 
+    /// Goto Type Definition
+    rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate>
+    getDocTypeDefinition(const lsp::TypeDefinitionParams&) override;
+
     /// Completion (get list of ids and kinds)
     rfl::Variant<std::vector<lsp::CompletionItem>, lsp::CompletionList, std::monostate>
     getDocCompletion(const lsp::CompletionParams&) override;

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -973,6 +973,18 @@ std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::P
 
 namespace {
 
+const ast::InstanceSymbol* getFirstInstance(const ast::InstanceArraySymbol& array) {
+    for (const auto* element : array.elements) {
+        if (auto* instance = element->as_if<ast::InstanceSymbol>())
+            return instance;
+        if (auto* nestedArray = element->as_if<ast::InstanceArraySymbol>()) {
+            if (auto* instance = getFirstInstance(*nestedArray))
+                return instance;
+        }
+    }
+    return nullptr;
+}
+
 /// Given a type it checks if the type is an array and if so it unwraps it.
 /// The loop is for recusively unwrapping nested arrays.
 /// If the type is not an array then it returns the type
@@ -1012,33 +1024,57 @@ std::vector<lsp::LocationLink> ServerDriver::getDocTypeDefinition(const URI& uri
     if (!info || !info->symbol())
         return {};
 
-    const auto* declaredType = info->symbol()->getDeclaredType();
+    const auto* symbol = info->symbol();
+
+    auto makeLink = [&](SourceLocation location, size_t length) {
+        const auto range = toRange(SourceRange(location, location + length), sm);
+        return std::vector<lsp::LocationLink>{lsp::LocationLink{
+            .targetUri = URI::fromFile(sm.getFullPath(location.buffer())),
+            .targetRange = range,
+            .targetSelectionRange = range,
+        }};
+    };
+
+    // A typedef names its own type. Preserve goto-definition behavior instead of following
+    // through its declared type (for example, `typedef some_t[$] other_t`).
+    if (ast::TypeAliasType::isKind(symbol->kind))
+        return makeLink(symbol->location, symbol->name.size());
+
+    // Instances have no declared data type. Their type definition is module / interface /
+    // program definition they instantiate.
+    if (auto* instance = symbol->as_if<ast::InstanceSymbol>()) {
+        const auto& definition = instance->getDefinition();
+        return makeLink(definition.location, definition.name.size());
+    }
+    if (auto* array = symbol->as_if<ast::InstanceArraySymbol>()) {
+        if (auto* instance = getFirstInstance(*array)) {
+            const auto& definition = instance->getDefinition();
+            return makeLink(definition.location, definition.name.size());
+        }
+        return {};
+    }
+
+    const auto* declaredType = symbol->getDeclaredType();
     if (!declaredType)
         return {};
 
-    // If its an array then we grab the underlying type
-    // ie: type_t thing[2]
-    // would return type_t as the underlying type
+    // Strip declaration dimensions to reach named element type.
     const auto* typeDefinition = unwrapArrayType(&declaredType->getType());
-
-    if (!typeDefinition || typeDefinition->name.empty() || !typeDefinition->location)
+    if (!typeDefinition || !typeDefinition->location)
         return {};
 
-    // Only typedef and classes are valid destinations
-    if (!ast::TypeAliasType::isKind(typeDefinition->kind) &&
-        !ast::ClassType::isKind(typeDefinition->kind))
-        return {};
+    if (ast::TypeAliasType::isKind(typeDefinition->kind) ||
+        ast::ClassType::isKind(typeDefinition->kind)) {
+        if (typeDefinition->name.empty())
+            return {};
+        return makeLink(typeDefinition->location, typeDefinition->name.size());
+    }
 
-    // Get the range in the code that the type name is defined at
-    const auto range = toRange(SourceRange(typeDefinition->location,
-                                           typeDefinition->location + typeDefinition->name.size()),
-                               sm);
+    // Anonymous enum types have no name; location points at `enum` keyword.
+    if (ast::EnumType::isKind(typeDefinition->kind))
+        return makeLink(typeDefinition->location, std::string_view("enum").size());
 
-    // There can't be more than one type returned
-    return {lsp::LocationLink{.targetUri = URI::fromFile(
-                                  sm.getFullPath(typeDefinition->location.buffer())),
-                              .targetRange = range,
-                              .targetSelectionRange = range}};
+    return {};
 }
 
 std::optional<std::vector<lsp::DocumentHighlight>> ServerDriver::getDocDocumentHighlight(

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -973,15 +973,23 @@ std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::P
 
 namespace {
 
+/// In an array of instances (modules) this recursively moves down the list and grabs the first
+/// valid instance. Because arrays are homogenous, we only need to look at the first element.
 const ast::InstanceSymbol* getFirstInstance(const ast::InstanceArraySymbol& array) {
-    for (const auto* element : array.elements) {
-        if (auto* instance = element->as_if<ast::InstanceSymbol>())
+    const ast::Symbol* element = array.elements.empty() ? nullptr : array.elements[0];
+
+    while (element) {
+        const auto* instance = element->as_if<ast::InstanceSymbol>();
+        if (instance)
             return instance;
-        if (auto* nestedArray = element->as_if<ast::InstanceArraySymbol>()) {
-            if (auto* instance = getFirstInstance(*nestedArray))
-                return instance;
-        }
+
+        const auto* nestedArray = element->as_if<ast::InstanceArraySymbol>();
+        if (!nestedArray || nestedArray->elements.empty())
+            return nullptr;
+
+        element = nestedArray->elements[0];
     }
+
     return nullptr;
 }
 
@@ -1042,12 +1050,12 @@ std::vector<lsp::LocationLink> ServerDriver::getDocTypeDefinition(const URI& uri
 
     // Instances have no declared data type. Their type definition is module / interface /
     // program definition they instantiate.
-    if (auto* instance = symbol->as_if<ast::InstanceSymbol>()) {
+    if (const auto* instance = symbol->as_if<ast::InstanceSymbol>()) {
         const auto& definition = instance->getDefinition();
         return makeLink(definition.location, definition.name.size());
     }
-    if (auto* array = symbol->as_if<ast::InstanceArraySymbol>()) {
-        if (auto* instance = getFirstInstance(*array)) {
+    if (const auto* array = symbol->as_if<ast::InstanceArraySymbol>()) {
+        if (const auto* instance = getFirstInstance(*array)) {
             const auto& definition = instance->getDefinition();
             return makeLink(definition.location, definition.name.size());
         }

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -30,6 +30,7 @@
 #include "slang/ast/Compilation.h"
 #include "slang/ast/Symbol.h"
 #include "slang/ast/SystemSubroutine.h"
+#include "slang/ast/symbols/ClassSymbols.h"
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/ParameterSymbols.h"
@@ -968,6 +969,76 @@ std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::P
     }
     const auto& info = *maybeInfo;
     return lsp::Hover{.contents = info.getHover(doc->getBuffer(), m_config.hovers.value())};
+}
+
+namespace {
+
+/// Given a type it checks if the type is an array and if so it unwraps it.
+/// The loop is for recusively unwrapping nested arrays.
+/// If the type is not an array then it returns the type
+const ast::Type* unwrapArrayType(const ast::Type* type) {
+    while (type) {
+        switch (type->kind) {
+            case ast::SymbolKind::PackedArrayType:
+                type = &type->as<ast::PackedArrayType>().elementType;
+                break;
+            case ast::SymbolKind::FixedSizeUnpackedArrayType:
+                type = &type->as<ast::FixedSizeUnpackedArrayType>().elementType;
+                break;
+            case ast::SymbolKind::DynamicArrayType:
+                type = &type->as<ast::DynamicArrayType>().elementType;
+                break;
+            case ast::SymbolKind::DPIOpenArrayType:
+                type = &type->as<ast::DPIOpenArrayType>().elementType;
+                break;
+            case ast::SymbolKind::AssociativeArrayType:
+                type = &type->as<ast::AssociativeArrayType>().elementType;
+                break;
+            case ast::SymbolKind::QueueType:
+                type = &type->as<ast::QueueType>().elementType;
+                break;
+            default:
+                return type;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+std::vector<lsp::LocationLink> ServerDriver::getDocTypeDefinition(const URI& uri,
+                                                                  const lsp::Position& position) {
+    const auto info = getDefinitionInfoAt(uri, position);
+    if (!info || !info->symbol())
+        return {};
+
+    const auto* declaredType = info->symbol()->getDeclaredType();
+    if (!declaredType)
+        return {};
+
+    // If its an array then we grab the underlying type
+    // ie: type_t thing[2]
+    // would return type_t as the underlying type
+    const auto* typeDefinition = unwrapArrayType(&declaredType->getType());
+
+    if (!typeDefinition || typeDefinition->name.empty() || !typeDefinition->location)
+        return {};
+
+    // Only typedef and classes are valid destinations
+    if (!ast::TypeAliasType::isKind(typeDefinition->kind) &&
+        !ast::ClassType::isKind(typeDefinition->kind))
+        return {};
+
+    // Get the range in the code that the type name is defined at
+    const auto range = toRange(SourceRange(typeDefinition->location,
+                                           typeDefinition->location + typeDefinition->name.size()),
+                               sm);
+
+    // There can't be more than one type returned
+    return {lsp::LocationLink{.targetUri = URI::fromFile(
+                                  sm.getFullPath(typeDefinition->location.buffer())),
+                              .targetRange = range,
+                              .targetSelectionRange = range}};
 }
 
 std::optional<std::vector<lsp::DocumentHighlight>> ServerDriver::getDocDocumentHighlight(

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -65,6 +65,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
 
     // Doc Features
     registerDocDefinition();
+    registerDocTypeDefinition();
     registerDocHover();
     registerDocDocumentSymbol();
     registerDocDocumentLink();
@@ -240,6 +241,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
                                                }},
                 .hoverProvider = true,
                 .definitionProvider = true,
+                .typeDefinitionProvider = true,
                 .referencesProvider = true,
                 .documentHighlightProvider = true,
                 .documentSymbolProvider = true,
@@ -690,6 +692,11 @@ rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate> 
         return info ? info->getDefinitionLspLinks() : std::vector<lsp::DefinitionLink>{};
 
     return lsp::Definition(info ? info->getDefinitionLspLocs() : std::vector<lsp::Location>{});
+}
+
+rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate> SlangServer::
+    getDocTypeDefinition(const lsp::TypeDefinitionParams& params) {
+    return m_driver->getDocTypeDefinition(params.textDocument.uri, params.position);
 }
 
 std::optional<lsp::Hover> SlangServer::getDocHover(const lsp::HoverParams& params) {

--- a/tests/cpp/GotoTests.cpp
+++ b/tests/cpp/GotoTests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Hudson River Trading
 // SPDX-License-Identifier: MIT
 
+#include "utils/GoldenTest.h"
 #include "utils/ServerHarness.h"
 
 using namespace slang;
@@ -188,6 +189,128 @@ endmodule
 
     checkResultType(std::nullopt);
     checkResultType(true);
+}
+
+namespace {
+void recordTypeDefinition(DocumentHandle& doc, JsonGoldenTest& golden,
+                          std::vector<lsp::LocationLink> links) {
+    REQUIRE(links.size() == 1);
+    const auto& start = links[0].targetSelectionRange.start;
+    auto line = doc.getLine(start.line + 1);
+    if (line.ends_with('\n'))
+        line.remove_suffix(1);
+    golden.record(std::string(line), links[0]);
+};
+} // namespace
+
+TEST_CASE("GotoTypeDefinition_TypedefStuct") {
+    ServerHarness server;
+    JsonGoldenTest golden;
+    auto doc = server.openFile("test.sv", R"(
+package p;
+    typedef struct packed { logic [7:0] data; } payload_t;
+endpackage
+module top;
+    p::payload_t payload;
+endmodule
+)");
+
+    recordTypeDefinition(doc, golden, doc.before("payload;").getTypeDefinitions());
+}
+
+TEST_CASE("GotoTypeDefinition_ArrayTypedefStruct") {
+    ServerHarness server;
+    JsonGoldenTest golden;
+    auto doc = server.openFile("test.sv", R"(
+package p;
+    typedef struct packed { logic [7:0] data; } payload_t;
+endpackage
+module top;
+    p::payload_t payloads [2];
+endmodule
+)");
+    recordTypeDefinition(doc, golden, doc.before("payloads [2]").getTypeDefinitions());
+}
+
+TEST_CASE("GotoTypeDefinition_Typedef") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+package p;
+    typedef struct packed { logic [7:0] data; } payload_t;
+endpackage
+)");
+
+    const auto links = doc.before("payload_t").getTypeDefinitions();
+
+    // Typedefs use same target as goto-definition: typedef name itself.
+    REQUIRE(links.size() == 1);
+    CHECK(links[0].targetSelectionRange.start.line == 2);
+}
+
+TEST_CASE("GotoTypeDefinition_Instance") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module leaf;
+endmodule
+module top;
+    leaf u_leaf();
+endmodule
+)");
+
+    const auto links = doc.before("u_leaf").getTypeDefinitions();
+
+    REQUIRE(links.size() == 1);
+    CHECK(links[0].targetSelectionRange.start.line == 1);
+    CHECK(links[0].targetSelectionRange.start.character == 7);
+}
+
+TEST_CASE("GotoTypeDefinition_Enum") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module top;
+    enum { IDLE, BUSY } state;
+    initial state = IDLE;
+endmodule
+)");
+
+    const auto links = doc.before("IDLE;").getTypeDefinitions();
+
+    REQUIRE(links.size() == 1);
+    CHECK(links[0].targetSelectionRange.start.line == 2);
+    CHECK(links[0].targetSelectionRange.start.character == 4);
+}
+
+TEST_CASE("GotoTypeDefinition_BuiltinType") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module m;
+    logic subject;
+endmodule
+)");
+
+    const auto links = doc.before("subject").getTypeDefinitions();
+
+    // builtins don't have a type we can go to
+    CHECK(links.size() == 0);
+}
+
+TEST_CASE("GotoTypeDefinition_BuiltinTypeBitArray") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module m;
+    bit [7:0] subject;
+endmodule
+)");
+
+    const auto links = doc.before("subject").getTypeDefinitions();
+
+    // builtins don't have a type we can go to
+    CHECK(links.size() == 0);
 }
 
 TEST_CASE("GotoDefinition_AllIndexedModuleDefinitions") {

--- a/tests/cpp/golden/GotoTypeDefinition_ArrayTypedefStruct.json
+++ b/tests/cpp/golden/GotoTypeDefinition_ArrayTypedefStruct.json
@@ -1,0 +1,27 @@
+[
+  {
+    "    typedef struct packed { logic [7:0] data; } payload_t;": {
+      "targetUri": "file://test.sv",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 48
+        },
+        "end": {
+          "line": 2,
+          "character": 57
+        }
+      },
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 48
+        },
+        "end": {
+          "line": 2,
+          "character": 57
+        }
+      }
+    }
+  }
+]

--- a/tests/cpp/golden/GotoTypeDefinition_TypedefStuct.json
+++ b/tests/cpp/golden/GotoTypeDefinition_TypedefStuct.json
@@ -1,0 +1,27 @@
+[
+  {
+    "    typedef struct packed { logic [7:0] data; } payload_t;": {
+      "targetUri": "file://test.sv",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 48
+        },
+        "end": {
+          "line": 2,
+          "character": 57
+        }
+      },
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 48
+        },
+        "end": {
+          "line": 2,
+          "character": 57
+        }
+      }
+    }
+  }
+]

--- a/tests/cpp/utils/ServerHarness.cpp
+++ b/tests/cpp/utils/ServerHarness.cpp
@@ -473,6 +473,15 @@ std::vector<lsp::LocationLink> Cursor::getDefinitions() {
     return {};
 }
 
+std::vector<lsp::LocationLink> Cursor::getTypeDefinitions() {
+    lsp::TypeDefinitionParams params{.textDocument = {.uri = m_doc.m_uri},
+                                     .position = m_doc.getPosition(m_offset)};
+    auto res = m_doc.m_server.getDocTypeDefinition(params);
+    if (rfl::holds_alternative<std::vector<lsp::DefinitionLink>>(res))
+        return rfl::get<std::vector<lsp::DefinitionLink>>(res);
+    return {};
+}
+
 std::vector<lsp::DocumentHighlight> Cursor::getHighlights() {
     auto maybeHighlights = m_doc.m_server.getDocDocumentHighlight(
         lsp::DocumentHighlightParams{.textDocument = {getUri()}, .position = getPosition()});

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -215,6 +215,7 @@ public:
     // Goto definition methods
     bool hasDefinition();
     std::vector<lsp::LocationLink> getDefinitions();
+    std::vector<lsp::LocationLink> getTypeDefinitions();
 
     // Get document highlights
     std::vector<lsp::DocumentHighlight> getHighlights();


### PR DESCRIPTION
Instead of `go to definition`, then `go to definition` on the type, we can now directly go to the type.