### PR TITLE
Shallow compilations: Load named port type dependencies

### DIFF
--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -338,7 +338,7 @@ std::vector<std::shared_ptr<SlangDoc>> ServerDriver::getDependentDocs(
         // Collect declared symbols from current tree
         meta.visitDeclaredSymbols([&](std::string_view name) { knownNames.emplace(name); });
 
-        meta.visitReferencedSymbols([&](std::string_view name) {
+        auto loadDependency = [&](std::string_view name) {
             if (knownNames.find(name) != knownNames.end())
                 return; // already added
 
@@ -374,7 +374,9 @@ std::vector<std::shared_ptr<SlangDoc>> ServerDriver::getDependentDocs(
             else {
                 ERROR("No doc found for {}", filePath);
             }
-        });
+        };
+
+        meta.visitReferencedSymbols(loadDependency);
     }
 
     return result;

--- a/tests/cpp/DiagTests.cpp
+++ b/tests/cpp/DiagTests.cpp
@@ -385,16 +385,24 @@ endmodule
 TEST_CASE("ShallowIncludesIfacePackages") {
     ServerHarness server("iface_pkg_dep");
 
-    auto doc = server.openFile("producer.sv");
+    auto producer = server.openFile("producer.sv");
 
     // No diagnostics should be reported on producer.sv: the interface and its imported
     // package both resolve once the package is pulled in transitively.
-    CHECK(doc.getDiagnostics().empty());
+    CHECK(producer.getDiagnostics().empty());
 
     // The struct member `data` is typed via payload_t in types_pkg, which is reachable only
     // through simple_if's package import. Goto-definition resolves it iff the package was
     // pulled into the shallow compilation.
-    auto defs = doc.after("bus.payload.da").getDefinitions();
+    auto defs = producer.after("bus.payload.da").getDefinitions();
+    REQUIRE(defs.size() == 1);
+    CHECK(defs[0].targetUri.str().ends_with("types_pkg.sv"));
+
+    auto consumer = server.openFile("consumer.sv");
+
+    // An interface port without a modport must pull in the interface and its dependencies too.
+    CHECK(consumer.getDiagnostics().empty());
+    defs = consumer.after("bus.payload.va").getDefinitions();
     REQUIRE(defs.size() == 1);
     CHECK(defs[0].targetUri.str().ends_with("types_pkg.sv"));
 }

--- a/tests/data/iface_pkg_dep/consumer.sv
+++ b/tests/data/iface_pkg_dep/consumer.sv
@@ -1,0 +1,6 @@
+module consumer (
+    simple_if bus,
+    output logic valid
+);
+  assign valid = bus.payload.valid;
+endmodule


### PR DESCRIPTION
Shallow compilations: Load named port type dependencies.

This now loads interface ports without a modport for use in shallow compilation