### PR TITLE
Hovers/Gotos: Support multiple symbols

### DIFF
--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -176,6 +176,10 @@ private:
     /// Parse config flags and build files, load sources, create documents
     void parseAndLoadSources(const std::vector<std::string>& buildfiles);
 
+    std::optional<DefinitionInfo> getMacroDefinitionInfo(const ShallowAnalysis& analysis,
+                                                         const parsing::Token& token,
+                                                         const syntax::SyntaxNode& referenceSyntax);
+
     /// Set of URIs for documents that are explicitly opened by the client
     flat_hash_set<URI> m_openDocs;
 

--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -10,7 +10,9 @@
 #include "Config.h"
 #include "document/ShallowAnalysis.h"
 #include "lsp/LspTypes.h"
+#include <cstddef>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -32,12 +34,6 @@ class Document;
 }
 
 struct DefinitionInfo {
-    enum class Kind {
-        Symbol,
-        Macro,
-        SystemSubroutine,
-    };
-
     struct SyntaxTarget {
         // The syntax that the token refers to.
         const slang::syntax::SyntaxNode* node;
@@ -61,18 +57,39 @@ struct DefinitionInfo {
     };
 
     struct SymbolTarget {
-        SyntaxTarget syntax;
+        // A semantic symbol can have more than one declaration site that is useful to display.
+        // For example, a modport port has both its directional declaration and the declaration of
+        // the underlying typed symbol.
+        std::vector<SyntaxTarget> syntaxes;
         const slang::ast::Symbol* symbol;
         std::shared_ptr<ShallowAnalysis> analysis;
+        bool renderInputPortDriver = false;
+        size_t generatedSignalCount = 1;
 
-        const slang::parsing::Token& nameToken() const { return syntax.nameToken; }
+        const slang::parsing::Token& nameToken() const { return syntaxes.front().nameToken; }
 
         bool operator==(const SymbolTarget& other) const {
-            return syntax == other.syntax && symbol == other.symbol;
+            return syntaxes == other.syntaxes && symbol == other.symbol &&
+                   renderInputPortDriver == other.renderInputPortDriver &&
+                   generatedSignalCount == other.generatedSignalCount;
         }
 
-        lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
-                                    const Config::HoverConfig& hovers) const;
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
+
+        std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
+    };
+
+    struct PortConnectionTarget {
+        SymbolTarget outer;
+        SymbolTarget inner;
+
+        const slang::parsing::Token& nameToken() const { return outer.nameToken(); }
+
+        bool operator==(const PortConnectionTarget&) const = default;
+
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
 
         std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
     };
@@ -95,6 +112,9 @@ struct DefinitionInfo {
         // Expanded text for macro usages (what the macro expands to at this call site).
         std::string macroExpansionText;
 
+        MacroTarget(Definition definition, const slang::syntax::SyntaxNode& referenceSyntax,
+                    const ShallowAnalysis& analysis);
+
         const slang::parsing::Token& nameToken() const {
             return std::visit([](const auto& definition)
                                   -> const slang::parsing::Token& { return definition.nameToken; },
@@ -111,8 +131,8 @@ struct DefinitionInfo {
             return definition == other.definition && macroExpansionText == other.macroExpansionText;
         }
 
-        lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
-                                    const Config::HoverConfig& hovers) const;
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
 
         std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
     };
@@ -129,62 +149,47 @@ struct DefinitionInfo {
                    isTask == other.isTask;
         }
 
-        lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
-                                    const Config::HoverConfig& hovers) const;
+        markup::Document getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
+                                  const Config::HoverConfig& hovers) const;
 
         std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
     };
 
-    using Target = std::variant<SymbolTarget, MacroTarget, SystemSubroutineTarget>;
+    using Target =
+        std::variant<SymbolTarget, PortConnectionTarget, MacroTarget, SystemSubroutineTarget>;
 
-    // The thing this token resolves to.
-    Target target;
+    // The things this token resolves to, in semantic / elaboration order.
+    std::vector<Target> targets;
 
-    Kind kind() const {
-        switch (target.index()) {
-            case 0:
-                return Kind::Symbol;
-            case 1:
-                return Kind::Macro;
-            default:
-                return Kind::SystemSubroutine;
-        }
-    }
+    explicit DefinitionInfo(Target target) { targets.push_back(std::move(target)); }
+    explicit DefinitionInfo(std::vector<Target> targets) : targets(std::move(targets)) {}
+
+    const Target& primaryTarget() const { return targets.front(); }
+    Target& primaryTarget() { return targets.front(); }
 
     const slang::parsing::Token& nameToken() const {
         return std::visit(
             [](const auto& target) -> const slang::parsing::Token& { return target.nameToken(); },
-            target);
+            primaryTarget());
     }
-
-    const SyntaxTarget* syntaxTarget() const {
-        if (auto* sym = std::get_if<SymbolTarget>(&target)) {
-            return &sym->syntax;
-        }
-        if (auto* macro = std::get_if<MacroTarget>(&target)) {
-            return macro->syntaxTarget();
-        }
-        return nullptr;
-    }
-
-    const SymbolTarget* symbolTarget() const { return std::get_if<SymbolTarget>(&target); }
 
     const slang::ast::Symbol* symbol() const {
-        if (auto* sym = symbolTarget()) {
-            return sym->symbol;
-        }
+        if (auto* symbol = std::get_if<SymbolTarget>(&primaryTarget()))
+            return symbol->symbol;
+        if (auto* port = std::get_if<PortConnectionTarget>(&primaryTarget()))
+            return port->outer.symbol;
         return nullptr;
     }
 
-    MacroTarget* macro() { return std::get_if<MacroTarget>(&target); }
+    MacroTarget* macro() { return std::get_if<MacroTarget>(&primaryTarget()); }
 
-    const MacroTarget* macro() const { return std::get_if<MacroTarget>(&target); }
+    const MacroTarget* macro() const { return std::get_if<MacroTarget>(&primaryTarget()); }
 
     const SystemSubroutineTarget* systemSubroutine() const {
-        return std::get_if<SystemSubroutineTarget>(&target);
+        return std::get_if<SystemSubroutineTarget>(&primaryTarget());
     }
 
-    bool operator==(const DefinitionInfo& other) const { return target == other.target; }
+    bool operator==(const DefinitionInfo& other) const { return targets == other.targets; }
 
     bool operator!=(const DefinitionInfo& other) const { return !(*this == other); }
 
@@ -192,8 +197,7 @@ struct DefinitionInfo {
     lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
                                 const Config::HoverConfig& hovers) const;
 
-    /// Resolve goto-definition links for this definition. May return multiple in the future
-    /// (e.g. for symbols with several declarations).
+    /// Resolve and deduplicate goto-definition links for every target and declaration site.
     std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
 };
 

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -15,6 +15,7 @@
 #include "util/Markdown.h"
 #include <memory>
 #include <optional>
+#include <span>
 #include <string_view>
 #include <vector>
 
@@ -120,6 +121,15 @@ public:
     /// @brief Gets the AST symbol that a declared token refers to, if any
     const slang::ast::Symbol* getSymbolAtToken(const slang::parsing::Token* node) const;
 
+    /// @brief Gets all AST symbols that a token refers to. A source token can denote multiple
+    /// elaborated symbols, or both sides of an implicit connection.
+    slang::SmallVector<const slang::ast::Symbol*, 2> getSymbolsAtToken(
+        const slang::parsing::Token* node) const;
+
+    /// @brief Gets the implicit per-iteration parameters for a loop-header genvar token.
+    std::span<const slang::ast::ParameterSymbol* const> getGenvarIterationParametersAtToken(
+        const slang::parsing::Token* node) const;
+
     /// Syntax finder for location->syntax mapping
     SyntaxIndexer syntaxes;
 
@@ -186,6 +196,16 @@ private:
 
     /// Symbol indexer for syntax->symbol mappings of definitions; Used for lookups
     SymbolIndexer m_symbolIndexer;
+
+    struct GenvarElaboration {
+        const slang::ast::GenvarSymbol* source = nullptr;
+        slang::SmallVector<const slang::ast::ParameterSymbol*> parameters;
+        bool initialized = false;
+    };
+    mutable slang::flat_hash_map<const slang::syntax::LoopGenerateSyntax*, GenvarElaboration>
+        m_genvarElaborations;
+
+    const GenvarElaboration* getGenvarElaborationAtToken(const slang::parsing::Token* node) const;
 
     /// @brief Helper method to check if a token is positioned over a selector
     bool isOverSelector(const slang::parsing::Token* node,

--- a/include/document/SymbolIndexer.h
+++ b/include/document/SymbolIndexer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
@@ -22,11 +23,14 @@
 #include "slang/ast/types/AllTypes.h"
 #include "slang/syntax/SyntaxNode.h"
 #include "slang/text/SourceLocation.h"
+#include "slang/util/SmallVector.h"
 
 namespace server {
 
-using Symdex = std::unordered_map<const slang::parsing::Token*, const slang::ast::Symbol*>;
-using Syntex = std::unordered_map<const slang::syntax::SyntaxNode*, const slang::ast::Symbol*>;
+using SymbolList = slang::SmallVector<const slang::ast::Symbol*, 2>;
+
+using Symdex = std::unordered_map<const slang::parsing::Token*, SymbolList>;
+using Syntex = std::unordered_map<const slang::syntax::SyntaxNode*, SymbolList>;
 
 struct SymbolIndexer
     : public slang::ast::ASTVisitor<SymbolIndexer, slang::ast::VisitFlags::Symbols> {
@@ -45,7 +49,12 @@ public:
 
     const slang::ast::Symbol* getSymbol(const slang::syntax::SyntaxNode* node) const;
 
+    std::span<const slang::ast::Symbol* const> getSymbols(const slang::parsing::Token* node) const;
+
     const slang::ast::Scope* getScopeForSyntax(const slang::syntax::SyntaxNode& syntax) const;
+
+    slang::SmallVector<const slang::ast::Scope*, 2> getScopesForSyntax(
+        const slang::syntax::SyntaxNode& syntax) const;
 
     // These are not in the buffer, but should be visited
     void handle(const slang::ast::RootSymbol& sym);
@@ -99,9 +108,14 @@ private:
     /// Helper to index instance syntax (shared by InstanceSymbol and InstanceArraySymbol)
     void indexInstanceSyntax(const slang::syntax::HierarchicalInstanceSyntax& instSyntax,
                              const slang::ast::InstanceBodySymbol& instanceSymbol,
-                             const slang::ast::DefinitionSymbol& definition);
+                             const slang::ast::DefinitionSymbol& definition,
+                             const slang::ast::InstanceSymbol* instance,
+                             const slang::ast::Scope* parentScope);
 
     void indexSymbolName(const slang::ast::Symbol& symbol, bool isUnnamed = false);
+
+    void addSymbol(const slang::parsing::Token* token, const slang::ast::Symbol& symbol);
+    void addSymbol(const slang::syntax::SyntaxNode* syntax, const slang::ast::Symbol& symbol);
 };
 
 } // namespace server

--- a/include/util/Markdown.h
+++ b/include/util/Markdown.h
@@ -31,11 +31,16 @@ public:
     /// Add a line break within the paragraph
     Paragraph& newLine();
 
+    /// Append an already rendered paragraph fragment
+    Paragraph& append(Paragraph paragraph);
+
     /// Check if the paragraph has any content
     bool isEmpty() const { return buffer.empty(); }
 
     /// Get the markdown content
     std::string_view asMarkdown() const { return buffer; }
+
+    bool operator==(const Paragraph&) const = default;
 
 private:
     std::string buffer;
@@ -49,6 +54,14 @@ public:
 
     /// Add an existing paragraph to the document
     void addParagraph(Paragraph para);
+
+    /// Append all paragraphs from another document
+    void append(Document doc);
+
+    /// Check if the document has any rendered content
+    bool isEmpty() const;
+
+    bool operator==(const Document&) const = default;
 
     /// Build and return LSP MarkupContent
     lsp::MarkupContent build() const;

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -20,6 +20,8 @@
 #include "util/Formatting.h"
 #include "util/Logging.h"
 #include "util/Markdown.h"
+#include <algorithm>
+#include <filesystem>
 #include <memory>
 #include <queue>
 #include <string_view>
@@ -30,6 +32,8 @@
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/ParameterSymbols.h"
+#include "slang/ast/symbols/ValueSymbol.h"
+#include "slang/ast/types/AllTypes.h"
 #include "slang/ast/types/Type.h"
 #include "slang/diagnostics/DiagnosticEngine.h"
 #include "slang/diagnostics/Diagnostics.h"
@@ -485,6 +489,88 @@ bool ServerDriver::createCompilation() {
     return true;
 }
 
+std::optional<DefinitionInfo> ServerDriver::getMacroDefinitionInfo(
+    const ShallowAnalysis& analysis, const parsing::Token& token,
+    const syntax::SyntaxNode& referenceSyntax) {
+    std::vector<const syntax::DefineDirectiveSyntax*> macroDefs;
+    auto addMacroDef = [&](const syntax::DefineDirectiveSyntax* definition) {
+        if (definition && std::ranges::find(macroDefs, definition) == macroDefs.end())
+            macroDefs.push_back(definition);
+    };
+    if (referenceSyntax.kind == syntax::SyntaxKind::MacroUsage ||
+        referenceSyntax.kind == syntax::SyntaxKind::UndefDirective) {
+        auto it = analysis.macroUsageDefinitions.find(&referenceSyntax);
+        if (it != analysis.macroUsageDefinitions.end())
+            addMacroDef(it->second);
+    }
+
+    // A macro usage in a define body has no direct usage mapping. The workspace index also
+    // supplies definitions that are not part of the current shallow compilation.
+    if (macroDefs.empty()) {
+        auto macroName = token.kind == parsing::TokenKind::Directive ? token.rawText().substr(1)
+                                                                     : token.valueText();
+        auto macro = analysis.macros.find(macroName);
+        if (macro != analysis.macros.end()) {
+            addMacroDef(macro->second);
+        }
+        else {
+            std::vector<std::filesystem::path> visited;
+            auto paths = m_indexer.getFilesForMacro(macroName);
+            if (paths.size() > 1)
+                std::ranges::sort(paths);
+            for (const auto& path : paths) {
+                if (std::ranges::find(visited, path) != visited.end())
+                    continue;
+                visited.push_back(path);
+
+                auto macroDoc = getDocument(URI::fromFile(path));
+                if (!macroDoc)
+                    continue;
+                auto macroAnalysis = macroDoc->getAnalysis();
+                auto indexedMacro = macroAnalysis->macros.find(macroName);
+                if (indexedMacro != macroAnalysis->macros.end())
+                    addMacroDef(indexedMacro->second);
+            }
+        }
+        if (macroDefs.empty())
+            return {};
+    }
+
+    std::vector<DefinitionInfo::Target> targets;
+    for (auto* macroDef : macroDefs) {
+        auto nameToken = macroDef->name;
+        auto macroUsageRange = SourceRange::NoLocation;
+        if (sm.isMacroLoc(nameToken.location())) {
+            auto tokenRange = SourceRange(nameToken.location(),
+                                          nameToken.location() + nameToken.rawText().length());
+            auto expansionRange = sm.getFullyExpandedRange(tokenRange);
+            if (sm.getSourceText(expansionRange).empty()) {
+                ERROR("Couldn't get original range for macro {}", nameToken.valueText());
+            }
+            else {
+                macroUsageRange = expansionRange;
+            }
+        }
+
+        DefinitionInfo::SyntaxTarget syntaxTarget{macroDef, nameToken, macroUsageRange};
+        DefinitionInfo::MacroTarget::Definition macroDefinition = syntaxTarget;
+
+        const auto defPath = sm.getFullPath(nameToken.location().buffer());
+        const auto defPathStr = defPath.filename().string();
+        if (defPathStr.empty() || defPathStr[0] == '<') {
+            std::string defineSourceFile;
+            const auto srcIt = m_defineSources.find(std::string(nameToken.valueText()));
+            if (srcIt != m_defineSources.end())
+                defineSourceFile = srcIt->second.string();
+            macroDefinition = DefinitionInfo::CommandLineDefineTarget{nameToken, defineSourceFile};
+        }
+
+        targets.emplace_back(
+            DefinitionInfo::MacroTarget{std::move(macroDefinition), referenceSyntax, analysis});
+    }
+    return DefinitionInfo{std::move(targets)};
+}
+
 std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
                                                                 const lsp::Position& position) {
     auto doc = getDocument(uri);
@@ -507,10 +593,6 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         return {};
     }
 
-    std::optional<parsing::Token> nameToken;
-    const syntax::SyntaxNode* symSyntax = nullptr;
-    const ast::Symbol* symbol = nullptr;
-
     auto isMacroRef = [&]() {
         // Normal macro usage (`FOO) or usage inside a `define body
         return declTok->kind == parsing::TokenKind::Directive &&
@@ -528,46 +610,10 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
                declSyntax->kind == syntax::SyntaxKind::NamedConditionalDirectiveExpression;
     };
 
-    if (isMacroRef() || isUndefRef() || isIfdefRef()) {
+    if (isMacroRef() || isUndefRef() || isIfdefRef())
+        return getMacroDefinitionInfo(*analysis, *declTok, *declSyntax);
 
-        // For macro usages and undefs, look up the definition that was
-        // active at the time (handles undef/redefine correctly)
-        const syntax::DefineDirectiveSyntax* macroDef = nullptr;
-        if (declSyntax->kind == syntax::SyntaxKind::MacroUsage ||
-            declSyntax->kind == syntax::SyntaxKind::UndefDirective) {
-            auto it = analysis->macroUsageDefinitions.find(declSyntax);
-            if (it != analysis->macroUsageDefinitions.end())
-                macroDef = it->second;
-        }
-
-        // Fall back to the macros map
-        // if we're looking at a macro usage in a define body, or macro isn't found but indexed
-        if (!macroDef) {
-            // For directive tokens (`FOO), valueText strips the backtick.
-            // For identifier tokens (FOO in `undef), valueText is the name.
-            auto macroName = declTok->kind == parsing::TokenKind::Directive
-                                 ? declTok->rawText().substr(1)
-                                 : declTok->valueText();
-            auto macro = analysis->macros.find(macroName);
-            if (macro == analysis->macros.end()) {
-                auto files = m_indexer.getFilesForMacro(macroName);
-                if (files.empty())
-                    return {};
-                auto macroDoc = getDocument(URI::fromFile(files[0].string()));
-                if (!macroDoc)
-                    return {};
-                auto macroAnalysis = macroDoc->getAnalysis();
-                macro = macroAnalysis->macros.find(macroName);
-                if (macro == macroAnalysis->macros.end())
-                    return {};
-            }
-            macroDef = macro->second;
-        }
-
-        symSyntax = macroDef;
-        nameToken = macroDef->name;
-    }
-    else if (declTok->kind == parsing::TokenKind::SystemIdentifier) {
+    if (declTok->kind == parsing::TokenKind::SystemIdentifier) {
         auto knownName = declTok->systemName();
         if (knownName == parsing::KnownSystemName::Unknown)
             return {};
@@ -580,93 +626,275 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         return DefinitionInfo{DefinitionInfo::SystemSubroutineTarget{
             *declTok, sysDoc, sub->kind == ast::SubroutineKind::Task}};
     }
-    else {
-        symbol = analysis->getSymbolAtToken(declTok);
-        if (!symbol) {
-            // check the index
-            auto symbols = m_indexer.getFilesForSymbol(declTok->rawText());
-            if (symbols.empty()) {
-                return {};
-            }
-            auto symDoc = getDocument(URI::fromFile(symbols[0].string()));
-            if (!symDoc) {
-                return {};
-            }
-            auto symAnalysis = symDoc->getAnalysis();
-            auto result = symAnalysis->getCompilation()->tryGetDefinition(
-                declTok->rawText(), symAnalysis->getCompilation()->getRoot());
-            if (!result.definition) {
-                return {};
-            }
-            symbol = result.definition;
+    auto symbolsEquivalent = [&](const ast::Symbol* left, const ast::Symbol* right) {
+        if (left == right)
+            return true;
+        if (left->kind != right->kind ||
+            sm.getFullyOriginalLoc(left->location) != sm.getFullyOriginalLoc(right->location)) {
+            return false;
         }
-        symSyntax = symbol->getSyntax();
 
+        if (ast::ValueSymbol::isKind(left->kind)) {
+            auto& leftValue = left->as<ast::ValueSymbol>();
+            auto& rightValue = right->as<ast::ValueSymbol>();
+            if (!leftValue.getType().isMatching(rightValue.getType()))
+                return false;
+
+            auto constantsMatch = [](const ConstantValue& a, const ConstantValue& b) {
+                return (a.bad() || b.bad()) ? a.bad() == b.bad() : a == b;
+            };
+            if (ast::ParameterSymbol::isKind(left->kind)) {
+                return constantsMatch(left->as<ast::ParameterSymbol>().getValue(),
+                                      right->as<ast::ParameterSymbol>().getValue());
+            }
+            if (ast::EnumValueSymbol::isKind(left->kind)) {
+                return constantsMatch(left->as<ast::EnumValueSymbol>().getValue(),
+                                      right->as<ast::EnumValueSymbol>().getValue());
+            }
+            return true;
+        }
+        if (ast::Type::isKind(left->kind))
+            return left->as<ast::Type>().isMatching(right->as<ast::Type>());
+        if (ast::TypeParameterSymbol::isKind(left->kind)) {
+            return left->as<ast::TypeParameterSymbol>().targetType.getType().isMatching(
+                right->as<ast::TypeParameterSymbol>().targetType.getType());
+        }
+        return false;
+    };
+
+    std::vector<std::pair<const ast::Symbol*, std::shared_ptr<ShallowAnalysis>>> symbols;
+    auto addSymbol = [&](const ast::Symbol* symbol,
+                         const std::shared_ptr<ShallowAnalysis>& symbolAnalysis) {
+        if (!symbol)
+            return;
+        auto duplicate = std::ranges::any_of(symbols, [&](const auto& existing) {
+            return (existing.first == symbol && existing.second == symbolAnalysis) ||
+                   (existing.second != symbolAnalysis && existing.first->kind == symbol->kind &&
+                    existing.first->location == symbol->location) ||
+                   symbolsEquivalent(existing.first, symbol);
+        });
+        if (!duplicate)
+            symbols.emplace_back(symbol, symbolAnalysis);
+    };
+
+    auto localSymbols = analysis->getSymbolsAtToken(declTok);
+    for (auto* symbol : localSymbols)
+        addSymbol(symbol, analysis);
+    if (std::ranges::any_of(localSymbols, [](const auto* symbol) {
+            return symbol->kind == ast::SymbolKind::Genvar;
+        })) {
+        for (auto* parameter : analysis->getGenvarIterationParametersAtToken(declTok))
+            addSymbol(parameter, analysis);
+    }
+
+    auto getGeneratedSignalCount = [&](const ast::Symbol* symbol) {
+        if (symbol->kind != ast::SymbolKind::Net && symbol->kind != ast::SymbolKind::Variable)
+            return size_t{1};
+
+        bool isGenerated = false;
+        for (auto* scope = symbol->getHierarchicalParent(); scope;
+             scope = scope->asSymbol().getHierarchicalParent()) {
+            if (scope->asSymbol().kind == ast::SymbolKind::GenerateBlock) {
+                isGenerated = true;
+                break;
+            }
+        }
+        if (!isGenerated)
+            return size_t{1};
+
+        std::vector<const ast::Symbol*> generatedSignals;
+        for (auto* candidate : localSymbols) {
+            if ((candidate->kind == ast::SymbolKind::Net ||
+                 candidate->kind == ast::SymbolKind::Variable) &&
+                symbolsEquivalent(symbol, candidate) &&
+                std::ranges::find(generatedSignals, candidate) == generatedSignals.end()) {
+                generatedSignals.push_back(candidate);
+            }
+        }
+        return std::max(size_t{1}, generatedSignals.size());
+    };
+
+    bool hasTopLevelResolution = std::ranges::any_of(localSymbols, [](const ast::Symbol* symbol) {
+        return symbol->kind == ast::SymbolKind::Definition ||
+               symbol->kind == ast::SymbolKind::Package;
+    });
+    bool hasLocalTopLevelResolution =
+        std::ranges::any_of(localSymbols, [&](const ast::Symbol* symbol) {
+            return (symbol->kind == ast::SymbolKind::Definition ||
+                    symbol->kind == ast::SymbolKind::Package) &&
+                   sm.getFullyExpandedLoc(symbol->location).buffer() == doc->getBuffer();
+        });
+
+    // A declaration in the queried document is authoritative. Externally resolved top-level
+    // names still use the index to retain other possible definitions.
+    bool searchIndex = localSymbols.empty() ||
+                       (hasTopLevelResolution && !hasLocalTopLevelResolution);
+    if (searchIndex) {
+        auto matchesResolvedKind = [&](const ast::Symbol* candidate) {
+            if (localSymbols.empty())
+                return true;
+            return std::ranges::any_of(localSymbols, [&](const ast::Symbol* resolved) {
+                if (resolved->kind != candidate->kind)
+                    return false;
+                if (auto* resolvedDef = resolved->as_if<ast::DefinitionSymbol>()) {
+                    auto* candidateDef = candidate->as_if<ast::DefinitionSymbol>();
+                    return candidateDef &&
+                           candidateDef->definitionKind == resolvedDef->definitionKind;
+                }
+                return true;
+            });
+        };
+
+        std::vector<std::filesystem::path> visited;
+        auto paths = m_indexer.getFilesForSymbol(declTok->valueText());
+        if (paths.size() > 1)
+            std::ranges::sort(paths);
+        for (const auto& path : paths) {
+            if (std::ranges::find(visited, path) != visited.end())
+                continue;
+            visited.push_back(path);
+
+            auto symbolDoc = getDocument(URI::fromFile(path));
+            if (!symbolDoc)
+                continue;
+            auto symbolAnalysis = symbolDoc->getAnalysis();
+            auto addGlobalDefinition = [&](const ast::Symbol* symbol) {
+                if (symbol && symbol->name == declTok->valueText() &&
+                    sm.getFullyExpandedLoc(symbol->location).buffer() == symbolDoc->getBuffer() &&
+                    matchesResolvedKind(symbol)) {
+                    addSymbol(symbol, symbolAnalysis);
+                }
+            };
+
+            for (auto* definition : symbolAnalysis->getCompilation()->getDefinitions())
+                addGlobalDefinition(definition);
+
+            for (auto* unit : symbolAnalysis->getCompilation()->getCompilationUnits()) {
+                for (auto& member : unit->members()) {
+                    if (member.kind == ast::SymbolKind::Package)
+                        addGlobalDefinition(&member);
+                }
+            }
+        }
+    }
+
+    auto makeSyntaxTarget =
+        [&](const ast::Symbol* symbol) -> std::optional<DefinitionInfo::SyntaxTarget> {
+        auto* symSyntax = symbol->getSyntax();
         if (!symSyntax) {
             ERROR("Failed to get syntax for symbol {} of kind {}", symbol->name,
                   toString(symbol->kind));
             return {};
         }
 
-        // For some symbols we want to return the parent to get the data type
-        if (symbol->kind == ast::SymbolKind::Modport ||
-            symbol->kind == ast::SymbolKind::ModportPort) {
+        // Modports have a directional declaration around their name syntax.
+        if ((symbol->kind == ast::SymbolKind::Modport ||
+             symbol->kind == ast::SymbolKind::ModportPort) &&
+            symSyntax->parent) {
             symSyntax = symSyntax->parent;
         }
-        nameToken = findNameToken(symSyntax, symbol->name);
-        if (!nameToken) {
+
+        auto foundNameToken = findNameToken(symSyntax, symbol->name);
+        if (!foundNameToken) {
             ERROR("Failed to find name token for symbol '{}' of kind {} = {}", symbol->name,
                   toString(symbol->kind), symSyntax->toString());
-
-            // TODO: figure out why this fails sometimes with all generates
-            nameToken = symSyntax->getFirstToken();
         }
-    }
+        parsing::Token nameToken = foundNameToken ? *foundNameToken : symSyntax->getFirstToken();
 
-    auto macroUsageRange = SourceRange::NoLocation;
-    if (nameToken && sm.isMacroLoc(nameToken->location())) {
-        auto tokenRange = SourceRange(nameToken->location(),
-                                      nameToken->location() + nameToken->rawText().length());
-        auto expansionRange = sm.getFullyExpandedRange(tokenRange);
-        auto text = sm.getSourceText(expansionRange);
-        if (text.empty()) {
-            ERROR("Couldn't get original range for symbol {}", nameToken->valueText());
+        auto macroUsageRange = SourceRange::NoLocation;
+        if (sm.isMacroLoc(nameToken.location())) {
+            auto tokenRange = SourceRange(nameToken.location(),
+                                          nameToken.location() + nameToken.rawText().length());
+            auto expansionRange = sm.getFullyExpandedRange(tokenRange);
+            if (sm.getSourceText(expansionRange).empty()) {
+                ERROR("Couldn't get original range for symbol {}", nameToken.valueText());
+            }
+            else {
+                macroUsageRange = expansionRange;
+            }
         }
-        else {
-            macroUsageRange = expansionRange;
-        }
-    }
 
-    std::string macroExpansionText;
-    if (declSyntax->kind == syntax::SyntaxKind::MacroUsage) {
-        auto it = analysis->syntaxes.macroExpansions.find(declSyntax);
-        if (it != analysis->syntaxes.macroExpansions.end())
-            macroExpansionText = it->second.getText();
-    }
-
-    auto makeSyntaxTarget = [&]() {
-        return DefinitionInfo::SyntaxTarget{symSyntax, *nameToken, macroUsageRange};
+        return DefinitionInfo::SyntaxTarget{symSyntax, nameToken, macroUsageRange};
     };
 
-    auto makeTarget = [&]() -> DefinitionInfo::Target {
-        if (symbol)
-            return DefinitionInfo::SymbolTarget{makeSyntaxTarget(), symbol, analysis};
+    auto makeSymbolTarget = [&](const ast::Symbol* symbol,
+                                const std::shared_ptr<ShallowAnalysis>& symbolAnalysis)
+        -> std::optional<DefinitionInfo::SymbolTarget> {
+        if (!symbol)
+            return {};
+        auto syntaxTarget = makeSyntaxTarget(symbol);
+        if (!syntaxTarget)
+            return {};
 
-        DefinitionInfo::MacroTarget::Definition macroDefinition = makeSyntaxTarget();
+        std::vector<DefinitionInfo::SyntaxTarget> syntaxes;
+        syntaxes.push_back(std::move(*syntaxTarget));
+        if (auto* modportPort = symbol->as_if<ast::ModportPortSymbol>()) {
+            if (modportPort->internalSymbol) {
+                if (auto internalSyntax = makeSyntaxTarget(modportPort->internalSymbol))
+                    syntaxes.push_back(std::move(*internalSyntax));
+            }
+        }
+        return DefinitionInfo::SymbolTarget{.syntaxes = std::move(syntaxes),
+                                            .symbol = symbol,
+                                            .analysis = symbolAnalysis,
+                                            .generatedSignalCount = getGeneratedSignalCount(
+                                                symbol)};
+    };
 
-        const auto defPath = sm.getFullPath(nameToken->location().buffer());
-        const auto defPathStr = defPath.filename().string();
-        if (defPathStr.empty() || defPathStr[0] == '<') {
-            std::string defineSourceFile;
-            const auto srcIt = m_defineSources.find(std::string(nameToken->valueText()));
-            if (srcIt != m_defineSources.end())
-                defineSourceFile = srcIt->second.string();
-            macroDefinition = DefinitionInfo::CommandLineDefineTarget{*nameToken, defineSourceFile};
+    if (declSyntax && declSyntax->kind == syntax::SyntaxKind::NamedPortConnection &&
+        !declSyntax->as<syntax::NamedPortConnectionSyntax>().openParen && localSymbols.size() > 1) {
+        std::vector<DefinitionInfo::Target> targets;
+        for (size_t i = 0; i + 1 < localSymbols.size(); i += 2) {
+            auto outer = makeSymbolTarget(localSymbols[i], analysis);
+            auto inner = makeSymbolTarget(localSymbols[i + 1], analysis);
+            if (outer && inner) {
+                inner->renderInputPortDriver = true;
+                DefinitionInfo::PortConnectionTarget port{std::move(*outer), std::move(*inner)};
+                auto duplicate = std::ranges::any_of(targets, [&](const auto& target) {
+                    auto* existing = std::get_if<DefinitionInfo::PortConnectionTarget>(&target);
+                    return existing &&
+                           symbolsEquivalent(existing->outer.symbol, port.outer.symbol) &&
+                           symbolsEquivalent(existing->inner.symbol, port.inner.symbol);
+                });
+                if (!duplicate)
+                    targets.emplace_back(std::move(port));
+            }
+            else if (outer) {
+                targets.emplace_back(std::move(*outer));
+            }
+            else if (inner) {
+                targets.emplace_back(std::move(*inner));
+            }
+        }
+        if (!targets.empty())
+            return DefinitionInfo{std::move(targets)};
+    }
+
+    std::vector<DefinitionInfo::Target> targets;
+    std::vector<const ast::Symbol*> foldedSymbols;
+    for (const auto& [symbol, symbolAnalysis] : symbols) {
+        if (std::ranges::find(foldedSymbols, symbol) != foldedSymbols.end())
+            continue;
+
+        auto target = makeSymbolTarget(symbol, symbolAnalysis);
+        if (!target)
+            continue;
+
+        if (auto* connection = declSyntax->as_if<syntax::NamedPortConnectionSyntax>();
+            connection && connection->expr) {
+            target->renderInputPortDriver = true;
         }
 
-        return DefinitionInfo::MacroTarget{macroDefinition, macroExpansionText};
-    };
-    return DefinitionInfo{makeTarget()};
+        if (auto* modportPort = symbol->as_if<ast::ModportPortSymbol>()) {
+            if (modportPort->internalSymbol)
+                foldedSymbols.push_back(modportPort->internalSymbol);
+        }
+        targets.emplace_back(std::move(*target));
+    }
+
+    if (targets.empty())
+        return {};
+    return DefinitionInfo{std::move(targets)};
 }
 
 std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::Position& position) {

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -15,6 +15,7 @@
 #include "util/Markdown.h"
 #include <algorithm>
 #include <filesystem>
+#include <type_traits>
 
 #include "slang/analysis/ValueDriver.h"
 #include "slang/ast/Expression.h"
@@ -80,7 +81,19 @@ std::string_view getPortDirectionHeader(ast::ArgumentDirection direction) {
     }
 }
 
-void renderSymbolHeaderName(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
+void renderSymbolHeaderName(markup::Paragraph& infoPg, const ast::Symbol& symbol,
+                            std::string_view kindOverride = {}) {
+    if (!kindOverride.empty()) {
+        infoPg.appendBold(kindOverride).appendCode(symbol.name);
+        return;
+    }
+
+    if (auto* parameter = symbol.as_if<ast::ParameterSymbol>();
+        parameter && parameter->isFromGenvar()) {
+        infoPg.appendBold("Genvar").appendCode(symbol.name);
+        return;
+    }
+
     if (auto* definition = symbol.as_if<ast::DefinitionSymbol>()) {
         infoPg.appendBold(toString(definition->definitionKind)).appendCode(symbol.name);
         return;
@@ -295,13 +308,20 @@ void appendSourceLink(markup::Paragraph& paragraph, SourceLocation location,
 }
 
 void renderDrivers(markup::Document& doc, const ast::Symbol& symbol, ShallowAnalysis& analysis,
-                   const SourceManager& sourceManager) {
+                   const SourceManager& sourceManager, bool renderInputPortDriver,
+                   bool followPortDriver,
+                   SmallVector<const syntax::SyntaxNode*, 4>* renderedGroupSyntaxes = nullptr) {
     if (!ast::ValueSymbol::isKind(symbol.kind) || symbol.kind == ast::SymbolKind::EnumValue)
         return;
 
+    SmallVector<const syntax::SyntaxNode*, 4> rootRenderedGroupSyntaxes;
+    if (!renderedGroupSyntaxes)
+        renderedGroupSyntaxes = &rootRenderedGroupSyntaxes;
+
     std::vector<DriverGroup> groups;
+    SmallVector<const ast::Symbol*, 2> connectedPortSymbols;
     for (const auto* driver : analysis.getDrivers(symbol.as<ast::ValueSymbol>())) {
-        if (!driver || driver->isInputPort())
+        if (!driver || (driver->isInputPort() && !renderInputPortDriver))
             continue;
 
         const ast::Symbol* containingSymbol = driver->containingSymbol;
@@ -321,9 +341,50 @@ void renderDrivers(markup::Document& doc, const ast::Symbol& symbol, ShallowAnal
             node && std::ranges::find(group.displayNodes, node) == group.displayNodes.end()) {
             group.displayNodes.push_back(node);
         }
+
+        if (!followPortDriver || !driver->flags.has(analysis::DriverFlags::OutputPort))
+            continue;
+
+        auto* instance = driver->containingSymbol->as_if<ast::InstanceSymbol>();
+        if (!instance)
+            continue;
+
+        for (auto* connection : instance->getPortConnections()) {
+            auto* expression = connection->getExpression();
+            if (!expression)
+                continue;
+            if (auto* assignment = expression->as_if<ast::AssignmentExpression>())
+                expression = &assignment->left();
+            if (expression->sourceRange != driver->getSourceRange())
+                continue;
+
+            auto addInternalSymbol = [&](const ast::PortSymbol& port) {
+                if (port.internalSymbol &&
+                    std::ranges::find(connectedPortSymbols, port.internalSymbol) ==
+                        connectedPortSymbols.end()) {
+                    connectedPortSymbols.push_back(port.internalSymbol);
+                }
+            };
+            if (auto* port = connection->port.as_if<ast::PortSymbol>()) {
+                addInternalSymbol(*port);
+            }
+            else if (auto* multiPort = connection->port.as_if<ast::MultiPortSymbol>()) {
+                for (auto* port : multiPort->ports)
+                    addInternalSymbol(*port);
+            }
+        }
     }
 
     for (const auto& group : groups) {
+        const auto* containingSyntax = group.containingSymbol->getSyntax();
+        if (containingSyntax) {
+            if (std::ranges::find(*renderedGroupSyntaxes, containingSyntax) !=
+                renderedGroupSyntaxes->end()) {
+                continue;
+            }
+            renderedGroupSyntaxes->push_back(containingSyntax);
+        }
+
         auto& paragraph = doc.addParagraph();
         paragraph.appendText(getDriverGroupHeader(group));
 
@@ -341,6 +402,10 @@ void renderDrivers(markup::Document& doc, const ast::Symbol& symbol, ShallowAnal
         if (!code.empty())
             paragraph.newLine().appendCodeBlock(code);
     }
+
+    for (const auto* connectedSymbol : connectedPortSymbols)
+        renderDrivers(doc, *connectedSymbol, analysis, sourceManager, false, false,
+                      renderedGroupSyntaxes);
 }
 
 void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
@@ -390,9 +455,10 @@ void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
     }
 }
 
-void renderSymbolHeader(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
+void renderSymbolHeader(markup::Paragraph& infoPg, const ast::Symbol& symbol,
+                        std::string_view kindOverride = {}) {
     // <Kind/Type> <Name> in <Scope>
-    renderSymbolHeaderName(infoPg, symbol);
+    renderSymbolHeaderName(infoPg, symbol, kindOverride);
 
     auto& parentSym = symbol.getParentScope()->asSymbol();
     auto lexicalPath = parentSym.getLexicalPath();
@@ -410,9 +476,223 @@ void renderSymbolHeader(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
     if (!lexicalPath.empty())
         infoPg.appendText(" in ").appendCode(lexicalPath);
     infoPg.newLine();
+}
 
-    renderSymbolType(infoPg, symbol);
-    renderSymbolValue(infoPg, symbol);
+const ast::Symbol& getDriverSymbol(const DefinitionInfo::SymbolTarget& target) {
+    if (auto* modportPort = target.symbol->as_if<ast::ModportPortSymbol>()) {
+        if (modportPort->internalSymbol)
+            return *modportPort->internalSymbol;
+    }
+    return *target.symbol;
+}
+
+void renderSymbolSyntaxes(markup::Document& doc, const DefinitionInfo::SymbolTarget& target,
+                          const SourceManager& sm, const Config::HoverConfig& hovers) {
+    std::vector<DefinitionInfo::SyntaxTarget> rendered;
+    for (const auto& syntax : target.syntaxes) {
+        if (std::ranges::find(rendered, syntax) != rendered.end())
+            continue;
+        syntax.renderCode(doc, sm, hovers);
+        rendered.push_back(syntax);
+    }
+}
+
+struct RenderedSymbolHover {
+    markup::Paragraph header;
+    markup::Paragraph type;
+    markup::Paragraph generatedSignals;
+    markup::Paragraph value;
+    markup::Document syntaxes;
+    markup::Document drivers;
+
+    void appendTo(markup::Document& doc) {
+        header.append(std::move(type));
+        header.append(std::move(generatedSignals));
+        header.append(std::move(value));
+        doc.addParagraph(std::move(header));
+        doc.append(std::move(syntaxes));
+        doc.append(std::move(drivers));
+    }
+};
+
+RenderedSymbolHover renderSymbolHover(const DefinitionInfo::SymbolTarget& target,
+                                      std::string_view label, const SourceManager& sm,
+                                      const Config::HoverConfig& hovers,
+                                      bool followPortDriver = true) {
+    RenderedSymbolHover result;
+    if (!label.empty())
+        result.header.appendBold(label);
+    renderSymbolHeader(result.header, *target.symbol);
+    renderSymbolType(result.type, *target.symbol);
+    if (target.generatedSignalCount > 1) {
+        result.generatedSignals.appendText("Generated signals: ")
+            .appendCode(fmt::format("{}", target.generatedSignalCount))
+            .newLine();
+    }
+    renderSymbolValue(result.value, *target.symbol);
+    renderSymbolSyntaxes(result.syntaxes, target, sm, hovers);
+    renderDrivers(result.drivers, getDriverSymbol(target), *target.analysis, sm,
+                  target.renderInputPortDriver, followPortDriver);
+    return result;
+}
+
+void deduplicatePortHoverParts(const RenderedSymbolHover& outer, RenderedSymbolHover& inner) {
+    if (inner.type == outer.type)
+        inner.type = {};
+    if (inner.value == outer.value)
+        inner.value = {};
+    if (inner.drivers == outer.drivers)
+        inner.drivers = {};
+}
+
+std::optional<lsp::MarkupContent> renderElaboratedParameterSummary(
+    const std::vector<DefinitionInfo::Target>& targets, const SourceManager& sm,
+    const Config::HoverConfig& hovers) {
+    if (targets.size() < 2)
+        return {};
+
+    std::vector<const DefinitionInfo::SymbolTarget*> parameters;
+    std::vector<const ConstantValue*> values;
+    const ConstantValue* minValue = nullptr;
+    const ConstantValue* maxValue = nullptr;
+    const DefinitionInfo::SymbolTarget* genvar = nullptr;
+    bool isGenvar = false;
+    SourceLocation declarationLocation;
+    const ast::Type* parameterType = nullptr;
+    for (const auto& target : targets) {
+        auto* symbolTarget = std::get_if<DefinitionInfo::SymbolTarget>(&target);
+        if (!symbolTarget)
+            return {};
+
+        if (symbolTarget->symbol->kind == ast::SymbolKind::Genvar) {
+            if (genvar || !parameters.empty())
+                return {};
+            genvar = symbolTarget;
+            isGenvar = true;
+            continue;
+        }
+
+        auto* parameter = symbolTarget->symbol->as_if<ast::ParameterSymbol>();
+        if (!parameter)
+            return {};
+
+        auto originalLocation = sm.getFullyOriginalLoc(parameter->location);
+        if (parameters.empty()) {
+            declarationLocation = originalLocation;
+            parameterType = &parameter->getType();
+            isGenvar = isGenvar || parameter->isFromGenvar();
+        }
+        else if (originalLocation != declarationLocation || parameter->isFromGenvar() != isGenvar ||
+                 !parameter->getType().isMatching(*parameterType)) {
+            return {};
+        }
+
+        const auto& value = parameter->getValue();
+        if (!value.isInteger() || value.hasUnknown())
+            return {};
+
+        if (!minValue || value < *minValue)
+            minValue = &value;
+        if (!maxValue || value > *maxValue)
+            maxValue = &value;
+        if (std::ranges::none_of(values, [&](const auto* existing) { return *existing == value; }))
+            values.push_back(&value);
+        parameters.push_back(symbolTarget);
+    }
+
+    if (parameters.empty() || (values.size() < 2 && !genvar))
+        return {};
+
+    auto sortedValues = values;
+    std::ranges::sort(sortedValues,
+                      [](const auto* left, const auto* right) { return *left < *right; });
+    bool isContiguous = true;
+    for (size_t i = 1; i < sortedValues.size(); i++) {
+        auto expected = sortedValues[i - 1]->integer();
+        if (++expected != sortedValues[i]->integer()) {
+            isContiguous = false;
+            break;
+        }
+    }
+
+    markup::Document doc;
+    auto& header = doc.addParagraph();
+    // TODO: when we have focused instances, gen loops will also have focused scopes
+    // in which we will both render the genvar (showing all values) and the internal parameter
+    // symbol
+    auto kindOverride = !genvar && isGenvar ? "Genvar" : "";
+    renderSymbolHeader(header, genvar ? *genvar->symbol : *parameters.front()->symbol,
+                       kindOverride);
+    renderSymbolType(header, *parameters.front()->symbol);
+    if (values.size() == 1) {
+        header.appendText("Value: ").appendCode(formatConstantValue(*values.front()));
+    }
+    else if (isContiguous) {
+        header.appendText("Value range: ")
+            .appendCode(formatConstantValue(*minValue))
+            .appendText(" through ")
+            .appendCode(formatConstantValue(*maxValue));
+    }
+    else {
+        header.appendText("Values: ");
+        for (size_t i = 0; i < values.size(); i++) {
+            if (i)
+                header.appendText(", ");
+            header.appendCode(formatConstantValue(*values[i]));
+        }
+    }
+    header.newLine();
+
+    std::vector<DefinitionInfo::SyntaxTarget> renderedSyntaxes;
+    for (const auto* target : parameters) {
+        for (const auto& syntax : target->syntaxes) {
+            if (std::ranges::find(renderedSyntaxes, syntax) != renderedSyntaxes.end())
+                continue;
+            syntax.renderCode(doc, sm, hovers);
+            renderedSyntaxes.push_back(syntax);
+        }
+    }
+    return doc.build();
+}
+
+std::optional<lsp::MarkupContent> renderElaboratedParameterValues(
+    const std::vector<DefinitionInfo::Target>& targets, const SourceManager& sm,
+    const Config::HoverConfig& hovers) {
+    if (targets.size() < 2)
+        return {};
+
+    std::vector<const DefinitionInfo::SymbolTarget*> parameterTargets;
+    for (const auto& target : targets) {
+        auto* symbolTarget = std::get_if<DefinitionInfo::SymbolTarget>(&target);
+        if (!symbolTarget || !symbolTarget->symbol->as_if<ast::ParameterSymbol>())
+            return {};
+        if (!parameterTargets.empty() &&
+            symbolTarget->syntaxes != parameterTargets.front()->syntaxes) {
+            return {};
+        }
+        parameterTargets.push_back(symbolTarget);
+    }
+
+    markup::Document result;
+    markup::Paragraph sharedType;
+    renderSymbolType(sharedType, *parameterTargets.front()->symbol);
+    std::vector<const ConstantValue*> renderedValues;
+    for (auto* target : parameterTargets) {
+        const auto& value = target->symbol->as<ast::ParameterSymbol>().getValue();
+        if (value.bad())
+            return {};
+        if (std::ranges::any_of(renderedValues,
+                                [&](auto* rendered) { return *rendered == value; })) {
+            continue;
+        }
+
+        auto hover = renderSymbolHover(*target, {}, sm, hovers);
+        if (!renderedValues.empty() && hover.type == sharedType)
+            hover.type = {};
+        hover.appendTo(result);
+        renderedValues.push_back(&value);
+    }
+    return result.build();
 }
 
 void renderMacroHeader(markup::Paragraph& infoPg, const DefinitionInfo::MacroTarget& macro,
@@ -472,19 +752,40 @@ void DefinitionInfo::SyntaxTarget::renderCode(markup::Document& doc, const Sourc
     }
 }
 
-lsp::MarkupContent DefinitionInfo::SymbolTarget::getHover(const SourceManager& sm,
-                                                          BufferID /*docBuffer*/,
-                                                          const Config::HoverConfig& hovers) const {
-    markup::Document doc;
-    renderSymbolHeader(doc.addParagraph(), *symbol);
-    syntax.renderCode(doc, sm, hovers);
-    renderDrivers(doc, *symbol, *analysis, sm);
-    return doc.build();
+DefinitionInfo::MacroTarget::MacroTarget(Definition definition,
+                                         const syntax::SyntaxNode& referenceSyntax,
+                                         const ShallowAnalysis& analysis) :
+    definition(std::move(definition)) {
+    if (referenceSyntax.kind != syntax::SyntaxKind::MacroUsage)
+        return;
+
+    auto it = analysis.syntaxes.macroExpansions.find(&referenceSyntax);
+    if (it != analysis.syntaxes.macroExpansions.end())
+        macroExpansionText = it->second.getText();
 }
 
-lsp::MarkupContent DefinitionInfo::MacroTarget::getHover(const SourceManager& sm,
-                                                         BufferID docBuffer,
-                                                         const Config::HoverConfig& hovers) const {
+markup::Document DefinitionInfo::SymbolTarget::getHover(const SourceManager& sm,
+                                                        BufferID /*docBuffer*/,
+                                                        const Config::HoverConfig& hovers) const {
+    markup::Document doc;
+    renderSymbolHover(*this, {}, sm, hovers).appendTo(doc);
+    return doc;
+}
+
+markup::Document DefinitionInfo::PortConnectionTarget::getHover(
+    const SourceManager& sm, BufferID /*docBuffer*/, const Config::HoverConfig& hovers) const {
+    auto outerHover = renderSymbolHover(outer, "Outer", sm, hovers, false);
+    auto innerHover = renderSymbolHover(inner, "Inner", sm, hovers);
+    deduplicatePortHoverParts(outerHover, innerHover);
+
+    markup::Document result;
+    outerHover.appendTo(result);
+    innerHover.appendTo(result);
+    return result;
+}
+
+markup::Document DefinitionInfo::MacroTarget::getHover(const SourceManager& sm, BufferID docBuffer,
+                                                       const Config::HoverConfig& hovers) const {
     markup::Document doc;
     renderMacroHeader(doc.addParagraph(), *this, sm, docBuffer);
 
@@ -500,10 +801,10 @@ lsp::MarkupContent DefinitionInfo::MacroTarget::getHover(const SourceManager& sm
             .appendText(svCodeBlockString(macroExpansionText));
     }
 
-    return doc.build();
+    return doc;
 }
 
-lsp::MarkupContent DefinitionInfo::SystemSubroutineTarget::getHover(
+markup::Document DefinitionInfo::SystemSubroutineTarget::getHover(
     const SourceManager& /*sm*/, BufferID /*docBuffer*/,
     const Config::HoverConfig& /*hovers*/) const {
     markup::Document md;
@@ -519,7 +820,7 @@ lsp::MarkupContent DefinitionInfo::SystemSubroutineTarget::getHover(
     if (!doc->description.empty()) {
         md.addParagraph().appendText(doc->description);
     }
-    return md.build();
+    return md;
 }
 
 std::vector<lsp::LocationLink> DefinitionInfo::SyntaxTarget::getDefinition(
@@ -540,7 +841,32 @@ std::vector<lsp::LocationLink> DefinitionInfo::SyntaxTarget::getDefinition(
 
 std::vector<lsp::LocationLink> DefinitionInfo::SymbolTarget::getDefinition(
     const SourceManager& sm) const {
-    return syntax.getDefinition(sm);
+    std::vector<lsp::LocationLink> result;
+    for (const auto& syntax : syntaxes) {
+        for (auto& link : syntax.getDefinition(sm)) {
+            auto duplicate = std::ranges::any_of(result, [&](const auto& existing) {
+                return existing.targetUri == link.targetUri &&
+                       existing.targetSelectionRange == link.targetSelectionRange;
+            });
+            if (!duplicate)
+                result.push_back(std::move(link));
+        }
+    }
+    return result;
+}
+
+std::vector<lsp::LocationLink> DefinitionInfo::PortConnectionTarget::getDefinition(
+    const SourceManager& sm) const {
+    auto result = outer.getDefinition(sm);
+    for (auto& link : inner.getDefinition(sm)) {
+        auto duplicate = std::ranges::any_of(result, [&](const auto& existing) {
+            return existing.targetUri == link.targetUri &&
+                   existing.targetSelectionRange == link.targetSelectionRange;
+        });
+        if (!duplicate)
+            result.push_back(std::move(link));
+    }
+    return result;
 }
 
 std::vector<lsp::LocationLink> DefinitionInfo::MacroTarget::getDefinition(
@@ -599,11 +925,46 @@ std::vector<lsp::LocationLink> DefinitionInfo::SystemSubroutineTarget::getDefini
 
 lsp::MarkupContent DefinitionInfo::getHover(const SourceManager& sm, BufferID docBuffer,
                                             const Config::HoverConfig& hovers) const {
-    return std::visit([&](const auto& t) { return t.getHover(sm, docBuffer, hovers); }, target);
+    if (auto parameterSummary = renderElaboratedParameterSummary(targets, sm, hovers))
+        return std::move(*parameterSummary);
+    if (auto parameterValues = renderElaboratedParameterValues(targets, sm, hovers))
+        return std::move(*parameterValues);
+
+    std::vector<std::pair<SourceLocation, markup::Document>> renderedTargets;
+    for (const auto& target : targets) {
+        auto rendered = std::visit(
+            [&](const auto& concreteTarget) {
+                return std::pair{concreteTarget.nameToken().location(),
+                                 concreteTarget.getHover(sm, docBuffer, hovers)};
+            },
+            target);
+        auto duplicate = std::ranges::any_of(renderedTargets, [&](const auto& existing) {
+            return existing.first == rendered.first && existing.second == rendered.second;
+        });
+        if (!duplicate)
+            renderedTargets.push_back(std::move(rendered));
+    }
+
+    markup::Document result;
+    for (auto& rendered : renderedTargets)
+        result.append(std::move(rendered.second));
+    return result.build();
 }
 
 std::vector<lsp::LocationLink> DefinitionInfo::getDefinition(const SourceManager& sm) const {
-    return std::visit([&](const auto& t) { return t.getDefinition(sm); }, target);
+    std::vector<lsp::LocationLink> result;
+    for (const auto& target : targets) {
+        auto links = std::visit([&](const auto& t) { return t.getDefinition(sm); }, target);
+        for (auto& link : links) {
+            auto duplicate = std::ranges::any_of(result, [&](const auto& existing) {
+                return existing.targetUri == link.targetUri &&
+                       existing.targetSelectionRange == link.targetSelectionRange;
+            });
+            if (!duplicate)
+                result.push_back(std::move(link));
+        }
+    }
+    return result;
 }
 
 } // namespace server

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -13,6 +13,7 @@
 #include "util/Converters.h"
 #include "util/Logging.h"
 #include "util/SlangExtensions.h"
+#include <algorithm>
 #include <fmt/format.h>
 #include <memory>
 #include <string_view>
@@ -20,9 +21,12 @@
 #include "slang/analysis/AnalysisManager.h"
 #include "slang/ast/ASTContext.h"
 #include "slang/ast/Compilation.h"
+#include "slang/ast/symbols/BlockSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/MemberSymbols.h"
+#include "slang/ast/symbols/ParameterSymbols.h"
 #include "slang/ast/symbols/PortSymbols.h"
+#include "slang/ast/symbols/SubroutineSymbols.h"
 #include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/ast/types/AllTypes.h"
 #include "slang/ast/types/Type.h"
@@ -273,15 +277,124 @@ struct OffsetFinder {
     const parsing::Token* foundToken = nullptr;
 };
 
-const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declTok) const {
-    if (!declTok) {
+const ShallowAnalysis::GenvarElaboration* ShallowAnalysis::getGenvarElaborationAtToken(
+    const parsing::Token* declTok) const {
+    if (!declTok)
         return nullptr;
+
+    auto* syntax = syntaxes.getTokenParent(declTok);
+    if (!syntax)
+        return nullptr;
+
+    while (syntax && syntax->kind != syntax::SyntaxKind::LoopGenerate)
+        syntax = syntax->parent;
+    if (!syntax)
+        return nullptr;
+
+    auto& loop = syntax->as<syntax::LoopGenerateSyntax>();
+    auto& elaboration = m_genvarElaborations[&loop];
+    if (elaboration.initialized)
+        return elaboration.source ? &elaboration : nullptr;
+    elaboration.initialized = true;
+
+    for (auto* scope : m_symbolIndexer.getScopesForSyntax(loop)) {
+        auto* array = scope->asSymbol().as_if<ast::GenerateBlockArraySymbol>();
+        if (!array)
+            continue;
+
+        auto* genvar = array->find(loop.identifier.valueText());
+        if ((!genvar || genvar->kind != ast::SymbolKind::Genvar) && array->getParentScope())
+            genvar = array->getParentScope()->find(loop.identifier.valueText());
+        if (!genvar || genvar->kind != ast::SymbolKind::Genvar)
+            continue;
+
+        if (!elaboration.source)
+            elaboration.source = &genvar->as<ast::GenvarSymbol>();
+
+        for (auto* entry : array->entries) {
+            auto* symbol = entry->find(loop.identifier.valueText());
+            auto* parameter = symbol ? symbol->as_if<ast::ParameterSymbol>() : nullptr;
+            if (parameter && parameter->isFromGenvar() &&
+                std::ranges::find(elaboration.parameters, parameter) ==
+                    elaboration.parameters.end()) {
+                elaboration.parameters.push_back(parameter);
+            }
+        }
+    }
+
+    return elaboration.source ? &elaboration : nullptr;
+}
+
+std::span<const ast::ParameterSymbol* const> ShallowAnalysis::getGenvarIterationParametersAtToken(
+    const parsing::Token* declTok) const {
+    auto* elaboration = getGenvarElaborationAtToken(declTok);
+    if (!elaboration)
+        return {};
+    return {elaboration->parameters.data(), elaboration->parameters.size()};
+}
+
+slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
+    const parsing::Token* declTok) const {
+    slang::SmallVector<const ast::Symbol*, 2> symbols;
+    auto addSymbol = [&](const ast::Symbol* symbol) {
+        auto addOne = [&](const ast::Symbol* candidate) {
+            if (!candidate)
+                return;
+
+            if (candidate->kind == ast::SymbolKind::Genvar) {
+                if (auto* elaboration = getGenvarElaborationAtToken(declTok))
+                    candidate = elaboration->source;
+            }
+
+            if (std::ranges::find(symbols, candidate) == symbols.end())
+                symbols.push_back(candidate);
+        };
+
+        if (!symbol)
+            return;
+
+        switch (symbol->kind) {
+            case ast::SymbolKind::InstanceBody:
+                addOne(&symbol->as<ast::InstanceBodySymbol>().getDefinition());
+                break;
+            case ast::SymbolKind::Port: {
+                // The internal symbol carries the declared type and is the symbol used by
+                // references inside the instance.
+                auto& port = symbol->as<ast::PortSymbol>();
+                addOne(port.internalSymbol ? port.internalSymbol : symbol);
+                break;
+            }
+            case ast::SymbolKind::ModportPort: {
+                // A named modport port has both an underlying typed symbol and a directional
+                // declaration in the modport.
+                auto& port = symbol->as<ast::ModportPortSymbol>();
+                addOne(symbol);
+                addOne(port.internalSymbol);
+                break;
+            }
+            case ast::SymbolKind::MethodPrototype: {
+                auto& prototype = symbol->as<ast::MethodPrototypeSymbol>();
+                addOne(symbol);
+                if (symbol->getSyntax() &&
+                    symbol->getSyntax()->kind == syntax::SyntaxKind::ModportSubroutinePort) {
+                    addOne(prototype.getSubroutine());
+                }
+                break;
+            }
+            default:
+                addOne(symbol);
+                break;
+        }
+    };
+
+    if (!declTok) {
+        return symbols;
     }
 
     auto syntax = syntaxes.getTokenParent(declTok);
     // Note: SuperHandle nodes can cause issues in symbol lookup
     if (!syntax || syntax->kind == syntax::SyntaxKind::SuperHandle) {
-        return nullptr;
+        return symbols;
     }
 
     // Handle macro args
@@ -321,41 +434,71 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
              syntax->kind == syntax::SyntaxKind::PackageImportItem) {
         auto pkg = m_compilation->getPackage(syntax->getFirstToken().valueText());
         if (!pkg) {
-            return {};
+            return symbols;
         }
         if (syntax->getFirstToken() == *declTok) {
-            return pkg;
+            addSymbol(pkg);
         }
-        return pkg->find(declTok->valueText());
+        else {
+            addSymbol(pkg->find(declTok->valueText()));
+        }
+        return symbols;
     }
-    else if (auto sym = m_symbolIndexer.getSymbol(declTok)) {
-        switch (sym->kind) {
-            case ast::SymbolKind::InstanceBody:
-                // Module declarations get indexed to their body. We do want to keep the body
-                // as the indexed sym for use in the future though with hdl features.
-                return &sym->as<ast::InstanceBodySymbol>().getDefinition();
-            case ast::SymbolKind::Port: {
-                // Named port connections get indexed to the port symbol. Return the internal
-                // symbol so that references work across instance boundaries.
-                auto& port = sym->as<ast::PortSymbol>();
-                if (port.internalSymbol) {
-                    return port.internalSymbol;
-                }
-                return sym;
+    else if (auto indexed = m_symbolIndexer.getSymbols(declTok); !indexed.empty()) {
+        if (syntax->kind == syntax::SyntaxKind::NamedPortConnection &&
+            !syntax->as<syntax::NamedPortConnectionSyntax>().openParen) {
+            if (indexed.size() > 1) {
+                symbols.append(indexed.begin(), indexed.end());
             }
-            default:
-                return sym;
+            else {
+                for (auto* scope : m_symbolIndexer.getScopesForSyntax(*syntax))
+                    addSymbol(scope->lookupName(declTok->valueText()));
+                addSymbol(indexed.front());
+            }
+            return symbols;
         }
+
+        // Keep the selected facade kind while retaining distinct elaborations of that kind.
+        auto legacyKind = indexed.back()->kind;
+        for (auto* symbol : indexed) {
+            if (symbol->kind == legacyKind)
+                addSymbol(symbol);
+        }
+        return symbols;
     }
 
-    auto scope = m_symbolIndexer.getScopeForSyntax(*syntax);
-    if (!scope) {
+    auto scopes = m_symbolIndexer.getScopesForSyntax(*syntax);
+
+    if (syntax->kind == syntax::SyntaxKind::LoopGenerate &&
+        syntax->as<syntax::LoopGenerateSyntax>().identifier == *declTok) {
+        if (auto* elaboration = getGenvarElaborationAtToken(declTok))
+            addSymbol(elaboration->source);
+        if (!symbols.empty())
+            return symbols;
+    }
+
+    if (scopes.empty()) {
         INFO("No scope found for syntax {}, using root scope", syntax->toString());
-        scope = &m_compilation->getRoot().as<ast::Scope>();
+        scopes.push_back(&m_compilation->getRoot().as<ast::Scope>());
     }
 
-    // Perform name lookup; this should be most gotos
-    if (auto nameSyntax = findNameSyntax(*syntax)) {
+    auto resolveInScope = [&](const ast::Scope* scope) -> const ast::Symbol* {
+        // Perform name lookup; this should be most gotos.
+        auto nameSyntax = findNameSyntax(*syntax);
+        if (!nameSyntax) {
+            if (declTok->kind != parsing::TokenKind::Identifier ||
+                syntax->kind == syntax::SyntaxKind::AttributeSpec) {
+                return nullptr;
+            }
+            if (syntax->kind == syntax::SyntaxKind::DotMemberClause)
+                return handleInterfacePortHeader(declTok, syntax, scope);
+            if (auto def = m_compilation->tryGetDefinition(declTok->valueText(), *scope);
+                def.definition) {
+                return def.definition;
+            }
+            return m_compilation->getPackage(declTok->valueText());
+        }
+
         auto scopedName = nameSyntax->as_if<slang::syntax::ScopedNameSyntax>();
         if (scopedName && scopedName->separator == *declTok) {
             return nullptr;
@@ -394,7 +537,7 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
                             type = &cur->as<ast::ValueSymbol>().getType();
                         }
 
-                        if (type->isArray()) {
+                        if (type && type->isArray()) {
                             cur = type->getArrayElementType();
                         }
                         else {
@@ -428,28 +571,48 @@ const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declT
         if (auto scopedResult = handleScopedNameLookup(nameSyntax, context, scope)) {
             return scopedResult;
         }
-    }
 
-    if (declTok->kind != parsing::TokenKind::Identifier ||
-        syntax->kind == syntax::SyntaxKind::AttributeSpec) {
-        return nullptr;
-    }
+        if (declTok->kind != parsing::TokenKind::Identifier ||
+            syntax->kind == syntax::SyntaxKind::AttributeSpec) {
+            return nullptr;
+        }
 
-    if (syntax->kind == syntax::SyntaxKind::DotMemberClause) {
-        return handleInterfacePortHeader(declTok, syntax, scope);
-    }
-    // Try getting a definition as a last resort
-    auto def = m_compilation->tryGetDefinition(declTok->valueText(), *scope);
-    if (def.definition) {
-        return def.definition;
-    }
+        if (syntax->kind == syntax::SyntaxKind::DotMemberClause) {
+            return handleInterfacePortHeader(declTok, syntax, scope);
+        }
+        // Try getting a definition as a last resort.
+        auto def = m_compilation->tryGetDefinition(declTok->valueText(), *scope);
+        if (def.definition) {
+            return def.definition;
+        }
 
-    auto pkg = m_compilation->getPackage(declTok->valueText());
-    if (pkg) {
-        return pkg;
-    }
+        return m_compilation->getPackage(declTok->valueText());
+    };
 
-    return nullptr;
+    for (auto* scope : scopes)
+        addSymbol(resolveInScope(scope));
+    return symbols;
+}
+
+const ast::Symbol* ShallowAnalysis::getSymbolAtToken(const parsing::Token* declTok) const {
+    auto symbols = getSymbolsAtToken(declTok);
+    if (declTok) {
+        auto* syntaxNode = syntaxes.getTokenParent(declTok);
+        if (syntaxNode && syntaxNode->kind == syntax::SyntaxKind::NamedPortConnection &&
+            !syntaxNode->as<syntax::NamedPortConnectionSyntax>().openParen) {
+            if (symbols.size() > 1)
+                return symbols[1];
+            return symbols.empty() ? nullptr : symbols.front();
+        }
+    }
+    if (auto it = std::ranges::find_if(symbols,
+                                       [](const ast::Symbol* symbol) {
+                                           return symbol->kind == ast::SymbolKind::ModportPort;
+                                       });
+        it != symbols.end()) {
+        return *it;
+    }
+    return symbols.empty() ? nullptr : symbols.back();
 }
 
 const ast::Symbol* ShallowAnalysis::getDefinition(std::string_view name) const {

--- a/src/document/SymbolIndexer.cpp
+++ b/src/document/SymbolIndexer.cpp
@@ -9,6 +9,7 @@
 #include "document/SymbolIndexer.h"
 
 #include "util/Logging.h"
+#include <algorithm>
 
 #include "slang/ast/Scope.h"
 #include "slang/ast/Symbol.h"
@@ -53,11 +54,11 @@ SymbolIndexer::SymbolIndexer(slang::BufferID buffer) : m_buffer(buffer) {
 }
 
 const slang::ast::Symbol* SymbolIndexer::getSymbol(const slang::parsing::Token* node) const {
-    auto it = symdex.find(node);
-    if (it == symdex.end()) {
+    auto symbols = getSymbols(node);
+    if (symbols.empty()) {
         return nullptr;
     }
-    return it->second;
+    return symbols.back();
 }
 
 const slang::ast::Symbol* SymbolIndexer::getSymbol(const slang::syntax::SyntaxNode* node) const {
@@ -65,35 +66,72 @@ const slang::ast::Symbol* SymbolIndexer::getSymbol(const slang::syntax::SyntaxNo
     if (it == syntex.end()) {
         return nullptr;
     }
-    return it->second;
+    return it->second.back();
+}
+
+std::span<const slang::ast::Symbol* const> SymbolIndexer::getSymbols(
+    const slang::parsing::Token* node) const {
+    auto it = symdex.find(node);
+    if (it == symdex.end()) {
+        return {};
+    }
+    return {it->second.data(), it->second.size()};
+}
+
+void SymbolIndexer::addSymbol(const slang::parsing::Token* token,
+                              const slang::ast::Symbol& symbol) {
+    auto& symbols = symdex[token];
+    if (std::ranges::find(symbols, &symbol) == symbols.end())
+        symbols.push_back(&symbol);
+}
+
+void SymbolIndexer::addSymbol(const slang::syntax::SyntaxNode* syntax,
+                              const slang::ast::Symbol& symbol) {
+    auto& symbols = syntex[syntax];
+    if (std::ranges::find(symbols, &symbol) == symbols.end())
+        symbols.push_back(&symbol);
 }
 
 const slang::ast::Scope* SymbolIndexer::getScopeForSyntax(
+    const slang::syntax::SyntaxNode& syntax) const {
+
+    auto scopes = getScopesForSyntax(syntax);
+    return scopes.empty() ? nullptr : scopes.back();
+}
+
+slang::SmallVector<const slang::ast::Scope*, 2> SymbolIndexer::getScopesForSyntax(
     const slang::syntax::SyntaxNode& syntax) const {
 
     const slang::syntax::SyntaxNode* current = &syntax;
     while (current != nullptr) {
         auto it = syntex.find(current);
         if (it != syntex.end()) {
-            const slang::ast::Symbol* symbol = it->second;
-            if (symbol) {
+            slang::SmallVector<const slang::ast::Scope*, 2> result;
+            for (const auto* symbol : it->second) {
+                const slang::ast::Scope* scope = nullptr;
                 if (symbol->isScope()) {
-                    return &symbol->as<slang::ast::Scope>();
+                    scope = &symbol->as<slang::ast::Scope>();
                 }
-                else {
-                    return symbol->getParentScope();
-                }
+                else
+                    scope = symbol->getParentScope();
+
+                if (scope && std::ranges::find(result, scope) == result.end())
+                    result.push_back(scope);
             }
+            if (!result.empty())
+                return result;
         }
         current = current->parent;
     }
 
-    return nullptr;
+    return {};
 }
 
 void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanceSyntax& instSyntax,
                                         const slang::ast::InstanceBodySymbol& body,
-                                        const slang::ast::DefinitionSymbol& definition) {
+                                        const slang::ast::DefinitionSymbol& definition,
+                                        const slang::ast::InstanceSymbol* instance,
+                                        const slang::ast::Scope* parentScope) {
 
     // Mark ports
     for (auto port : instSyntax.connections) {
@@ -109,7 +147,82 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
                     continue;
                 }
 
-                symdex[&portSyntax.name] = maybePortSym;
+                // `.name` is shorthand for `.name(name)`, so its single token denotes both the
+                // formal port and the value in the instance's parent scope.
+                if (!portSyntax.openParen) {
+                    auto addConnection = [&](const slang::ast::Symbol* outer,
+                                             const slang::ast::Symbol* inner) {
+                        if (!outer || !inner)
+                            return false;
+
+                        auto& symbols = symdex[&portSyntax.name];
+                        for (size_t i = 0; i + 1 < symbols.size(); i += 2) {
+                            if (symbols[i] == outer && symbols[i + 1] == inner)
+                                return true;
+                        }
+                        symbols.push_back(outer);
+                        symbols.push_back(inner);
+                        return true;
+                    };
+
+                    bool indexedConnection = false;
+                    if (instance && instance->getSyntax()) {
+                        for (auto* connection : instance->getPortConnections()) {
+                            bool matchesFormal = &connection->port == maybePortSym;
+                            if (auto* multiPort =
+                                    maybePortSym->as_if<slang::ast::MultiPortSymbol>()) {
+                                matchesFormal = std::ranges::find(multiPort->ports,
+                                                                  &connection->port) !=
+                                                multiPort->ports.end();
+                            }
+                            if (!matchesFormal)
+                                continue;
+
+                            const slang::ast::Symbol* outer = nullptr;
+                            if (parentScope) {
+                                outer = parentScope->lookupName(
+                                    name, slang::ast::LookupLocation::after(*instance));
+                            }
+                            if (!outer) {
+                                if (auto* expression = connection->getExpression())
+                                    outer = expression->getSymbolReference();
+                            }
+                            if (!outer &&
+                                connection->port.kind == slang::ast::SymbolKind::InterfacePort) {
+                                outer = connection->getIfaceConn().first;
+                            }
+
+                            const slang::ast::Symbol* inner = &connection->port;
+                            if (auto* port = connection->port.as_if<slang::ast::PortSymbol>();
+                                port && port->internalSymbol) {
+                                inner = port->internalSymbol;
+                            }
+                            indexedConnection |= addConnection(outer, inner);
+                        }
+                    }
+                    else {
+                        const slang::ast::Symbol* connected = nullptr;
+                        if (parentScope) {
+                            auto location = instance && instance->getParentScope() == parentScope
+                                                ? slang::ast::LookupLocation::after(*instance)
+                                                : slang::ast::LookupLocation::max;
+                            connected = parentScope->lookupName(name, location);
+                        }
+
+                        const slang::ast::Symbol* inner = maybePortSym;
+                        if (auto* port = maybePortSym->as_if<slang::ast::PortSymbol>();
+                            port && port->internalSymbol) {
+                            inner = port->internalSymbol;
+                        }
+                        indexedConnection = addConnection(connected, inner);
+                    }
+
+                    if (indexedConnection)
+                        continue;
+                }
+
+                // Keep the formal last because single-symbol lookup selects the last entry.
+                addSymbol(&portSyntax.name, *maybePortSym);
 
             } break;
             default:
@@ -121,14 +234,10 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
         return;
     }
 
-    // Mark module type and param if we haven't already
+    // Mark module type and parameters. The definition is normally shared, while elaborated
+    // parameter symbols can differ for each instance that shares this syntax.
     auto& paramInst = instSyntax.parent->as<slang::syntax::HierarchyInstantiationSyntax>();
-    if (symdex.find(&paramInst.type) != symdex.end()) {
-        return;
-    }
-
-    // Mark instance type
-    symdex[&paramInst.type] = &definition;
+    addSymbol(&paramInst.type, definition);
 
     if (paramInst.parameters == nullptr) {
         return;
@@ -144,7 +253,7 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
                     const slang::ast::Symbol* paramSym = body.lookupName(
                         paramSyntax.name.valueText());
                     if (paramSym) {
-                        symdex[&paramSyntax.name] = paramSym;
+                        addSymbol(&paramSyntax.name, *paramSym);
                     }
                 }
             } break;
@@ -156,7 +265,7 @@ void SymbolIndexer::indexInstanceSyntax(const slang::syntax::HierarchicalInstanc
 
 void SymbolIndexer::indexSymbolName(const slang::ast::Symbol& symbol, bool isUnnamed) {
     if (symbol.getSyntax() != nullptr) {
-        syntex[symbol.getSyntax()] = &symbol;
+        addSymbol(symbol.getSyntax(), symbol);
 
         auto& syntax = *symbol.getSyntax();
         if (!isUnnamed && syntax.sourceRange().start().buffer() == m_buffer &&
@@ -170,7 +279,7 @@ void SymbolIndexer::indexSymbolName(const slang::ast::Symbol& symbol, bool isUnn
             }
 
             for (auto* tok : tokens) {
-                symdex[tok] = &symbol;
+                addSymbol(tok, symbol);
             }
         }
     }
@@ -184,13 +293,14 @@ void SymbolIndexer::handle(const slang::ast::InstanceArraySymbol& sym) {
     }
 
     auto& instSyntax = sym.getSyntax()->as<slang::syntax::HierarchicalInstanceSyntax>();
-    symdex[&instSyntax.decl->name] = &sym;
+    addSymbol(&instSyntax.decl->name, sym);
 
     // Get definition and body - either from first element or by lookup
     if (!sym.elements.empty() && sym.elements[0]->kind == slang::ast::SymbolKind::Instance) {
         // Use first element if available
         auto& firstInst = sym.elements[0]->as<slang::ast::InstanceSymbol>();
-        indexInstanceSyntax(instSyntax, firstInst.body, firstInst.getDefinition());
+        indexInstanceSyntax(instSyntax, firstInst.body, firstInst.getDefinition(), &firstInst,
+                            firstInst.getParentScope());
     }
     else if (instSyntax.parent != nullptr &&
              instSyntax.parent->kind == slang::syntax::SyntaxKind::HierarchyInstantiation) {
@@ -208,7 +318,7 @@ void SymbolIndexer::handle(const slang::ast::InstanceArraySymbol& sym) {
         auto& definition = result.definition->as<slang::ast::DefinitionSymbol>();
         auto& inst = slang::ast::InstanceSymbol::createInvalid(parentScope->getCompilation(),
                                                                definition);
-        indexInstanceSyntax(instSyntax, inst.body, definition);
+        indexInstanceSyntax(instSyntax, inst.body, definition, &inst, sym.getParentScope());
     }
 }
 
@@ -218,7 +328,7 @@ void SymbolIndexer::handle(const slang::ast::InstanceSymbol& sym) {
         // This means it's the top level- just index the module name
         auto& modName =
             sym.getDefinition().getSyntax()->as<slang::syntax::ModuleDeclarationSyntax>();
-        symdex[&modName.header->name] = &sym.getDefinition();
+        addSymbol(&modName.header->name, sym.getDefinition());
         visitDefault(sym);
         return;
     }
@@ -231,8 +341,9 @@ void SymbolIndexer::handle(const slang::ast::InstanceSymbol& sym) {
     switch (sym.getSyntax()->kind) {
         case slang::syntax::SyntaxKind::HierarchicalInstance: {
             auto& instSyntax = sym.getSyntax()->as<slang::syntax::HierarchicalInstanceSyntax>();
-            symdex[&instSyntax.decl->name] = &sym;
-            indexInstanceSyntax(instSyntax, sym.body, sym.getDefinition());
+            addSymbol(&instSyntax.decl->name, sym);
+            indexInstanceSyntax(instSyntax, sym.body, sym.getDefinition(), &sym,
+                                sym.getParentScope());
         } break;
         default: {
             WARN("Unknown instance symbol kind: {}", toString(sym.getSyntax()->kind));
@@ -247,7 +358,7 @@ void SymbolIndexer::handle(const slang::ast::InstanceSymbol& sym) {
 void SymbolIndexer::handle(const slang::ast::EnumValueSymbol& sym) {
     auto& syntax = sym.getSyntax()->as<slang::syntax::DeclaratorSyntax>();
     if (syntax.dimensions.empty()) {
-        symdex[&syntax.name] = &sym;
+        addSymbol(&syntax.name, sym);
     }
 }
 

--- a/src/util/Markdown.cpp
+++ b/src/util/Markdown.cpp
@@ -107,6 +107,14 @@ Paragraph& Paragraph::newLine() {
     return *this;
 }
 
+Paragraph& Paragraph::append(Paragraph paragraph) {
+    if (buffer.empty())
+        buffer = std::move(paragraph.buffer);
+    else
+        buffer += paragraph.buffer;
+    return *this;
+}
+
 // Document implementation
 
 Paragraph& Document::addParagraph() {
@@ -116,6 +124,16 @@ Paragraph& Document::addParagraph() {
 
 void Document::addParagraph(Paragraph para) {
     paragraphs.push_back(std::move(para));
+}
+
+void Document::append(Document doc) {
+    paragraphs.reserve(paragraphs.size() + doc.paragraphs.size());
+    for (auto& paragraph : doc.paragraphs)
+        paragraphs.push_back(std::move(paragraph));
+}
+
+bool Document::isEmpty() const {
+    return std::ranges::all_of(paragraphs, &Paragraph::isEmpty);
 }
 
 lsp::MarkupContent Document::build() const {

--- a/tests/cpp/GotoTests.cpp
+++ b/tests/cpp/GotoTests.cpp
@@ -41,6 +41,24 @@ TEST_CASE("FindSymbolRefMacro") {
     scanner.scanDocument(hdl);
 }
 
+TEST_CASE("FindMultiSymbolRef") {
+    ServerHarness server("multi_symbol");
+    auto first = server.openFile("first.sv");
+    first.save();
+    auto second = server.openFile("second.sv");
+    second.save();
+    auto hdl = server.openFile("use.sv");
+
+    SymbolRefScanner scanner(
+        {hdl.after("import features::").m_offset, hdl.after("export features::").m_offset,
+         hdl.after("modport endpoint(output ").m_offset, hdl.after("import task ").m_offset,
+         hdl.after("module top;\n    import ").m_offset, hdl.after("leaf u(.").m_offset,
+         hdl.before("duplicate d").m_offset, hdl.after("genvar ").m_offset,
+         hdl.before("VALUE =").m_offset, hdl.after("VALUE = ").m_offset,
+         hdl.after("`ifdef ").m_offset});
+    scanner.scanDocument(hdl);
+}
+
 TEST_CASE("GotoDefinition_UndefDirective") {
     ServerHarness server;
 
@@ -109,6 +127,162 @@ TEST_CASE("GotoDefinition_IfdefUndefinedMacro") {
     auto cursor = doc.after("`ifdef ");
     auto defs = cursor.getDefinitions();
     CHECK(defs.empty());
+}
+
+TEST_CASE("GotoDefinition_AllIndexedModuleDefinitions") {
+    ServerHarness server;
+
+    auto first = server.openFile("first.sv", R"(
+module duplicate #(parameter int FIRST_VALUE = 1);
+endmodule
+)");
+    first.save();
+    auto second = server.openFile("second.sv", R"(
+module duplicate #(parameter int SECOND_VALUE = 2);
+endmodule
+)");
+    second.save();
+
+    auto use = server.openFile("use.sv", R"(
+module top;
+    duplicate u();
+endmodule
+)");
+    auto cursor = use.before("duplicate u");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("FIRST_VALUE") != std::string::npos);
+    CHECK(content.find("SECOND_VALUE") != std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_SemanticDefinitionExcludesWorkspaceNamesake") {
+    ServerHarness server;
+
+    auto indexed = server.openFile("indexed.sv", R"(
+interface chosen_if #(parameter int INDEXED_VALUE = 1);
+endinterface
+)");
+    indexed.save();
+
+    auto use = server.openFile("use.sv", R"(
+interface chosen_if #(parameter int LOCAL_VALUE = 2);
+endinterface
+
+module top(chosen_if port);
+endmodule
+)");
+    auto cursor = use.after("module top(");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 1);
+    CHECK(defs[0].targetUri == use.m_uri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("LOCAL_VALUE") != std::string::npos);
+    CHECK(content.find("INDEXED_VALUE") == std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_MacroGeneratedModuleDefinition") {
+    ServerHarness server;
+
+    auto generated = server.openFile("generated.sv", R"(
+`define DECLARE_DUPLICATE module duplicate #(parameter int MACRO_VALUE = 1); endmodule
+`DECLARE_DUPLICATE
+)");
+    generated.save();
+    auto declared = server.openFile("declared.sv", R"(
+module duplicate #(parameter int DECLARED_VALUE = 2);
+endmodule
+)");
+    declared.save();
+
+    auto use = server.openFile("use.sv", R"(
+module top;
+    duplicate u();
+endmodule
+)");
+    auto cursor = use.before("duplicate u");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("MACRO_VALUE") != std::string::npos);
+    CHECK(content.find("DECLARED_VALUE") != std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_AllIndexedPackageDefinitions") {
+    ServerHarness server;
+
+    auto first = server.openFile("first_pkg.sv", R"(
+package automatic duplicate_pkg;
+    localparam int FIRST_VALUE = 1;
+endpackage
+)");
+    first.save();
+    auto second = server.openFile("second_pkg.sv", R"(
+package static duplicate_pkg;
+    localparam int SECOND_VALUE = 2;
+endpackage
+)");
+    second.save();
+
+    auto use = server.openFile("use_pkg.sv", R"(
+module top;
+    import duplicate_pkg::*;
+endmodule
+)");
+    auto cursor = use.before("duplicate_pkg");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("package automatic duplicate_pkg") != std::string::npos);
+    CHECK(content.find("package static duplicate_pkg") != std::string::npos);
+}
+
+TEST_CASE("GotoDefinition_AllIndexedMacroDefinitions") {
+    ServerHarness server;
+
+    auto first = server.openFile("first_macro.sv", R"(
+`define DUPLICATE_MACRO FIRST_VALUE
+)");
+    first.save();
+    auto second = server.openFile("second_macro.sv", R"(
+`define DUPLICATE_MACRO SECOND_VALUE
+)");
+    second.save();
+
+    auto use = server.openFile("use_macro.sv", R"(
+`ifdef DUPLICATE_MACRO
+`endif
+)");
+    auto cursor = use.after("`ifdef ");
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetUri != defs[1].targetUri);
+
+    auto hover = use.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("FIRST_VALUE") != std::string::npos);
+    CHECK(content.find("SECOND_VALUE") != std::string::npos);
 }
 
 TEST_CASE("LoadTransitivePackages") {

--- a/tests/cpp/HoverTests.cpp
+++ b/tests/cpp/HoverTests.cpp
@@ -5,6 +5,15 @@
 #include "utils/ServerHarness.h"
 #include <cstdlib>
 
+static size_t countSubstring(std::string_view text, std::string_view substring) {
+    size_t count = 0;
+    for (size_t pos = 0; (pos = text.find(substring, pos)) != std::string_view::npos;
+         pos += substring.size()) {
+        count++;
+    }
+    return count;
+}
+
 TEST_CASE("HoverMacroExpansion") {
     ServerHarness server;
 
@@ -179,6 +188,465 @@ endmodule
     CAPTURE(content.value);
     CHECK(content.value.find("**TypeAlias** `T`") != std::string::npos);
     CHECK(content.value.find("Value: `byte`") != std::string::npos);
+}
+
+TEST_CASE("HoverAndGotoImplicitPortShowBothSides") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module leaf(input logic [7:0] shared);
+endmodule
+
+module top;
+    logic [7:0] shared;
+    leaf u(.shared);
+endmodule
+)");
+
+    auto cursor = doc.after("u(.");
+    auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+    REQUIRE(info);
+    REQUIRE(info->targets.size() == 1);
+    auto* portTarget = std::get_if<server::DefinitionInfo::PortConnectionTarget>(
+        &info->targets.front());
+    REQUIRE(portTarget);
+
+    auto defs = cursor.getDefinitions();
+    REQUIRE(defs.size() == 2);
+    CHECK(defs[0].targetSelectionRange.start.line > defs[1].targetSelectionRange.start.line);
+
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("input logic [7:0] shared") != std::string::npos);
+    CHECK(content.find("logic [7:0] shared") != std::string::npos);
+    CHECK(countSubstring(content, "Type: `logic[7:0]`") == 1);
+    CHECK(countSubstring(content, "Width: `8`") == 1);
+    auto outerLabel = content.find("**Outer**");
+    auto innerLabel = content.find("**Inner**");
+    CHECK(outerLabel != std::string::npos);
+    CHECK(innerLabel != std::string::npos);
+    CHECK(outerLabel < innerLabel);
+    CHECK(content.find("Driven via port from `leaf u`") != std::string::npos);
+}
+
+TEST_CASE("HoverImplicitPortInGenerateLoopDeduplicatesElaborations") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module leaf(input logic reset);
+endmodule
+
+module top(input logic reset);
+    for (genvar i = 0; i < 2; i++) begin : instances
+        leaf memory(.reset);
+    end
+endmodule
+)");
+
+    auto cursor = doc.after("memory(.");
+    auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+    REQUIRE(info);
+    REQUIRE(info->targets.size() == 1);
+
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CAPTURE(content);
+    CHECK(countSubstring(content, "**Outer**") == 1);
+    CHECK(countSubstring(content, "**Inner**") == 1);
+    CHECK(countSubstring(content, "Generated signals: `2`") == 1);
+    CHECK(countSubstring(content, "Driven via port from `leaf memory`") == 1);
+}
+
+TEST_CASE("HoverExplicitPortShowsInputDriver") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module leaf(input logic [7:0] data);
+endmodule
+
+module top;
+    logic [7:0] value;
+    leaf u(.data(value));
+endmodule
+)");
+
+    auto cursor = doc.after("u(.");
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CAPTURE(content);
+    CHECK(content.find("input logic [7:0] data") != std::string::npos);
+    CHECK(content.find("Driven via port from `leaf u`") != std::string::npos);
+}
+
+TEST_CASE("HoverOutputConnectionsShowInnerDriver") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module implicit_leaf(output logic implicit_value);
+    always_comb implicit_value = 1'b1;
+endmodule
+
+module explicit_leaf(output logic data);
+    always_comb data = 1'b1;
+endmodule
+
+module top(
+    output logic implicit_value,
+    output logic explicit_value
+);
+    implicit_leaf implicit_u(.implicit_value);
+    explicit_leaf explicit_u(.data(explicit_value));
+endmodule
+)");
+
+    auto implicitCursor = doc.after("implicit_u(.");
+    auto implicitHover = doc.getHoverAt(implicitCursor.m_offset);
+    REQUIRE(implicitHover);
+    auto implicitContent = rfl::get<lsp::MarkupContent>(implicitHover->contents).value;
+    CAPTURE(implicitContent);
+    CHECK(implicitContent.find("Driven via port from `implicit_leaf implicit_u`") !=
+          std::string::npos);
+    CHECK(implicitContent.find("Driven by always_comb") != std::string::npos);
+
+    auto explicitCursor = doc.after(".data(");
+    auto explicitHover = doc.getHoverAt(explicitCursor.m_offset);
+    REQUIRE(explicitHover);
+    auto explicitContent = rfl::get<lsp::MarkupContent>(explicitHover->contents).value;
+    CAPTURE(explicitContent);
+    CHECK(explicitContent.find("Driven via port from `explicit_leaf explicit_u`") !=
+          std::string::npos);
+    CHECK(explicitContent.find("Driven by always_comb") != std::string::npos);
+
+    auto declarationCursor = doc.after("output logic explicit_");
+    auto declarationHover = doc.getHoverAt(declarationCursor.m_offset);
+    REQUIRE(declarationHover);
+    auto declarationContent = rfl::get<lsp::MarkupContent>(declarationHover->contents).value;
+    CAPTURE(declarationContent);
+    CHECK(declarationContent.find("Driven via port from `explicit_leaf explicit_u`") !=
+          std::string::npos);
+    CHECK(declarationContent.find("Driven by always_comb") != std::string::npos);
+}
+
+TEST_CASE("HoverAndGotoForwardedInterfacePortShowBothSides") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+interface bus;
+    logic data;
+endinterface
+
+module leaf(bus shared);
+endmodule
+
+module top(bus shared);
+    leaf u(.shared);
+endmodule
+)");
+
+    auto cursor = doc.after("u(.");
+    auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+    REQUIRE(info);
+    REQUIRE(info->targets.size() == 1);
+    auto* portTarget = std::get_if<server::DefinitionInfo::PortConnectionTarget>(
+        &info->targets.front());
+    REQUIRE(portTarget);
+    CHECK(portTarget->outer.symbol->kind == slang::ast::SymbolKind::InterfacePort);
+    CHECK(portTarget->inner.symbol->kind == slang::ast::SymbolKind::InterfacePort);
+
+    auto location = doc.getLocation(cursor.m_offset);
+    REQUIRE(location);
+    auto analysis = doc.doc->getAnalysis();
+    auto* token = analysis->getWordTokenAt(*location);
+    REQUIRE(token);
+    CHECK(analysis->getSymbolAtToken(token) == portTarget->inner.symbol);
+
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(countSubstring(content, "**Outer**") == 1);
+    CHECK(countSubstring(content, "**Inner**") == 1);
+}
+
+TEST_CASE("HoverAndGotoModportShowTypeAndDirection") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+interface bus;
+    logic [7:0] data;
+    assign data = '0;
+    modport initiator(output data);
+endinterface
+
+module top;
+    bus b();
+endmodule
+)");
+
+    auto cursor = doc.before("data);");
+    auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+    REQUIRE(info);
+    REQUIRE(info->targets.size() == 1);
+    auto* symbolTarget = std::get_if<server::DefinitionInfo::SymbolTarget>(&info->primaryTarget());
+    REQUIRE(symbolTarget);
+    CHECK(symbolTarget->symbol->kind == slang::ast::SymbolKind::ModportPort);
+    CHECK(symbolTarget->syntaxes.size() == 2);
+
+    auto defs = cursor.getDefinitions();
+    CHECK(defs.size() == 2);
+
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("logic [7:0] data") != std::string::npos);
+    CHECK(content.find("output data") != std::string::npos);
+    CHECK(countSubstring(content, "**ModportPort** `data`") == 1);
+    CHECK(countSubstring(content, "Type: `logic[7:0]`") == 1);
+    CHECK(countSubstring(content, "Width: `8`") == 1);
+    CHECK(countSubstring(content, "Driven by continuous assignment") == 1);
+}
+
+TEST_CASE("HoverAndGotoExplicitModportPrototypeRetainsDeclaration") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+interface bus;
+    task transfer(input logic value);
+    endtask
+    modport matching(import task transfer(input logic value));
+    modport mismatched(import task transfer(input int value));
+endinterface
+)");
+
+    auto matching = doc.after("matching(import task ");
+    auto matchingInfo = doc.getDefinitionInfoAt(matching.m_offset);
+    REQUIRE(matchingInfo);
+    REQUIRE(matchingInfo->targets.size() == 2);
+    CHECK(std::get<server::DefinitionInfo::SymbolTarget>(matchingInfo->targets[0]).symbol->kind ==
+          slang::ast::SymbolKind::MethodPrototype);
+    CHECK(std::get<server::DefinitionInfo::SymbolTarget>(matchingInfo->targets[1]).symbol->kind ==
+          slang::ast::SymbolKind::Subroutine);
+    auto matchingLocation = doc.getLocation(matching.m_offset);
+    REQUIRE(matchingLocation);
+    auto analysis = doc.doc->getAnalysis();
+    auto* matchingToken = analysis->getWordTokenAt(*matchingLocation);
+    REQUIRE(matchingToken);
+    CHECK(analysis->getSymbolAtToken(matchingToken) ==
+          std::get<server::DefinitionInfo::SymbolTarget>(matchingInfo->targets[1]).symbol);
+
+    auto matchingDefs = matching.getDefinitions();
+    REQUIRE(matchingDefs.size() == 2);
+    CHECK(matchingDefs[0].targetSelectionRange.start.line == 4);
+    CHECK(matchingDefs[1].targetSelectionRange.start.line == 2);
+
+    auto matchingHover = doc.getHoverAt(matching.m_offset);
+    REQUIRE(matchingHover);
+    auto matchingContent = rfl::get<lsp::MarkupContent>(matchingHover->contents).value;
+    CHECK(matchingContent.find("**MethodPrototype** `transfer` in `bus.matching`") !=
+          std::string::npos);
+    CHECK(matchingContent.find("**Subroutine** `transfer` in `bus`") != std::string::npos);
+    CHECK(matchingContent.find("task transfer(input logic value);") != std::string::npos);
+
+    auto mismatched = doc.after("mismatched(import task ");
+    auto mismatchedInfo = doc.getDefinitionInfoAt(mismatched.m_offset);
+    REQUIRE(mismatchedInfo);
+    REQUIRE(mismatchedInfo->targets.size() == 1);
+    CHECK(std::get<server::DefinitionInfo::SymbolTarget>(mismatchedInfo->targets[0]).symbol->kind ==
+          slang::ast::SymbolKind::MethodPrototype);
+    auto mismatchedLocation = doc.getLocation(mismatched.m_offset);
+    REQUIRE(mismatchedLocation);
+    auto* mismatchedToken = analysis->getWordTokenAt(*mismatchedLocation);
+    REQUIRE(mismatchedToken);
+    CHECK(analysis->getSymbolAtToken(mismatchedToken) ==
+          std::get<server::DefinitionInfo::SymbolTarget>(mismatchedInfo->targets[0]).symbol);
+
+    auto mismatchedDefs = mismatched.getDefinitions();
+    REQUIRE(mismatchedDefs.size() == 1);
+    CHECK(mismatchedDefs[0].targetSelectionRange.start.line == 5);
+
+    auto mismatchedHover = doc.getHoverAt(mismatched.m_offset);
+    REQUIRE(mismatchedHover);
+    auto mismatchedContent = rfl::get<lsp::MarkupContent>(mismatchedHover->contents).value;
+    CHECK(mismatchedContent.find("**MethodPrototype** `transfer` in `bus.mismatched`") !=
+          std::string::npos);
+    CHECK(mismatchedContent.find("task transfer(input int value)") != std::string::npos);
+}
+
+TEST_CASE("HoverGeneratedSymbolsSummarizesValues") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module top;
+    for (genvar i = 0; i < 3; i++) begin : g
+        localparam int VALUE = i;
+        localparam int EVEN = i * 2 + 2;
+        localparam int SAME = 1;
+        logic [VALUE:0] data;
+    end
+endmodule
+)");
+
+    auto checkValueRange = [&](Cursor cursor) {
+        auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+        REQUIRE(info);
+        CHECK(info->targets.size() == 3);
+
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+        CHECK(content.find("Value range: `0` through `2`") != std::string::npos);
+        CHECK(content.find("Value: `0`") == std::string::npos);
+        CHECK(countSubstring(content, "**Parameter** `VALUE`") == 1);
+        CHECK(countSubstring(content, "Type: `int`") == 1);
+
+        // All elaborated symbols share the same source declaration.
+        CHECK(cursor.getDefinitions().size() == 1);
+    };
+
+    checkValueRange(doc.before("VALUE ="));
+    checkValueRange(doc.before("VALUE:0"));
+
+    auto evenHover = doc.getHoverAt(doc.before("EVEN =").m_offset);
+    REQUIRE(evenHover);
+    auto evenContent = rfl::get<lsp::MarkupContent>(evenHover->contents).value;
+    CHECK(evenContent.find("Values: `2`, `4`, `6`") != std::string::npos);
+    CHECK(evenContent.find("Value range:") == std::string::npos);
+    CHECK(countSubstring(evenContent, "**Parameter** `EVEN`") == 1);
+
+    auto sameHover = doc.getHoverAt(doc.before("SAME =").m_offset);
+    REQUIRE(sameHover);
+    auto sameContent = rfl::get<lsp::MarkupContent>(sameHover->contents).value;
+    CHECK(countSubstring(sameContent, "**Parameter** `SAME`") == 1);
+    CHECK(countSubstring(sameContent, "Value: `1`") == 1);
+
+    auto checkGenvarRange = [&](Cursor cursor, size_t targetCount,
+                                slang::ast::SymbolKind primaryKind) {
+        auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+        REQUIRE(info);
+        CHECK(info->targets.size() == targetCount);
+        REQUIRE(info->symbol());
+        CHECK(info->symbol()->kind == primaryKind);
+
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+        CAPTURE(content);
+        CHECK(content.find("Value range: `0` through `2`") != std::string::npos);
+        CHECK(content.find("Value: `0`") == std::string::npos);
+    };
+
+    checkGenvarRange(doc.after("genvar "), 4, slang::ast::SymbolKind::Genvar);
+    checkGenvarRange(doc.before("i < 3"), 4, slang::ast::SymbolKind::Genvar);
+    checkGenvarRange(doc.before("i++)"), 4, slang::ast::SymbolKind::Genvar);
+    checkGenvarRange(doc.after("VALUE = "), 3, slang::ast::SymbolKind::Parameter);
+}
+
+TEST_CASE("HoverNestedGeneratedSymbolsDeduplicatesEquivalentElaborations") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module producer(output logic [8:0] exponent_out);
+    always_comb exponent_out = '0;
+endmodule
+
+module top;
+    for (genvar unit_index = 0; unit_index < 2; unit_index++) begin : units
+        for (genvar row = 0; row < 2; row++) begin : rows
+            localparam int ROW_INDEX = row;
+            logic [8:0] math_out_exponent;
+            logic [row:0] varying_width;
+            producer math(.exponent_out(math_out_exponent));
+        end
+    end
+endmodule
+)");
+
+    auto rowHeader = doc.before("row = 0; row < 2");
+    auto rowHeaderInfo = doc.getDefinitionInfoAt(rowHeader.m_offset);
+    REQUIRE(rowHeaderInfo);
+    REQUIRE(rowHeaderInfo->targets.size() == 3);
+    REQUIRE(rowHeaderInfo->symbol());
+    CHECK(rowHeaderInfo->symbol()->kind == slang::ast::SymbolKind::Genvar);
+    auto rowHeaderHover = doc.getHoverAt(rowHeader.m_offset);
+    REQUIRE(rowHeaderHover);
+    auto rowHeaderContent = rfl::get<lsp::MarkupContent>(rowHeaderHover->contents).value;
+    CAPTURE(rowHeaderContent);
+    CHECK(countSubstring(rowHeaderContent, "**Genvar** `row`") == 1);
+    CHECK(countSubstring(rowHeaderContent, "Value range: `0` through `1`") == 1);
+
+    auto row = doc.after("ROW_INDEX = ");
+    auto rowInfo = doc.getDefinitionInfoAt(row.m_offset);
+    REQUIRE(rowInfo);
+    REQUIRE(rowInfo->targets.size() == 2);
+    auto rowHover = doc.getHoverAt(row.m_offset);
+    REQUIRE(rowHover);
+    auto rowContent = rfl::get<lsp::MarkupContent>(rowHover->contents).value;
+    CAPTURE(rowContent);
+    CHECK(countSubstring(rowContent, "````systemverilog\nrow\n````") == 1);
+
+    auto rowIndexHover = doc.getHoverAt(doc.before("ROW_INDEX =").m_offset);
+    REQUIRE(rowIndexHover);
+    auto rowIndexContent = rfl::get<lsp::MarkupContent>(rowIndexHover->contents).value;
+    CAPTURE(rowIndexContent);
+    CHECK(rowIndexContent.find("Value range: `0` through `1`") != std::string::npos);
+    CHECK(countSubstring(rowIndexContent, "**Parameter** `ROW_INDEX`") == 1);
+
+    auto value = doc.before("math_out_exponent;");
+    auto valueInfo = doc.getDefinitionInfoAt(value.m_offset);
+    REQUIRE(valueInfo);
+    REQUIRE(valueInfo->targets.size() == 1);
+    auto valueHover = doc.getHoverAt(value.m_offset);
+    REQUIRE(valueHover);
+    auto valueContent = rfl::get<lsp::MarkupContent>(valueHover->contents).value;
+    CAPTURE(valueContent);
+    CHECK(countSubstring(valueContent, "**Variable** `math_out_exponent`") == 1);
+    CHECK(countSubstring(valueContent, "Generated signals: `4`") == 1);
+    CHECK(countSubstring(valueContent, "Driven via port from `producer math`") == 1);
+    CHECK(countSubstring(valueContent, "Driven by always_comb") == 1);
+
+    auto varying = doc.before("varying_width;");
+    auto varyingInfo = doc.getDefinitionInfoAt(varying.m_offset);
+    REQUIRE(varyingInfo);
+    REQUIRE(varyingInfo->targets.size() == 2);
+    auto varyingHover = doc.getHoverAt(varying.m_offset);
+    REQUIRE(varyingHover);
+    auto varyingContent = rfl::get<lsp::MarkupContent>(varyingHover->contents).value;
+    CAPTURE(varyingContent);
+    CHECK(countSubstring(varyingContent, "**Variable** `varying_width`") == 2);
+    CHECK(countSubstring(varyingContent, "Generated signals: `2`") == 2);
+}
+
+TEST_CASE("HoverReusedGenvarKeepsLoopValuesSeparate") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module top;
+    genvar i;
+    for (i = 0; i < 2; i++) begin : first
+    end
+    for (i = 4; i < 6; i++) begin : second
+    end
+endmodule
+)");
+
+    auto checkRange = [&](Cursor cursor, std::string_view expected) {
+        auto info = doc.getDefinitionInfoAt(cursor.m_offset);
+        REQUIRE(info);
+        REQUIRE(info->targets.size() == 3);
+        REQUIRE(info->symbol());
+        CHECK(info->symbol()->kind == slang::ast::SymbolKind::Genvar);
+
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+        CAPTURE(content);
+        CHECK(content.find(expected) != std::string::npos);
+    };
+
+    checkRange(doc.before("i = 0"), "Value range: `0` through `1`");
+    checkRange(doc.before("i = 4"), "Value range: `4` through `5`");
 }
 
 TEST_CASE("HoverPlaintextDocComments") {

--- a/tests/cpp/MarkupTests.cpp
+++ b/tests/cpp/MarkupTests.cpp
@@ -1,5 +1,6 @@
 #include "catch2/catch_test_macros.hpp"
 #include "util/Markdown.h"
+#include <utility>
 
 static std::string escapeMultilineMarkdown(std::string_view text) {
     std::string escaped;
@@ -84,4 +85,27 @@ TEST_CASE("AppendCode_NoBackticks") {
 
     // Should use single backticks without spaces (no backticks in content)
     CHECK(result == "`int variable = 42`");
+}
+
+TEST_CASE("ComposeAndCompareMarkup") {
+    using namespace server::markup;
+
+    Paragraph header;
+    header.appendText("header");
+    Paragraph detail;
+    detail.appendText(" detail");
+    header.append(std::move(detail));
+
+    Paragraph expected;
+    expected.appendText("header detail");
+    CHECK(header == expected);
+
+    Document first;
+    CHECK(first.isEmpty());
+    first.addParagraph(std::move(header));
+
+    Document second;
+    second.addParagraph(std::move(expected));
+    CHECK(first == second);
+    CHECK_FALSE(first.isEmpty());
 }

--- a/tests/cpp/golden/FindMultiSymbolRef.out
+++ b/tests/cpp/golden/FindMultiSymbolRef.out
@@ -1,0 +1,130 @@
+
+package features;
+
+    localparam int ITEM = 4;
+
+endpackage
+
+package forwarded;
+
+    import features::ITEM;
+                     ^^^^ Ref -> **Parameter** `ITEM` in `features`  \n\Type: `int`  \n\Value: `4`  \n\\n\\n\---\n\\n\`localparam int ITEM = 4`
+
+    export features::ITEM;
+                     ^^^^ Ref -> **Parameter** `ITEM` in `features`  \n\Type: `int`  \n\Value: `4`  \n\\n\\n\---\n\\n\`localparam int ITEM = 4`
+
+endpackage
+
+interface bus;
+
+    logic [3:0] data;
+
+    task run(input logic value);
+
+    endtask
+
+    modport endpoint(output data, import task run(input logic value));
+                            ^^^^ Ref ->
+    | **ModportPort** `data` in `bus.endpoint`
+    | Type: `logic[3:0]`
+    | Width: `4`
+    | ---
+    | `output data`
+    | ---
+    | `logic [3:0] data;`
+                                              ^^^ Ref ->
+    | **MethodPrototype** `run` in `bus.endpoint`
+    | ---
+    | `task run(input logic value)`
+    | ---
+    | **Subroutine** `run` in `bus`
+    | ---
+    | `task run(input logic value);
+    | endtask`
+
+endinterface
+
+module leaf(input logic [3:0] shared);
+
+endmodule
+
+module top;
+
+    import duplicate_pkg::*;
+           ^^^^^^^^^^^^^ Ref ->
+    | **Package** `duplicate_pkg`
+    | ---
+    | `package automatic duplicate_pkg;`
+    | ---
+    | **Package** `duplicate_pkg`
+    | ---
+    | `package static duplicate_pkg;`
+
+    logic [3:0] shared;
+
+    leaf u(.shared);
+            ^^^^^^ Ref ->
+    | **Outer** **Variable** `shared` in `top`
+    | Type: `logic[3:0]`
+    | Width: `4`
+    | ---
+    | `logic [3:0] shared;`
+    | ---
+    | **Inner** **Input Net** `shared` in `leaf`
+    | ---
+    | `input logic [3:0] shared`
+    | ---
+    | Driven via port from `leaf u` at [use.sv:14:13](<file:///tests/data/multi_symbol/use.sv#L14,13>)
+    | `input logic [3:0] shared`
+
+    bus b();
+
+    duplicate d();
+    ^^^^^^^^^ Ref ->
+    | **Module** `duplicate`
+    | ---
+    | `module duplicate #(parameter int FIRST_MODULE = 1);`
+    | ---
+    | **Module** `duplicate`
+    | ---
+    | `module duplicate #(parameter int SECOND_MODULE = 2);`
+
+    for (genvar i = 0; i < 2; i++) begin : g
+                ^ Ref ->
+    | **Genvar** `i` in `top.g`
+    | Type: `integer`
+    | Value range: `0` through `1`
+    | ---
+    | `i`
+
+        localparam int VALUE = i;
+                       ^^^^^ Ref ->
+    | **Parameter** `VALUE` in `top.g`
+    | Type: `int`
+    | Value range: `0` through `1`
+    | ---
+    | `localparam int VALUE = i`
+                               ^ Ref ->
+    | **Genvar** `i` in `top.g`
+    | Type: `integer`
+    | Value range: `0` through `1`
+    | ---
+    | `i`
+
+    end
+
+endmodule
+
+`ifdef MULTI_MACRO
+       ^^^^^^^^^^^ Ref ->
+    | DefineDirective MULTI_MACRO
+    | From `macro_first.svh`
+    | ---
+    | ``define MULTI_MACRO FIRST_MACRO`
+    | ---
+    | DefineDirective MULTI_MACRO
+    | From `macro_second.svh`
+    | ---
+    | ``define MULTI_MACRO SECOND_MACRO`
+
+`endif

--- a/tests/cpp/golden/FindReferencesAllTokens_all.sv.out
+++ b/tests/cpp/golden/FindReferencesAllTokens_all.sv.out
@@ -539,11 +539,12 @@ macromodule m3;
            ^ Refs[1]
 
     for (genvar i = 0; i < 10; i += 2)
-                       ^ Refs[3]
-                               ^ Refs[3]
+                ^ Refs[4]
+                       ^ Refs[4]
+                               ^ Refs[4]
 
         if (i == 7) begin
-            ^ Refs[3]
+            ^ Refs[4]
 
         end
 

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -188,7 +188,7 @@ macromodule m3;
 
     ) m (, b, c, d, );
       ^ Sym m : Instance
-           ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`
+           ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`\n\\n\---\n\\n\Driven by initializer at [all.sv:40:21](<file:///tests/data/all.sv#L40,21>)  \n\`(* bar = "asdf" *) output logic b = 1`
               ^ Ref -> **Variable** `c` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic c;`
                  ^ Ref -> `I` `d` in `m3`  \n\\n\\n\---\n\\n\`I d(.a(), .b());`
 
@@ -217,11 +217,11 @@ macromodule m3;
       ^^^^^^^ Sym m2_inst : Instance
 
         .a({1, 2}),
-         ^ Ref -> **Input Net** `a` in `m2`  \n\Type: `int$[]`  \n\\n\\n\---\n\\n\`input int a[]`
+         ^ Ref -> **Input Net** `a` in `m2`  \n\Type: `int$[]`  \n\\n\\n\---\n\\n\`input int a[]`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:40:6](<file:///tests/data/all.sv#L40,6>)  \n\`input int a[]`
 
         .b(b),
          ^ Ref -> **Output Variable** `b` in `m2`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`(* bar = "asdf" *) output logic b = 1`\n\\n\---\n\\n\Driven by initializer at [all.sv:40:21](<file:///tests/data/all.sv#L40,21>)  \n\`(* bar = "asdf" *) output logic b = 1`
-           ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`
+           ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`\n\\n\---\n\\n\Driven by initializer at [all.sv:40:21](<file:///tests/data/all.sv#L40,21>)  \n\`(* bar = "asdf" *) output logic b = 1`
 
         .c(),
          ^ Ref -> **Ref Variable** `c` in `m2`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`ref c`
@@ -271,7 +271,7 @@ macromodule m3;
     initial begin
 
         repeat (3) @(negedge b) f = #2 1;
-                             ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`
+                             ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`\n\\n\---\n\\n\Driven by initializer at [all.sv:40:21](<file:///tests/data/all.sv#L40,21>)  \n\`(* bar = "asdf" *) output logic b = 1`
                                 ^ Ref -> **Variable** `f` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic f, z;`\n\\n\---\n\\n\Driven by initial at [all.sv:88:5](<file:///tests/data/all.sv#L88,5>)  \n\`initial begin\n\    repeat (3) @(negedge b) f = #2 1;\n\    wait (f) ++f;\n\    wait fork;\n\    wait_order (m3.ev) f++;\n\    fork : fkb\n\        static int i = 1;\n\        disable fork;\n\    join_none\n\    disable m3.foo;\n\    assign z = 1;\n\    deassign z;\n\    if (1) begin end else begin end\n\    unique0 casex (w)\n\        0, 1: ;\n\        default ;\n\    endcase\n\    case (w) inside\n\        [0: 3]: ;\n\    endcase\n\end`
 
         wait (f) ++f;
@@ -338,7 +338,7 @@ macromodule m3;
 
 
     always_ff @(posedge b iff f == 1) begin
-                        ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`
+                        ^ Ref -> **Net** `b` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`wire b;`\n\\n\---\n\\n\Driven via port from `m2 m2_inst` at [all.sv:72:9](<file:///tests/data/all.sv#L72,9>)  \n\`.b(b)`\n\\n\---\n\\n\Driven via port from `m2 m` at [all.sv:62:12](<file:///tests/data/all.sv#L62,12>)  \n\`b`\n\\n\---\n\\n\Driven by initializer at [all.sv:40:21](<file:///tests/data/all.sv#L40,21>)  \n\`(* bar = "asdf" *) output logic b = 1`
                               ^ Ref -> **Variable** `f` in `m3`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`logic f, z;`\n\\n\---\n\\n\Driven by initial at [all.sv:88:5](<file:///tests/data/all.sv#L88,5>)  \n\`initial begin\n\    repeat (3) @(negedge b) f = #2 1;\n\    wait (f) ++f;\n\    wait fork;\n\    wait_order (m3.ev) f++;\n\    fork : fkb\n\        static int i = 1;\n\        disable fork;\n\    join_none\n\    disable m3.foo;\n\    assign z = 1;\n\    deassign z;\n\    if (1) begin end else begin end\n\    unique0 casex (w)\n\        0, 1: ;\n\        default ;\n\    endcase\n\    case (w) inside\n\        [0: 3]: ;\n\    endcase\n\end`
 
         forever break;
@@ -539,11 +539,12 @@ macromodule m3;
            ^ Sym j : Genvar
 
     for (genvar i = 0; i < 10; i += 2)
-                       ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\\n\\n\---\n\\n\`i`
-                               ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\\n\\n\---\n\\n\`i`
+                ^ Sym i : Genvar
+                       ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\Type: `integer`  \n\Values: `0`, `2`, `4`, `6`, `8`  \n\\n\\n\---\n\\n\`i`
+                               ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\Type: `integer`  \n\Values: `0`, `2`, `4`, `6`, `8`  \n\\n\\n\---\n\\n\`i`
 
         if (i == 7) begin
-            ^ Ref -> **Parameter** `i` in `m3.genblk1`  \n\Type: `integer`  \n\Value: `8`  \n\\n\\n\---\n\\n\`i`
+            ^ Ref -> **Genvar** `i` in `m3.genblk1`  \n\Type: `integer`  \n\Values: `0`, `2`, `4`, `6`, `8`  \n\\n\\n\---\n\\n\`i`
 
         end
 
@@ -829,14 +830,14 @@ interface Iface;
     modport m(export foo, function void bar(int, logic), task baz, export func);
             ^ Sym m : Modport
                      ^^^ Sym foo : MethodPrototype
-                                        ^^^ Sym bar : Subroutine
-                                                              ^^^ Sym baz : Subroutine
+                                        ^^^ Sym bar : MethodPrototype
+                                                              ^^^ Sym baz : MethodPrototype
                                                                           ^^^^ Sym func : MethodPrototype
 
     modport n(import function void func(int), import task t2);
             ^ Sym n : Modport
-                                   ^^^^ Sym func : Subroutine
-                                                          ^^ Sym t2 : Subroutine
+                                   ^^^^ Sym func : MethodPrototype
+                                                          ^^ Sym t2 : MethodPrototype
 
     modport o(export t2);
             ^ Sym o : Modport

--- a/tests/cpp/golden/FindSymbolRefHdl.out
+++ b/tests/cpp/golden/FindSymbolRefHdl.out
@@ -368,20 +368,20 @@ module TestModule #(
                                 ^^^^^^^^ Ref -> **Parameter** `NUM_SUBS` in `TestModule`  \n\Type: `int`  \n\Value: `4`  \n\\n\\n\---\n\\n\`parameter int NUM_SUBS = 4`
 
         .clk(clk),
-         ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
+         ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:73:5](<file:///tests/data/hdl_test.sv#L73,5>)  \n\`input logic clk`
              ^^^ Ref -> **Input Net** `clk` in `TestModule`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
 
         .rst(rst),
-         ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
+         ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:74:5](<file:///tests/data/hdl_test.sv#L74,5>)  \n\`input logic rst`
              ^^^ Ref -> **Input Net** `rst` in `TestModule`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
 
         .data_in(sub_data_in),
-         ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+         ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:75:5](<file:///tests/data/hdl_test.sv#L75,5>)  \n\`input logic [WIDTH-1:0] data_in`
                  ^^^^^^^^^^^ Ref -> **Variable** `sub_data_in` in `TestModule`  \n\Type: `logic[15:0]$[4]`  \n\\n\\n\---\n\\n\Instance array that depends on NUM_SUBS parameter  \n\  \n\\n\\n\---\n\\n\`logic [15:0] sub_data_in [NUM_SUBS];`
 
         .data_out(sub_data_out)
          ^^^^^^^^ Ref -> **Output Variable** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`\n\\n\---\n\\n\Driven by always_ff at [hdl_test.sv:79:5](<file:///tests/data/hdl_test.sv#L79,5>)  \n\`always_ff @(posedge clk or posedge rst) begin\n\    if (rst) begin\n\        data_out <= '0;\n\    end else begin\n\        data_out <= data_in;\n\    end\n\end`
-                  ^^^^^^^^^^^^ Ref -> **Variable** `sub_data_out` in `TestModule`  \n\Type: `logic[15:0]$[4]`  \n\\n\\n\---\n\\n\`logic [15:0] sub_data_out [NUM_SUBS];`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:118:9](<file:///tests/data/hdl_test.sv#L118,9>)  \n\`.data_out(sub_data_out)`
+                  ^^^^^^^^^^^^ Ref -> **Variable** `sub_data_out` in `TestModule`  \n\Type: `logic[15:0]$[4]`  \n\\n\\n\---\n\\n\`logic [15:0] sub_data_out [NUM_SUBS];`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:118:9](<file:///tests/data/hdl_test.sv#L118,9>)  \n\`.data_out(sub_data_out)`\n\\n\---\n\\n\Driven by always_ff at [hdl_test.sv:79:5](<file:///tests/data/hdl_test.sv#L79,5>)  \n\`always_ff @(posedge clk or posedge rst) begin\n\    if (rst) begin\n\        data_out <= '0;\n\    end else begin\n\        data_out <= data_in;\n\    end\n\end`
 
     );
 
@@ -504,7 +504,7 @@ module TestModule #(
 
             bus_follower.ready <= 1'b0;
             ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`
+                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`\n\\n\---\n\\n\`logic ready;`
 
         end else begin
 
@@ -512,18 +512,18 @@ module TestModule #(
 
             bus_follower.ready <= 1'b1;
             ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`
+                         ^^^^^ Ref -> **ModportPort** `ready` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output ready`\n\\n\---\n\\n\`logic ready;`
 
             if (bus_follower.valid && bus_follower.write_enable) begin
                 ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                             ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`
+                             ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`\n\\n\---\n\\n\`logic valid;`
                                       ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                                                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`
+                                                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.follower`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`\n\\n\---\n\\n\`logic write_enable;`
 
                 data_out <= bus_follower.data[7:0]; // Convert to data_t size
                 ^^^^^^^^ Ref -> **Output Variable** `data_out` in `TestModule`  \n\Type: `data_t` (aka `logic[7:0]`)  \n\Width: `8`  \n\\n\\n\---\n\\n\`output test_pkg::data_t data_out`
                             ^^^^^^^^^^^^ Ref -> **InterfacePort** `bus_follower` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.follower bus_follower`
-                                         ^^^^ Ref -> **ModportPort** `data` in `bus_if.follower`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`
+                                         ^^^^ Ref -> **ModportPort** `data` in `bus_if.follower`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input clk, rst, valid, addr, data, write_enable`\n\\n\---\n\\n\`data_t data;`
 
             end
 
@@ -539,25 +539,25 @@ module TestModule #(
 
         bus_master.valid <= 1'b0;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^^ Ref -> **ModportPort** `valid` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`logic valid;`
 
         bus_master.write_enable <= 1'b0;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^^^^^^^^^ Ref -> **ModportPort** `write_enable` in `bus_if.master`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`logic write_enable;`
 
         bus_master.addr = width_port[0];
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^ Ref -> **ModportPort** `addr` in `bus_if.master`  \n\Type: `logic[31:0]`  \n\Width: `32`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^ Ref -> **ModportPort** `addr` in `bus_if.master`  \n\Type: `logic[31:0]`  \n\Width: `32`  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`logic [ADDR_WIDTH-1:0] addr;`
                           ^^^^^^^^^^ Ref -> **Input Net** `width_port` in `TestModule`  \n\Type: `logic[31:0]`  \n\Width: `32`  \n\\n\\n\---\n\\n\some useful info  \n\  \n\\n\\n\---\n\\n\`input logic [test_pkg::WIDTH-1:0] width_port`
 
         bus_master.data <= state;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`data_t data;`
                            ^^^^^ Ref -> **Variable** `state` in `TestModule`  \n\Type: Enum `state_t` (`logic[1:0]`)  \n\Width: `2`  \n\\n\\n\---\n\\n\`test_pkg::state_t state, state_next;`\n\\n\---\n\\n\Driven by always_ff at [hdl_test.sv:132:5](<file:///tests/data/hdl_test.sv#L132,5>)  \n\`always_ff @(posedge clk) begin\n\    if (rst) begin\n\        state   <= test_pkg::STATE_A;\n\        counter <= '0;\n\    end else begin\n\        state   <= state_next;\n\        counter <= counter + 1'b1;\n\        if (thing) begin\n\            $display("Do this thing");\n\        end\n\    end\n\end`
 
         bus_master.data <= pkt_array[0].id;
         ^^^^^^^^^^ Ref -> **InterfacePort** `bus_master` in `TestModule`  \n\\n\\n\---\n\\n\`bus_if.master bus_master`
-                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`
+                   ^^^^ Ref -> **ModportPort** `data` in `bus_if.master`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output valid, addr, data, write_enable`\n\\n\---\n\\n\`data_t data;`
                            ^^^^^^^^^ Ref -> **Input Net** `pkt_array` in `TestModule`  \n\Type: `packet_t$[2]`  \n\\n\\n\---\n\\n\`input test_pkg::packet_t pkt_array[2]`
                                         ^^ Ref -> **Field** `id` in `test_pkg::packet_t`  \n\Type: `id_t` (aka `logic[31:0]`)  \n\Width: `32`  \n\\n\\n\---\n\\n\`id_t id;`
 
@@ -616,15 +616,15 @@ module NoDefaults #(
       ^^^^^^^^ Sym sub_inst : Instance
 
         .clk(clk),
-         ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
+         ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:73:5](<file:///tests/data/hdl_test.sv#L73,5>)  \n\`input logic clk`
              ^^^ Ref -> **Input Net** `clk` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
 
         .rst(rst),
-         ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
+         ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:74:5](<file:///tests/data/hdl_test.sv#L74,5>)  \n\`input logic rst`
              ^^^ Ref -> **Input Net** `rst` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
 
         .data_in(data_in),
-         ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+         ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`\n\\n\---\n\\n\Driven via port from `Sub sub_inst` at [hdl_test.sv:75:5](<file:///tests/data/hdl_test.sv#L75,5>)  \n\`input logic [WIDTH-1:0] data_in`
                  ^^^^^^^ Ref -> **Input Net** `data_in` in `NoDefaults`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
 
         .data_out(data_out)
@@ -681,8 +681,9 @@ module NoDefaults #(
            ^ Sym j : Genvar
 
     for(j = 0; j < 3; j++) begin : gen_loop_2
-               ^ Ref -> **Genvar** `j` in `NoDefaults`  \n\\n\\n\---\n\\n\`j`
-                      ^ Ref -> **Genvar** `j` in `NoDefaults`  \n\\n\\n\---\n\\n\`j`
+        ^ Ref -> **Genvar** `j` in `NoDefaults`  \n\Type: `integer`  \n\Value range: `0` through `2`  \n\\n\\n\---\n\\n\`j`
+               ^ Ref -> **Genvar** `j` in `NoDefaults`  \n\Type: `integer`  \n\Value range: `0` through `2`  \n\\n\\n\---\n\\n\`j`
+                      ^ Ref -> **Genvar** `j` in `NoDefaults`  \n\Type: `integer`  \n\Value range: `0` through `2`  \n\\n\\n\---\n\\n\`j`
                                    ^^^^^^^^^^ Sym gen_loop_2 : GenerateBlockArray
 
         Sub #(.WIDTH(WIDTH)) gen_sub_array [4] (
@@ -692,19 +693,19 @@ module NoDefaults #(
                              ^^^^^^^^^^^^^ Sym gen_sub_array : InstanceArray
 
             .clk(clk),
-             ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
+             ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic clk`
                  ^^^ Ref -> **Input Net** `clk` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
 
             .rst(rst),
-             ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
+             ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic rst`
                  ^^^ Ref -> **Input Net** `rst` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
 
             .data_in(data_in),
-             ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+             ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Type: Incomplete type  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
                      ^^^^^^^ Ref -> **Input Net** `data_in` in `NoDefaults`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
 
             .data_out()
-             ^^^^^^^^ Ref -> **Output Variable** `data_out` in `Sub`  \n\Type: Incomplete type  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+             ^^^^^^^^ Ref -> **Output Variable** `data_out` in `Sub`  \n\Type: Incomplete type  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
 
         );
 
@@ -730,6 +731,7 @@ module NoDefaults #(
            ^ Sym i : Genvar
 
     for(i = 0; i < n_iters; i++) begin : gen_loop
+        ^ Ref -> **Genvar** `i` in `NoDefaults`  \n\\n\\n\---\n\\n\`i`
                ^ Ref -> **Genvar** `i` in `NoDefaults`  \n\\n\\n\---\n\\n\`i`
                    ^^^^^^^ Ref -> **Parameter** `n_iters` in `NoDefaults`  \n\Type: `int`  \n\\n\\n\---\n\\n\`parameter int n_iters`
                             ^ Ref -> **Genvar** `i` in `NoDefaults`  \n\\n\\n\---\n\\n\`i`

--- a/tests/cpp/golden/FindSymbolRefMacro.out
+++ b/tests/cpp/golden/FindSymbolRefMacro.out
@@ -237,9 +237,10 @@ module test;
     generate
 
         for (i = 0; i < `SIMPLE_MACRO; i++) begin : gen_block
-                    ^ Ref -> **Genvar** `i` in `test`  \n\\n\\n\---\n\\n\`i`
+             ^ Ref -> **Genvar** `i` in `test`  \n\Type: `integer`  \n\Value range: `0` through `41`  \n\\n\\n\---\n\\n\`i`
+                    ^ Ref -> **Genvar** `i` in `test`  \n\Type: `integer`  \n\Value range: `0` through `41`  \n\\n\\n\---\n\\n\`i`
                         ^^^^^^^^^^^^^ Ref -> DefineDirective SIMPLE_MACRO  \n\\n\\n\---\n\\n\Basic macro definitions  \n\  \n\\n\\n\---\n\\n\``define SIMPLE_MACRO 42`\n\\n\---\n\\n\Expands to   \n\`42`
-                                       ^ Ref -> **Genvar** `i` in `test`  \n\\n\\n\---\n\\n\`i`
+                                       ^ Ref -> **Genvar** `i` in `test`  \n\Type: `integer`  \n\Value range: `0` through `41`  \n\\n\\n\---\n\\n\`i`
                                                     ^^^^^^^^^ Sym gen_block : GenerateBlockArray
 
             logic [`FUNC_MACRO(7):0] gen_signal;

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -360,12 +360,30 @@ protected:
 
 class SymbolRefScanner : public DocumentScanner<server::DefinitionInfo> {
 public:
-    SymbolRefScanner() : DocumentScanner<server::DefinitionInfo>() {}
+    explicit SymbolRefScanner(std::vector<lsp::uint> selectedOffsets = {}) :
+        DocumentScanner<server::DefinitionInfo>(), selectedOffsets(std::move(selectedOffsets)) {}
 
 protected:
+    std::vector<lsp::uint> selectedOffsets;
+
     std::optional<server::DefinitionInfo> getElementAt(DocumentHandle* hdl,
                                                        lsp::uint offset) override {
-        return hdl->getDefinitionInfoAt(offset);
+        auto info = hdl->getDefinitionInfoAt(offset);
+        if (!info || selectedOffsets.empty())
+            return info;
+
+        auto doc = hdl->doc;
+        auto token = doc->getWordTokenAt(slang::SourceLocation(doc->getBuffer(), offset));
+        if (!token)
+            return {};
+
+        for (auto selectedOffset : selectedOffsets) {
+            auto selectedToken = doc->getWordTokenAt(
+                slang::SourceLocation(doc->getBuffer(), selectedOffset));
+            if (selectedToken && selectedToken->location() == token->location())
+                return info;
+        }
+        return {};
     }
 
     void processElementTransition(DocumentHandle* hdl, SourceManager&, lsp::uint offset) override {
@@ -375,7 +393,16 @@ protected:
 
         auto pElem = std::get<server::DefinitionInfo>(*prevElement);
         auto& nameToken = pElem.nameToken();
-        if (tok && nameToken.location() == tok->location()) {
+        bool multilineHover =
+            !selectedOffsets.empty() &&
+            (pElem.targets.size() > 1 || std::ranges::any_of(pElem.targets, [](const auto& target) {
+                 if (std::holds_alternative<server::DefinitionInfo::PortConnectionTarget>(target))
+                     return true;
+                 if (auto* symbol = std::get_if<server::DefinitionInfo::SymbolTarget>(&target))
+                     return symbol->syntaxes.size() > 1;
+                 return false;
+             }));
+        if (tok && nameToken.location() == tok->location() && !multilineHover) {
             auto symbol = pElem.symbol();
             auto kindStr = symbol ? toString(symbol->kind)
                            : pElem.macro() && pElem.macro()->syntaxTarget()
@@ -385,9 +412,7 @@ protected:
             test.record(fmt::format(" Sym {} : {}\n", nameToken.valueText(), kindStr));
         }
         else {
-            test.record(fmt::format(" Ref -> "));
-            // Print hover, but turn newlines into \n
-            // auto maybeHover = doc->getAnalysis().getDocHover(hdl->getPosition(offset), true);
+            test.record(multilineHover ? " Ref ->\n" : " Ref -> ");
             auto maybeHover = hdl->getHoverAt(offset);
             if (!maybeHover) {
                 test.record(" No Hover\n");
@@ -406,6 +431,23 @@ protected:
             replace(hoverText, "````systemverilog\n", "`");
             replace(hoverText, "\n````", "`");
             replace(hoverText, URI::fromFile(findSlangRoot()).str(), "file://");
+            if (multilineHover) {
+                size_t start = 0;
+                while (start <= hoverText.size()) {
+                    auto end = hoverText.find('\n', start);
+                    if (end == std::string::npos)
+                        end = hoverText.size();
+                    auto line = std::string_view(hoverText).substr(start, end - start);
+                    while (line.ends_with(' '))
+                        line.remove_suffix(1);
+                    if (!line.empty())
+                        test.record(fmt::format("    | {}\n", line));
+                    if (end == hoverText.size())
+                        break;
+                    start = end + 1;
+                }
+                return;
+            }
             std::string singleLine;
             for (char c : hoverText) {
                 if (c == '\n' || c == '\r') {

--- a/tests/data/multi_symbol/first.sv
+++ b/tests/data/multi_symbol/first.sv
@@ -1,0 +1,6 @@
+module duplicate #(parameter int FIRST_MODULE = 1);
+endmodule
+
+package automatic duplicate_pkg;
+    localparam int FIRST_PACKAGE = 1;
+endpackage

--- a/tests/data/multi_symbol/macro_first.svh
+++ b/tests/data/multi_symbol/macro_first.svh
@@ -1,0 +1,1 @@
+`define MULTI_MACRO FIRST_MACRO

--- a/tests/data/multi_symbol/macro_second.svh
+++ b/tests/data/multi_symbol/macro_second.svh
@@ -1,0 +1,1 @@
+`define MULTI_MACRO SECOND_MACRO

--- a/tests/data/multi_symbol/second.sv
+++ b/tests/data/multi_symbol/second.sv
@@ -1,0 +1,6 @@
+module duplicate #(parameter int SECOND_MODULE = 2);
+endmodule
+
+package static duplicate_pkg;
+    localparam int SECOND_PACKAGE = 2;
+endpackage

--- a/tests/data/multi_symbol/use.sv
+++ b/tests/data/multi_symbol/use.sv
@@ -1,0 +1,27 @@
+package features;
+    localparam int ITEM = 4;
+endpackage
+package forwarded;
+    import features::ITEM;
+    export features::ITEM;
+endpackage
+interface bus;
+    logic [3:0] data;
+    task run(input logic value);
+    endtask
+    modport endpoint(output data, import task run(input logic value));
+endinterface
+module leaf(input logic [3:0] shared);
+endmodule
+module top;
+    import duplicate_pkg::*;
+    logic [3:0] shared;
+    leaf u(.shared);
+    bus b();
+    duplicate d();
+    for (genvar i = 0; i < 2; i++) begin : g
+        localparam int VALUE = i;
+    end
+endmodule
+`ifdef MULTI_MACRO
+`endif


### PR DESCRIPTION
Hovers/Gotos: Support multiple symbols
This is useful for:
- implicit port connections
- multiple syms in the index
- Modports (separate type / direction syntaxes)
- package imports/exports
- gen loops
- future work with focused instances