### PR TITLE
Completions: add context-aware function and task snippets

### DIFF
--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -627,6 +627,25 @@ void addModuleMemberKwCompletions(std::vector<lsp::CompletionItem>& results) {
         .insertText = "always_latch begin\n\t$0\nend",
         .insertTextFormat = lsp::InsertTextFormat::Snippet,
     });
+    results.emplace_back(lsp::CompletionItem{
+        .label = "function",
+        .kind = lsp::CompletionItemKind::Snippet,
+        .documentation = svCodeBlock(
+            "function automatic functionName(arguments);\n    ...\nendfunction : functionName"),
+        .filterText = "function",
+        .insertText =
+            "function ${1:automatic} ${2:functionName}(${3:arguments});\n\t$0\nendfunction : $2",
+        .insertTextFormat = lsp::InsertTextFormat::Snippet,
+    });
+    results.emplace_back(lsp::CompletionItem{
+        .label = "task",
+        .kind = lsp::CompletionItemKind::Snippet,
+        .documentation = svCodeBlock(
+            "task automatic taskName(arguments);\n    ...\nendtask : taskName"),
+        .filterText = "task",
+        .insertText = "task ${1:automatic} ${2:taskName}(${3:arguments});\n\t$0\nendtask : $2",
+        .insertTextFormat = lsp::InsertTextFormat::Snippet,
+    });
 }
 
 //------------------------------------------------------------------------------

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -427,6 +427,20 @@ TEST_CASE("ModuleMemberCompletion") {
     auto lhs = doc.before("sub_module u_sub (").getResolvedCompletions();
     auto rhs = doc.after("wide_signal =").getResolvedCompletions();
 
+    auto hasCompletion = [](const std::vector<CompletionHandle>& items, std::string_view label) {
+        return std::any_of(items.begin(), items.end(), [&](const CompletionHandle& item) {
+            return item.m_item.label == label;
+        });
+    };
+
+    // Declaration snippets should not be offered from procedural bodies.
+    auto functionBody = doc.after("return ^data;").getCompletions();
+    auto taskBody = doc.after("wide_signal <= 16'h0;").getCompletions();
+    CHECK(!hasCompletion(functionBody, "function"));
+    CHECK(!hasCompletion(functionBody, "task"));
+    CHECK(!hasCompletion(taskBody, "function"));
+    CHECK(!hasCompletion(taskBody, "task"));
+
     golden.record("lhs", lhs);
     golden.record("rhs", rhs);
 

--- a/tests/cpp/golden/ModuleMemberCompletion.json
+++ b/tests/cpp/golden/ModuleMemberCompletion.json
@@ -82,6 +82,17 @@
         "insertTextFormat": "Snippet"
       },
       {
+        "label": "function",
+        "kind": "Snippet",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\nfunction automatic functionName(arguments);\n    ...\nendfunction : functionName\n````"
+        },
+        "filterText": "function",
+        "insertText": "function ${1:automatic} ${2:functionName}(${3:arguments});\n    $0\nendfunction : $2",
+        "insertTextFormat": "Snippet"
+      },
+      {
         "label": "logic",
         "kind": "Keyword",
         "filterText": "logic"
@@ -102,6 +113,17 @@
           "value": "````systemverilog\ntypedef enum logic [1:0] {\n    IDLE = 2'b00,\n    ACTIVE = 2'b01,\n    WAIT = 2'b10\n} state_t;\n````"
         },
         "filterText": "state_t"
+      },
+      {
+        "label": "task",
+        "kind": "Snippet",
+        "documentation": {
+          "kind": "markdown",
+          "value": "````systemverilog\ntask automatic taskName(arguments);\n    ...\nendtask : taskName\n````"
+        },
+        "filterText": "task",
+        "insertText": "task ${1:automatic} ${2:taskName}(${3:arguments});\n    $0\nendtask : $2",
+        "insertTextFormat": "Snippet"
       },
       {
         "label": "tb",


### PR DESCRIPTION
## Summary

- add server-side `function` and `task` snippet completions in `ModuleMember` contexts
- return Markdown `MarkupContent` documentation for both snippets
- add golden output and verify that the snippets stay out of function and task bodies

This is a focused first step toward #346. It keeps the existing client-side snippets in place.

## Testing

- `build/bin/server_unittests 'ModuleMemberCompletion'`
- `build/bin/server_unittests`
- `uv run prek run --files src/completions/Completions.cpp tests/cpp/CompletionTests.cpp tests/cpp/golden/ModuleMemberCompletion.json`

The full C++ suite passes with 211 test cases and 58,837 assertions.
