### PR TITLE
Fix unchanged file reloads overwriting compilation diagnostics

### DIFF
--- a/include/document/SlangDoc.h
+++ b/include/document/SlangDoc.h
@@ -129,7 +129,7 @@ public:
     void onChange(const std::vector<lsp::TextDocumentContentChangeEvent>& contentChanges);
 
     /// @brief Re-read the buffer from disk (used for external file changes)
-    /// @return true if successful, false if the read failed
+    /// @return true if the contents changed, false if unchanged or the read failed
     bool reloadBuffer();
 
     bool textMatches(std::string_view text);

--- a/src/document/SlangDoc.cpp
+++ b/src/document/SlangDoc.cpp
@@ -28,6 +28,7 @@
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/SourceLocation.h"
 #include "slang/text/SourceManager.h"
+#include "slang/util/OS.h"
 namespace server {
 
 using namespace slang;
@@ -245,12 +246,20 @@ void SlangDoc::onChange(const std::vector<lsp::TextDocumentContentChangeEvent>& 
     m_analysis.reset();
 }
 bool SlangDoc::reloadBuffer() {
-    auto result = m_sourceManager.reloadBuffer(m_buffer.id);
-    if (!result) {
-        ERROR("Failed to re-read buffer for {}: {}", m_uri.getPath(), result.error().message());
+    SmallVector<char> newData;
+    if (std::error_code ec = OS::readFile(m_sourceManager.getFullPath(m_buffer.id), newData)) {
+        ERROR("Failed to re-read buffer for {}: {}", m_uri.getPath(), ec.message());
         return false;
     }
-    m_buffer = *result;
+
+    // Watcher events often fire without a content change (e.g. after the editor
+    // saves a file). Keep the current buffer in that case; replacing it would
+    // needlessly reparse and replace compilation diags with shallow diags.
+    if (std::string_view(newData.data(), newData.size()) == getText()) {
+        return false;
+    }
+
+    m_buffer = m_sourceManager.replaceBuffer(m_buffer.id, std::move(newData));
     m_tree.reset();
     m_analysis.reset();
     return true;

--- a/tests/cpp/DiagTests.cpp
+++ b/tests/cpp/DiagTests.cpp
@@ -365,6 +365,31 @@ TEST_CASE("OpenBuildFileDoesNotOverwriteCompilationDiags") {
     }
 }
 
+TEST_CASE("UnchangedWatchedFileDoesNotOverwriteCompilationDiags") {
+    ServerHarness server("comp_repo");
+    server.setBuildFile("cpu_design.f");
+
+    // unused_mod is not instantiated under the design top, so its compilation diags
+    // (unused module definition) differ from what a shallow analysis would produce
+    auto modUri = URI::fromFile(fs::current_path() / "unused_mod.sv");
+    auto compDiags = server.client.getDiagnostics(modUri);
+    REQUIRE(!compDiags.empty());
+
+    auto mod = server.openFile("unused_mod.sv");
+
+    // A watcher event without an actual content change must not replace the
+    // compilation diags with shallow diags.
+    server.onWorkspaceDidChangeWatchedFiles(lsp::DidChangeWatchedFilesParams{
+        .changes = {{lsp::FileEvent{.uri = modUri, .type = lsp::FileChangeType::Changed}}}});
+
+    auto afterDiags = server.client.getDiagnostics(modUri);
+    REQUIRE(compDiags.size() == afterDiags.size());
+    for (size_t i = 0; i < compDiags.size(); i++) {
+        CHECK(compDiags[i].message == afterDiags[i].message);
+        CHECK(compDiags[i].range.start.line == afterDiags[i].range.start.line);
+    }
+}
+
 TEST_CASE("OpenNonBuildFileGetsShallowDiags") {
     ServerHarness server("comp_repo");
     server.setBuildFile("cpu_design.f");


### PR DESCRIPTION
## Summary

* Reloading an open document from disk could re-publish shallow diagnostics even when its contents had not changed, replacing compilation diagnostics for that file.
* `SlangDoc::reloadBuffer` now skips the reload when the on-disk contents already match the current buffer.

## Why

#311 prevents matching `didOpen` contents from replacing compilation diagnostics with shallow diagnostics. The reload path could still cause the same downgrade because `reloadBuffer()` replaced the buffer unconditionally before `updateDoc(CHANGE)`. Genuine external changes continue through the existing reload path.

## Tests

* Added `UnchangedWatchedFileDoesNotOverwriteCompilationDiags`
* On unmodified main, the regression test fails with 1 compilation diagnostic replaced by 18 shallow diagnostics.
* Relevant diagnostic, watcher, and external-file-change tests pass.

Refs #428
