### PR TITLE
Fix call hierarchy item source ranges

### DIFF
--- a/include/ast/ServerCompilation.h
+++ b/include/ast/ServerCompilation.h
@@ -83,14 +83,22 @@ public:
             if (range.start().valid()) {
                 auto fullPath = std::filesystem::absolute(
                     m_sourceManager.getFileName(range.start()));
+                auto lspRange = toRange(range, m_sourceManager);
+
                 // only different by to / from field name . . . sigh
                 if constexpr (std::is_same_v<lsp::CallHierarchyIncomingCallsParams, P>) {
-                    result.push_back({.from = {.name = hier, .uri = URI::fromFile(fullPath)},
-                                      .fromRanges = {{toRange(range, m_sourceManager)}}});
+                    result.push_back({.from = {.name = hier,
+                                               .uri = URI::fromFile(fullPath),
+                                               .range = lspRange,
+                                               .selectionRange = lspRange},
+                                      .fromRanges = {lspRange}});
                 }
                 else {
-                    result.push_back({.to = {.name = hier, .uri = URI::fromFile(fullPath)},
-                                      .fromRanges = {{toRange(range, m_sourceManager)}}});
+                    result.push_back({.to = {.name = hier,
+                                             .uri = URI::fromFile(fullPath),
+                                             .range = lspRange,
+                                             .selectionRange = lspRange},
+                                      .fromRanges = {lspRange}});
                 }
             }
         }

--- a/tests/cpp/ConeTests.cpp
+++ b/tests/cpp/ConeTests.cpp
@@ -55,6 +55,16 @@ TEST_CASE("Cone Tracing") {
     SECTION("Incoming Multiple") {
         auto cursor_a = doc.before("a + b;");
         auto cursor_b = doc.before("b;");
+
+        auto result = server.getCallHierarchyIncomingCalls(
+            lsp::CallHierarchyIncomingCallsParams{.item = {.name = "test.the_sub_2.x"}});
+
+        REQUIRE(result.has_value());
+
+        // A multi-bit signal should produce one incoming hierarchy item per
+        // unique driver, not one item per cone leaf.
+        CHECK(result->size() == 2);
+
         server.checkIncomingCalls("test.the_sub_2.x", {{"test.the_sub_2.a", &cursor_a},
                                                        {"test.the_sub_2.b", &cursor_b}});
     }
@@ -79,6 +89,12 @@ TEST_CASE("Cone Tracing") {
         };
         auto result = *incoming("test.the_sub_2.b");
         checkIncoming(result, {{.name = "test.x1", .line = 34, .character = 12}});
+
+        REQUIRE(result.size() == 1);
+        REQUIRE(result[0].fromRanges.size() == 1);
+
+        CHECK(result[0].from.range == result[0].fromRanges[0]);
+        CHECK(result[0].from.selectionRange == result[0].fromRanges[0]);
     }
 
     SECTION("Incoming Single2") {


### PR DESCRIPTION
## Summary

Fixes the source ranges reported on call hierarchy items for driver/incoming-call results.

Previously, `CallHierarchyItem.range` and `selectionRange` were left at their default `(0, 0)` values even though the correct source location was already available in `fromRanges`.

This caused clients that rely on the hierarchy item's own range to display or navigate to the wrong location.

## Changes

- Populate `CallHierarchyItem.range` with the cone leaf source range
- Populate `CallHierarchyItem.selectionRange` with the same source range
- Reuse the converted LSP range for `fromRanges`
- Add regression coverage verifying that `range` and `selectionRange` match the actual incoming-call source location

## Testing

```text
server_unittests "Cone Tracing"
All tests passed
```

Also verified the full test suite locally.

## Issue

Partial fix for #423.

I also investigated the duplicate cone-leaf behavior described in the issue. I tested both the existing multi-bit cone fixture and a minimized 4-bit continuous-assignment reproduction, but could not reproduce duplicate incoming hierarchy entries on current `main`, so this PR intentionally does not add deduplication logic without a failing regression.
