### PR TITLE
Add named port and parameter completions

### DIFF
--- a/include/completions/Completions.h
+++ b/include/completions/Completions.h
@@ -42,6 +42,14 @@ void resolveModuleInstance(const slang::syntax::ModuleHeaderSyntax& header,
 void resolveModule(const slang::syntax::SyntaxTree& tree, std::string_view moduleName,
                    lsp::CompletionItem& ret, bool excludeName = false);
 
+/// Add completions for named parameter assignments inside `#(...)`.
+void addNamedParameterCompletions(std::vector<lsp::CompletionItem>& results,
+                                  const slang::syntax::ModuleHeaderSyntax& header);
+
+/// Add completions for named port connections inside an instance `(...)`.
+void addNamedPortCompletions(std::vector<lsp::CompletionItem>& results,
+                             const slang::syntax::ModuleHeaderSyntax& header);
+
 /// Index based completions
 void addIndexedCompletions(std::vector<lsp::CompletionItem>& results, const Indexer& indexer,
                            const CompletionContext& ctx);

--- a/src/completions/CompletionDispatch.cpp
+++ b/src/completions/CompletionDispatch.cpp
@@ -18,6 +18,7 @@
 #include "util/Formatting.h"
 #include "util/Logging.h"
 #include <filesystem>
+#include <unordered_set>
 
 #include "slang/ast/Compilation.h"
 #include "slang/ast/Lookup.h"
@@ -27,6 +28,7 @@
 
 namespace fs = std::filesystem;
 namespace ast = slang::ast;
+namespace syntax = slang::syntax;
 
 namespace server {
 
@@ -114,6 +116,108 @@ void CompletionDispatch::getCompletions(std::vector<lsp::CompletionItem>& result
         // Member completions
         // Capture analysis once to avoid invalidation from repeated getAnalysis() calls.
         auto analysis = doc->getAnalysis();
+
+        const syntax::HierarchyInstantiationSyntax* hierarchy = nullptr;
+        const syntax::HierarchicalInstanceSyntax* instance = nullptr;
+        bool parameterConnection = false;
+        bool portConnection = false;
+
+        for (auto* node = ctx.syntax; node; node = node->parent) {
+            switch (node->kind) {
+                case syntax::SyntaxKind::NamedParamAssignment:
+                case syntax::SyntaxKind::ParameterValueAssignment:
+                    parameterConnection = true;
+                    break;
+
+                case syntax::SyntaxKind::HierarchicalInstance:
+                    instance = &node->as<syntax::HierarchicalInstanceSyntax>();
+                    portConnection = true;
+                    break;
+
+                case syntax::SyntaxKind::HierarchyInstantiation:
+                    hierarchy = &node->as<syntax::HierarchyInstantiationSyntax>();
+                    break;
+
+                default:
+                    break;
+            }
+
+            if (hierarchy)
+                break;
+        }
+
+        if (hierarchy && (parameterConnection || portConnection)) {
+            const ast::DefinitionSymbol* definition = nullptr;
+
+            if (auto* symbol = analysis->getSymbolAtToken(&hierarchy->type);
+                symbol && ast::DefinitionSymbol::isKind(symbol->kind)) {
+                definition = &symbol->as<ast::DefinitionSymbol>();
+            }
+
+            if (!definition) {
+                auto* symbol = analysis->getDefinition(hierarchy->type.valueText());
+                if (symbol && ast::DefinitionSymbol::isKind(symbol->kind)) {
+                    definition = &symbol->as<ast::DefinitionSymbol>();
+                }
+            }
+
+            if (definition) {
+                const auto* definitionSyntax = definition->getSyntax();
+
+                if (definitionSyntax &&
+                    definitionSyntax->kind == syntax::SyntaxKind::ModuleDeclaration) {
+                    const auto& module = definitionSyntax->as<syntax::ModuleDeclarationSyntax>();
+
+                    std::unordered_set<std::string> connectedNames;
+
+                    if (parameterConnection && hierarchy->parameters) {
+                        for (const auto* parameter : hierarchy->parameters->parameters) {
+                            if (parameter->kind != syntax::SyntaxKind::NamedParamAssignment)
+                                continue;
+
+                            const auto& assignment =
+                                parameter->as<syntax::NamedParamAssignmentSyntax>();
+                            if (!assignment.name.valueText().empty()) {
+                                connectedNames.emplace(assignment.name.valueText());
+                            }
+                        }
+                    }
+                    else if (portConnection && instance) {
+                        for (const auto* connection : instance->connections) {
+                            if (connection->kind != syntax::SyntaxKind::NamedPortConnection)
+                                continue;
+
+                            const auto& named = connection->as<syntax::NamedPortConnectionSyntax>();
+                            if (!named.name.valueText().empty()) {
+                                connectedNames.emplace(named.name.valueText());
+                            }
+                        }
+                    }
+
+                    std::vector<lsp::CompletionItem> candidates;
+
+                    if (parameterConnection) {
+                        completions::addNamedParameterCompletions(candidates, *module.header);
+                    }
+                    else {
+                        completions::addNamedPortCompletions(candidates, *module.header);
+                    }
+
+                    for (auto& candidate : candidates) {
+                        if (!connectedNames.contains(candidate.label)) {
+                            results.push_back(std::move(candidate));
+                        }
+                    }
+
+                    return;
+                }
+            }
+
+            WARN("Could not resolve module definition for named connection {}",
+                 hierarchy->type.valueText());
+            return;
+        }
+
         auto exprToken = analysis->getTokenAt(loc - 2);
         if (!exprToken) {
             WARN("No expression token found before '.'");

--- a/src/completions/Completions.cpp
+++ b/src/completions/Completions.cpp
@@ -138,6 +138,66 @@ void collectParams(const syntax::ParameterPortListSyntax& paramList,
     }
 }
 
+void addNamedParameterCompletions(std::vector<lsp::CompletionItem>& results,
+                                  const slang::syntax::ModuleHeaderSyntax& header) {
+    if (!header.parameters)
+        return;
+
+    size_t maxLen = 0;
+    std::vector<std::string_view> names;
+    std::vector<std::string> defaults;
+    collectParams(*header.parameters, names, defaults, maxLen);
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        auto name = std::string(names[i]);
+
+        SnippetString snippet(name);
+        snippet.appendText("(");
+        snippet.appendPlaceholder(name);
+        snippet.appendText(")");
+
+        std::string detail = " parameter";
+        if (!defaults[i].empty())
+            detail += fmt::format(" = {}", defaults[i]);
+
+        results.push_back(lsp::CompletionItem{
+            .label = name,
+            .labelDetails = lsp::CompletionItemLabelDetails{.detail = std::move(detail)},
+            .kind = lsp::CompletionItemKind::TypeParameter,
+            .filterText = name,
+            .insertText = std::string(snippet.getValue()),
+            .insertTextFormat = lsp::InsertTextFormat::Snippet,
+        });
+    }
+}
+
+void addNamedPortCompletions(std::vector<lsp::CompletionItem>& results,
+                             const slang::syntax::ModuleHeaderSyntax& header) {
+    if (!header.ports)
+        return;
+
+    PortVisitor visitor;
+    header.ports->visit(visitor);
+
+    for (auto portName : visitor.names) {
+        auto name = std::string(portName);
+
+        SnippetString snippet(name);
+        snippet.appendText("(");
+        snippet.appendPlaceholder(name);
+        snippet.appendText(")");
+
+        results.push_back(lsp::CompletionItem{
+            .label = name,
+            .labelDetails = lsp::CompletionItemLabelDetails{.detail = " port"},
+            .kind = lsp::CompletionItemKind::Field,
+            .filterText = name,
+            .insertText = std::string(snippet.getValue()),
+            .insertTextFormat = lsp::InsertTextFormat::Snippet,
+        });
+    }
+}
+
 void resolveModuleInstance(const slang::syntax::ModuleHeaderSyntax& header,
                            lsp::CompletionItem& ret, bool excludeName) {
 

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -863,3 +863,109 @@ TEST_CASE("LocalparamKeywordInheritance") {
     CHECK(insertText.find("lp1") == std::string::npos);
     CHECK(insertText.find("lp2") == std::string::npos);
 }
+
+TEST_CASE("NamedPortAndParameterCompletion") {
+    ServerHarness server("repo1");
+
+    auto doc = server.openFile("named_connection_completion.sv", R"(
+        module child #(
+            parameter int WIDTH = 8,
+            parameter int DEPTH = 16
+        ) (
+            input logic clk,
+            input logic rst,
+            output logic data
+        );
+        endmodule
+
+        module top;
+            logic clk;
+            logic rst;
+            logic data;
+
+            child #(
+                .
+            ) u_child (
+                .
+            );
+        endmodule
+    )");
+
+    auto hasCompletion = [](const auto& items, std::string_view label) {
+        return std::any_of(items.begin(), items.end(),
+                           [&](const auto& item) { return item.m_item.label == label; });
+    };
+
+    auto paramCompletions = doc.after("child #(\n                .").getCompletions(".");
+    CHECK(hasCompletion(paramCompletions, "WIDTH"));
+    CHECK(hasCompletion(paramCompletions, "DEPTH"));
+
+    auto portCompletions = doc.after("u_child (\n                .").getCompletions(".");
+    CHECK(hasCompletion(portCompletions, "clk"));
+    CHECK(hasCompletion(portCompletions, "rst"));
+    CHECK(hasCompletion(portCompletions, "data"));
+
+    auto memberDoc = server.openFile("named_connection_member_regression.sv", R"(
+        module member_regression;
+            typedef struct {
+                logic field_a;
+                logic field_b;
+            } item_t;
+
+            item_t item;
+
+            initial begin
+                item.;
+            end
+        endmodule
+    )");
+
+    auto memberCompletions = memberDoc.after("item.").getCompletions(".");
+    CHECK(hasCompletion(memberCompletions, "field_a"));
+    CHECK(hasCompletion(memberCompletions, "field_b"));
+
+    auto filteredDoc = server.openFile("named_connection_filtering.sv", R"(
+        module filter_child #(
+            parameter int WIDTH = 8,
+            parameter int DEPTH = 16
+        ) (
+            input logic clk,
+            input logic rst,
+            output logic data
+        );
+        endmodule
+
+        module filter_top;
+            logic clk;
+            logic rst;
+            logic data;
+
+            filter_child #(
+                .WIDTH(32),
+                .
+            ) param_inst (
+                .clk(clk),
+                .rst(rst),
+                .data(data)
+            );
+
+            filter_child port_inst (
+                .clk(clk),
+                .
+            );
+        endmodule
+    )");
+
+    auto filteredParams = filteredDoc.after(".WIDTH(32),\n                .").getCompletions(".");
+
+    CHECK(!hasCompletion(filteredParams, "WIDTH"));
+    CHECK(hasCompletion(filteredParams, "DEPTH"));
+
+    auto filteredPorts = filteredDoc.after("filter_child port_inst (")
+                             .after(".clk(clk),\n                .")
+                             .getCompletions(".");
+
+    CHECK(!hasCompletion(filteredPorts, "clk"));
+    CHECK(hasCompletion(filteredPorts, "rst"));
+    CHECK(hasCompletion(filteredPorts, "data"));
+}


### PR DESCRIPTION
Summary

Adds completion support for named parameter assignments and named port connections in module instantiations.

Typing . inside a parameter or port connection list now suggests the corresponding parameters or ports from the instantiated module.

For example, typing . inside child #(...) suggests the module's parameters, while typing . inside the instance connection list suggests its ports.

Changes
Detect named parameter and port connection contexts when completion is triggered by .
Resolve the instantiated module from the surrounding HierarchyInstantiation
Add snippet completions for module parameters and ports
Filter parameters and ports that have already been connected
Preserve existing . member completion behavior
Add regression coverage for named connections, filtering, and ordinary member completion
Implementation

Incomplete named connections are represented by slang's recovery syntax while the user is typing. Parameter completion is detected through the NamedParamAssignment / ParameterValueAssignment ancestry, while port completion is detected through HierarchicalInstance.

The implementation reuses the existing parameter collection and port visitor logic to generate completion candidates.

Testing

Focused regression: NamedPortAndParameterCompletion — all 12 assertions pass.

Full test suite: 212/212 tests pass.

Fixes #422