### PR TITLE
Doc Indexing: Ignore warnings from synthesized tokens

### DIFF
--- a/src/document/SyntaxIndexer.cpp
+++ b/src/document/SyntaxIndexer.cpp
@@ -84,15 +84,6 @@ void SyntaxIndexer::visit(const slang::syntax::SyntaxNode& node) {
 
             if (token->location().buffer() == m_buffer &&
                 token->kind != parsing::TokenKind::Placeholder) {
-                if (collected.size() > 0) {
-                    /// TODO: investigate overlaps
-                    // SLANG_ASSERT(collected.back()->range().end() <= token->range().start());
-                    if (!(collected.back()->range().end() <= token->range().start())) {
-                        ERROR("Token '{}': {} overlaps with previous token '{}' : {}",
-                              token->rawText(), toString(token->kind), collected.back()->rawText(),
-                              toString(collected.back()->kind));
-                    }
-                }
                 collected.push_back(token);
 
                 tokenToParent[token] = &node;

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -720,7 +720,7 @@ TEST_CASE("NonProceduralSignalCompletion") {
     auto comps = doc.after("assign\n").getResolvedCompletions();
     golden.record("assign_lhs", comps);
 
-    // Non-procedural contexts like continuous assign should include local signals
+    // An unfinished continuous assign still needs signals from the surrounding module body.
     auto findByLabel = [&](const std::string& label) {
         return std::find_if(comps.begin(), comps.end(),
                             [&](const lsp::CompletionItem& item) { return item.label == label; });

--- a/tests/cpp/InactiveRegionsTests.cpp
+++ b/tests/cpp/InactiveRegionsTests.cpp
@@ -91,6 +91,32 @@ TEST_CASE("InactiveRegions_ParseError") {
     CHECK(text.find("`ASDF") != std::string::npos);
 }
 
+TEST_CASE("SyntaxIndexer retains synthesized recovery tokens for context") {
+    using namespace slang;
+
+    SourceManager sm;
+    Bag options;
+    std::string_view text = R"(
+module top;
+    logic value;
+
+    assign
+    endmodule
+)";
+    auto tree = syntax::SyntaxTree::fromText(text, sm, "test", "", options);
+
+    server::SyntaxIndexer indexer(*tree);
+    auto missing = std::ranges::find_if(indexer.collected,
+                                        [](const auto* token) { return token->isMissing(); });
+    REQUIRE(missing != indexer.collected.end());
+    CHECK(indexer.getTokenParent(*missing) != nullptr);
+
+    auto cursor = SourceLocation(tree->getSourceBufferIds()[0], text.find("assign\n") + 7);
+    auto context = indexer.getSyntaxAt(cursor);
+    REQUIRE(context);
+    CHECK(context->kind == syntax::SyntaxKind::ContinuousAssign);
+}
+
 TEST_CASE("InactiveRegions_MacroInDisabledBranch") {
     using namespace slang;
 


### PR DESCRIPTION
The remaining warnings were all from synthesized tokens; however we actually want these because the incomplete syntax that slang fills in for incomplete members is better for completion context.