### PR TITLE
Completions: Filter macro results and improve coverage checks

### DIFF
--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -811,6 +811,12 @@ rfl::Variant<std::vector<lsp::CompletionItem>, lsp::CompletionList, std::monosta
     // We need to hack around with client side middileware like in clangd-
     // https://github.com/clangd/vscode-clangd/blob/master/src/clangd-context.ts
 
+    if (ctx.query->isIncomplete()) {
+        // Macro results are server-filtered and bounded. Mark the list incomplete so clients ask
+        // again as the user types instead of treating omitted candidates as unavailable.
+        return lsp::CompletionList{.isIncomplete = true, .items = std::move(results)};
+    }
+
     return results;
 }
 

--- a/src/completions/MacroCompletions.cpp
+++ b/src/completions/MacroCompletions.cpp
@@ -13,6 +13,8 @@
 #include "lsp/SnippetString.h"
 #include "util/Formatting.h"
 #include "util/Logging.h"
+#include <cctype>
+#include <unordered_set>
 
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxTree.h"
@@ -21,6 +23,21 @@ namespace server::completions {
 using namespace slang;
 
 namespace {
+
+bool matchesPrefix(std::string_view name, std::string_view typedPrefix) {
+    if (typedPrefix.starts_with('`'))
+        typedPrefix.remove_prefix(1);
+    if (typedPrefix.size() > name.size())
+        return false;
+
+    for (size_t i = 0; i < typedPrefix.size(); i++) {
+        auto actual = static_cast<unsigned char>(name[i]);
+        auto expected = static_cast<unsigned char>(typedPrefix[i]);
+        if (std::tolower(actual) != std::tolower(expected))
+            return false;
+    }
+    return true;
+}
 
 lsp::CompletionItem getCompletion(std::string name) {
     auto spelling = "`" + name;
@@ -75,17 +92,33 @@ public:
 
     CompletionQueryKind kind() const final { return CompletionQueryKind::Macro; }
 
+    bool isIncomplete() const final { return true; }
+
     void getCompletions(std::vector<lsp::CompletionItem>& results, CompletionDispatch& dispatch,
                         const std::shared_ptr<SlangDoc>& doc,
                         const CompletionContext&) const final {
+        std::unordered_set<std::string> seenLabels;
+        // Filter before building rich items because compilations can contain thousands of macros.
         for (auto& macro : doc->getSyntaxTree()->getDefinedMacros()) {
             if (macro->name.location() == SourceLocation::NoLocation)
+                continue;
+            auto name = macro->name.valueText();
+            if (!matchesPrefix(name, typedPrefix))
+                continue;
+            auto label = "`" + std::string(name);
+            if (!seenLabels.insert(label).second)
                 continue;
             results.push_back(getCompletion(*macro));
         }
 
-        for (const auto& name : getIndexer(dispatch).getAllMacroNames())
-            results.push_back(getCompletion(name));
+        for (auto& name : getIndexer(dispatch).getAllMacroNames()) {
+            if (!matchesPrefix(name, typedPrefix))
+                continue;
+            auto item = getCompletion(std::move(name));
+            if (!seenLabels.insert(item.label).second)
+                continue;
+            results.push_back(std::move(item));
+        }
     }
 
 private:

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -64,7 +64,19 @@ TEST_CASE("MacroCompletion") {
 
     // Only return the indexed one
     auto doc2 = server.openFile("test2.sv", "`");
-    CHECK(doc2.end().getCompletions("`").size() == 1);
+    auto macroCursor = doc2.end();
+    auto rawResult = server.getDocCompletion(lsp::CompletionParams{
+        .context =
+            lsp::CompletionContext{
+                .triggerKind = lsp::CompletionTriggerKind::TriggerCharacter,
+                .triggerCharacter = "`",
+            },
+        .textDocument = lsp::TextDocumentIdentifier{macroCursor.getUri()},
+        .position = macroCursor.getPosition(),
+    });
+    REQUIRE(rfl::holds_alternative<lsp::CompletionList>(rawResult));
+    CHECK(rfl::get<lsp::CompletionList>(rawResult).isIncomplete);
+    CHECK(rfl::get<lsp::CompletionList>(rawResult).items.size() == 1);
 
     // Now that it's saved, it should be indexed
     doc.save();
@@ -108,7 +120,8 @@ TEST_CASE("MacroArgumentCompletion") {
 }
 
 TEST_CASE("CompletionCoverageCompRepo") {
-    ServerHarness server("comp_repo");
+    ServerHarness server(makeCompletionResolveParams(
+        {"documentation", "insertText", "insertTextFormat", "textEdit"}, "comp_repo"));
     CompletionCoverageScanner scanner;
 
     auto root = findSlangRoot() / "tests" / "data" / "comp_repo";
@@ -543,6 +556,9 @@ TEST_CASE("MidIdentifierCompletion") {
     SECTION("macro") {
         auto cursor = doc.after("`MID_MA");
         auto items = cursor.getCompletions();
+        CHECK(std::ranges::all_of(items, [](const CompletionHandle& item) {
+            return item.m_item.label.starts_with("`MID_MA");
+        }));
         auto item = findByLabel(items, "`MID_MACRO");
         REQUIRE(item != items.end());
         CHECK(getCompletionTextEdit(item->m_item).newText == "`MID_MACRO");

--- a/tests/cpp/golden/CompletionCoverageCompRepo/simple_counter.out.sv
+++ b/tests/cpp/golden/CompletionCoverageCompRepo/simple_counter.out.sv
@@ -17,4 +17,23 @@ module simple_counter #(
             count <= count + 1'b1;
     end
 
+    class completion_class #(parameter int MEMBER_WIDTH);
+        function void run(input logic [MEMBER_WIDTH-1:0] arg);
+        endfunction
+    endclass
+
+    completion_class #(8) wide;
+//  ^^^^^^^^^^^^^^^^ MissingCompletion[completion_class] Context[ModuleMember] Trigger[Invoked] Items[17]
+    completion_class #(2) narrow;
+//  ^^^^^^^^^^^^^^^^ MissingCompletion[completion_class] Context[ModuleMember] Trigger[Invoked] Items[17]
+    struct {
+        logic field_a;
+    } value;
+
+    initial begin
+        wide.run('0);
+        narrow.run('0);
+        value.field_a = '0;
+    end
+
 endmodule

--- a/tests/cpp/golden/GetScopeChildren.json
+++ b/tests/cpp/golden/GetScopeChildren.json
@@ -955,7 +955,7 @@
               "character": 0
             },
             "end": {
-              "line": 19,
+              "line": 36,
               "character": 9
             }
           }
@@ -986,7 +986,7 @@
                   "character": 0
                 },
                 "end": {
-                  "line": 19,
+                  "line": 36,
                   "character": 9
                 }
               }

--- a/tests/cpp/golden/GetScopesByModule.json
+++ b/tests/cpp/golden/GetScopesByModule.json
@@ -127,7 +127,7 @@
               "character": 0
             },
             "end": {
-              "line": 19,
+              "line": 36,
               "character": 9
             }
           }

--- a/tests/cpp/golden/HierarchicalViewIntegration.json
+++ b/tests/cpp/golden/HierarchicalViewIntegration.json
@@ -127,7 +127,7 @@
               "character": 0
             },
             "end": {
-              "line": 19,
+              "line": 36,
               "character": 9
             }
           }

--- a/tests/cpp/utils/CompletionCoverageScanner.cpp
+++ b/tests/cpp/utils/CompletionCoverageScanner.cpp
@@ -64,7 +64,7 @@ std::optional<std::string> CompletionCoverageScanner::triggerForToken(
     return trigger;
 }
 
-std::optional<CompletionCoverageScanner::MissingCompletion> CompletionCoverageScanner::checkToken(
+std::optional<CompletionCoverageScanner::CompletionIssue> CompletionCoverageScanner::checkToken(
     DocumentHandle& hdl, const slang::parsing::Token& token) {
     if (token.kind != slang::parsing::TokenKind::Identifier) {
         return std::nullopt;
@@ -90,23 +90,72 @@ std::optional<CompletionCoverageScanner::MissingCompletion> CompletionCoverageSc
         .triggerCharacter = trigger,
     };
     auto ctx = server::CompletionContext::fromLocation(*hdl.doc, token.location(), lspContext);
-    auto completions = cursor.getCompletions(trigger);
-    auto hasCompletion = std::ranges::any_of(completions, [&](const CompletionHandle& completion) {
+    auto items = cursor.getCompletions(trigger);
+    auto completion = std::ranges::find_if(items, [&](const CompletionHandle& completion) {
         return completion.m_item.label == label;
     });
-    if (hasCompletion) {
-        return std::nullopt;
+    if (completion != items.end()) {
+        if (trigger != "." || !completion->m_item.data)
+            return std::nullopt;
+
+        auto expected = completion->m_item;
+        server::completions::MemberCompletionQuery::resolve(*definition->symbol(), expected, true);
+        completion->resolve();
+
+        auto documentationText = [](const lsp::CompletionItem& item) -> std::optional<std::string> {
+            if (!item.documentation)
+                return std::nullopt;
+            return rfl::visit(
+                [](const auto& documentation) {
+                    using T = std::decay_t<decltype(documentation)>;
+                    if constexpr (std::is_same_v<T, std::string>)
+                        return documentation;
+                    else
+                        return documentation.value;
+                },
+                *item.documentation);
+        };
+
+        std::string mismatches;
+        auto addMismatch = [&](std::string_view field) {
+            if (!mismatches.empty())
+                mismatches += ",";
+            mismatches += field;
+        };
+        if (documentationText(completion->m_item) != documentationText(expected))
+            addMismatch("documentation");
+        if (completion->m_item.insertText != expected.insertText)
+            addMismatch("insertText");
+        if (completion->m_item.insertTextFormat != expected.insertTextFormat)
+            addMismatch("insertTextFormat");
+
+        if (mismatches.empty())
+            return std::nullopt;
+
+        auto line = hdl.m_server.sourceManager().getLineNumber(token.location());
+        auto column = hdl.m_server.sourceManager().getColumnNumber(token.location()) - 1;
+        return CompletionIssue{
+            .line = static_cast<lsp::uint>(line),
+            .column = static_cast<lsp::uint>(column),
+            .length = static_cast<lsp::uint>(std::max<size_t>(label.size(), 1)),
+            .label = std::move(label),
+            .contextKind = std::string(toString(ctx.kind)),
+            .triggerKind = *trigger,
+            .completionCount = items.size(),
+            .resolutionMismatch = std::move(mismatches),
+        };
     }
 
     auto line = hdl.m_server.sourceManager().getLineNumber(token.location());
     auto column = hdl.m_server.sourceManager().getColumnNumber(token.location()) - 1;
-    return MissingCompletion{.line = static_cast<lsp::uint>(line),
-                             .column = static_cast<lsp::uint>(column),
-                             .length = static_cast<lsp::uint>(std::max<size_t>(label.size(), 1)),
-                             .label = std::move(label),
-                             .contextKind = std::string(toString(ctx.kind)),
-                             .triggerKind = trigger.value_or("Invoked"),
-                             .completionCount = completions.size()};
+    return CompletionIssue{.line = static_cast<lsp::uint>(line),
+                           .column = static_cast<lsp::uint>(column),
+                           .length = static_cast<lsp::uint>(std::max<size_t>(label.size(), 1)),
+                           .label = std::move(label),
+                           .contextKind = std::string(toString(ctx.kind)),
+                           .triggerKind = trigger.value_or("Invoked"),
+                           .completionCount = items.size(),
+                           .resolutionMismatch = std::nullopt};
 }
 
 void CompletionCoverageScanner::scanDocument(DocumentHandle hdl,
@@ -117,7 +166,7 @@ void CompletionCoverageScanner::scanDocument(DocumentHandle hdl,
                     Catch::getCurrentContext().getResultCapture()->getCurrentTestName() /
                     goldenPath);
 
-    std::vector<MissingCompletion> misses;
+    std::vector<CompletionIssue> issues;
     std::unordered_set<size_t> seenTokenOffsets;
     auto text = hdl.getText();
     for (lsp::uint offset = 0; offset < text.size(); offset++) {
@@ -132,12 +181,12 @@ void CompletionCoverageScanner::scanDocument(DocumentHandle hdl,
             continue;
         }
 
-        if (auto missing = checkToken(hdl, *token)) {
-            misses.push_back(std::move(*missing));
+        if (auto issue = checkToken(hdl, *token)) {
+            issues.push_back(std::move(*issue));
         }
     }
 
-    auto missIt = misses.begin();
+    auto issueIt = issues.begin();
     lsp::uint lineNumber = 1;
     size_t lineStart = 0;
     while (lineStart < text.size()) {
@@ -149,16 +198,24 @@ void CompletionCoverageScanner::scanDocument(DocumentHandle hdl,
             test.record("\n");
         }
 
-        while (missIt != misses.end() && missIt->line == lineNumber) {
+        while (issueIt != issues.end() && issueIt->line == lineNumber) {
             test.record("//");
-            if (missIt->column > 2) {
-                test.record(std::string(missIt->column - 2, ' '));
+            if (issueIt->column > 2) {
+                test.record(std::string(issueIt->column - 2, ' '));
             }
-            test.record(std::string(missIt->length, '^'));
-            test.record(fmt::format(" MissingCompletion[{}] Context[{}] Trigger[{}] Items[{}]\n",
-                                    missIt->label, missIt->contextKind, missIt->triggerKind,
-                                    missIt->completionCount));
-            ++missIt;
+            test.record(std::string(issueIt->length, '^'));
+            if (issueIt->resolutionMismatch) {
+                test.record(fmt::format(
+                    " MismatchedCompletion[{}] Fields[{}] Context[{}] Trigger[{}] Items[{}]\n",
+                    issueIt->label, *issueIt->resolutionMismatch, issueIt->contextKind,
+                    issueIt->triggerKind, issueIt->completionCount));
+            }
+            else {
+                test.record(fmt::format(
+                    " MissingCompletion[{}] Context[{}] Trigger[{}] Items[{}]\n", issueIt->label,
+                    issueIt->contextKind, issueIt->triggerKind, issueIt->completionCount));
+            }
+            ++issueIt;
         }
 
         lineStart = nextLineStart;

--- a/tests/cpp/utils/CompletionCoverageScanner.h
+++ b/tests/cpp/utils/CompletionCoverageScanner.h
@@ -19,7 +19,7 @@ public:
     void scanDocument(DocumentHandle hdl, std::filesystem::path relativePath);
 
 private:
-    struct MissingCompletion {
+    struct CompletionIssue {
         lsp::uint line;
         lsp::uint column;
         lsp::uint length;
@@ -27,11 +27,12 @@ private:
         std::string contextKind;
         std::string triggerKind;
         size_t completionCount;
+        std::optional<std::string> resolutionMismatch;
     };
 
     static std::optional<std::string> triggerForToken(const DocumentHandle& hdl,
                                                       const slang::parsing::Token& token);
 
-    std::optional<MissingCompletion> checkToken(DocumentHandle& hdl,
-                                                const slang::parsing::Token& token);
+    std::optional<CompletionIssue> checkToken(DocumentHandle& hdl,
+                                              const slang::parsing::Token& token);
 };

--- a/tests/data/comp_repo/simple_counter.sv
+++ b/tests/data/comp_repo/simple_counter.sv
@@ -17,4 +17,21 @@ module simple_counter #(
             count <= count + 1'b1;
     end
 
+    class completion_class #(parameter int MEMBER_WIDTH);
+        function void run(input logic [MEMBER_WIDTH-1:0] arg);
+        endfunction
+    endclass
+
+    completion_class #(8) wide;
+    completion_class #(2) narrow;
+    struct {
+        logic field_a;
+    } value;
+
+    initial begin
+        wide.run('0);
+        narrow.run('0);
+        value.field_a = '0;
+    end
+
 endmodule


### PR DESCRIPTION
Filter macro completion candidates by the prefix typed before the cursor and deduplicate local and indexed definitions. Return macro completion lists as incomplete so clients request a fresh filtered list as the prefix changes.

Extend completion coverage scanning to resolve deferred member items and compare their documentation and insertion fields against the referenced symbol. Add parameterized class and struct member examples to the completion corpus to exercise specialization-specific snippets and documentation.