### PR TITLE
Add LSP commands for driver/load tracing

### DIFF
--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -145,6 +145,28 @@ export async function getLoads(hierPath: string): Promise<string[]> {
   return await vscode.commands.executeCommand('slang.getLoads', hierPath)
 }
 
+/// Cone tracing: Get drivers (incoming calls) of a given RTL path with full location info
+/// Returns CallHierarchyIncomingCall array which includes URI, range, and hierPath for navigation
+export async function getDriversWithLocation(
+  hierPath: string
+): Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
+  return await vscode.commands.executeCommand(
+    'slang.getDriversWithLocation',
+    hierPath
+  )
+}
+
+/// Cone tracing: Get loads (outgoing calls) of a given RTL path with full location info
+/// Returns CallHierarchyOutgoingCall array which includes URI, range, and hierPath for navigation
+export async function getLoadsWithLocation(
+  hierPath: string
+): Promise<vscode.CallHierarchyOutgoingCall[] | undefined> {
+  return await vscode.commands.executeCommand(
+    'slang.getLoadsWithLocation',
+    hierPath
+  )
+}
+
 interface ExpandMacroArgs {
   dst: string
   src: string

--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -153,23 +153,13 @@ export interface ConeEntry {
 }
 
 /// Cone tracing: Get the drivers of a given RTL path, each with its RTL path and source location.
-export async function getDriversWithLocation(
-  hierPath: string
-): Promise<ConeEntry[] | undefined> {
-  return await vscode.commands.executeCommand(
-    'slang.getDriversWithLocation',
-    hierPath
-  )
+export async function getDriversWithLocation(hierPath: string): Promise<ConeEntry[] | undefined> {
+  return await vscode.commands.executeCommand('slang.getDriversWithLocation', hierPath)
 }
 
 /// Cone tracing: Get the loads of a given RTL path, each with its RTL path and source location.
-export async function getLoadsWithLocation(
-  hierPath: string
-): Promise<ConeEntry[] | undefined> {
-  return await vscode.commands.executeCommand(
-    'slang.getLoadsWithLocation',
-    hierPath
-  )
+export async function getLoadsWithLocation(hierPath: string): Promise<ConeEntry[] | undefined> {
+  return await vscode.commands.executeCommand('slang.getLoadsWithLocation', hierPath)
 }
 
 interface ExpandMacroArgs {

--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -137,6 +137,14 @@ export async function getModulesInFile(fsPath: string): Promise<string[]> {
   return await vscode.commands.executeCommand('slang.getModulesInFile', fsPath)
 }
 
+export async function getDrivers(hierPath: string): Promise<string[]> {
+  return await vscode.commands.executeCommand('slang.getDrivers', hierPath)
+}
+
+export async function getLoads(hierPath: string): Promise<string[]> {
+  return await vscode.commands.executeCommand('slang.getLoads', hierPath)
+}
+
 interface ExpandMacroArgs {
   dst: string
   src: string

--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -145,22 +145,27 @@ export async function getLoads(hierPath: string): Promise<string[]> {
   return await vscode.commands.executeCommand('slang.getLoads', hierPath)
 }
 
-/// Cone tracing: Get drivers (incoming calls) of a given RTL path with full location info
-/// Returns CallHierarchyIncomingCall array which includes URI, range, and hierPath for navigation
+/// A single endpoint of a driver/load cone: the RTL path of the driver/load and
+/// where it appears in source.
+export interface ConeEntry {
+  path: string
+  location: Location
+}
+
+/// Cone tracing: Get the drivers of a given RTL path, each with its RTL path and source location.
 export async function getDriversWithLocation(
   hierPath: string
-): Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
+): Promise<ConeEntry[] | undefined> {
   return await vscode.commands.executeCommand(
     'slang.getDriversWithLocation',
     hierPath
   )
 }
 
-/// Cone tracing: Get loads (outgoing calls) of a given RTL path with full location info
-/// Returns CallHierarchyOutgoingCall array which includes URI, range, and hierPath for navigation
+/// Cone tracing: Get the loads of a given RTL path, each with its RTL path and source location.
 export async function getLoadsWithLocation(
   hierPath: string
-): Promise<vscode.CallHierarchyOutgoingCall[] | undefined> {
+): Promise<ConeEntry[] | undefined> {
   return await vscode.commands.executeCommand(
     'slang.getLoadsWithLocation',
     hierPath

--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -137,14 +137,6 @@ export async function getModulesInFile(fsPath: string): Promise<string[]> {
   return await vscode.commands.executeCommand('slang.getModulesInFile', fsPath)
 }
 
-export async function getDrivers(hierPath: string): Promise<string[]> {
-  return await vscode.commands.executeCommand('slang.getDrivers', hierPath)
-}
-
-export async function getLoads(hierPath: string): Promise<string[]> {
-  return await vscode.commands.executeCommand('slang.getLoads', hierPath)
-}
-
 /// A single endpoint of a driver/load cone: the RTL path of the driver/load and
 /// where it appears in source.
 export interface ConeEntry {

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -239,6 +239,14 @@ public:
     /// Get a list of RTL paths of the loads of a given RTL path
     std::vector<std::string> getLoads(const std::string&) final;
 
+    /// Get drivers (incoming calls) of a given RTL path with full location info
+    std::optional<std::vector<lsp::CallHierarchyIncomingCall>> getDriversWithLocation(
+        const std::string&);
+
+    /// Get loads (outgoing calls) of a given RTL path with full location info
+    std::optional<std::vector<lsp::CallHierarchyOutgoingCall>> getLoadsWithLocation(
+        const std::string&);
+
     /// Get the mutex to prevent collisions between LSP and WCP message handling
     std::mutex& getMutex() final { return mutex; };
 };

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -17,6 +17,7 @@
 #include "document/SlangDoc.h"
 #include "lsp/LspServer.h"
 #include "lsp/LspTypes.h"
+#include <functional>
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/Generic.hpp>
@@ -43,6 +44,19 @@ protected:
     /// Manages open docuemnts and a single compilation
     /// Created each time config/flags are changed, including switching between explore/build mode
     std::unique_ptr<ServerDriver> m_driver;
+
+    template<typename Params, typename Result>
+    void registerDesignCommand(
+        const std::string& name,
+        const std::function<Result(ServerCompilation&, const Params&)>& func) {
+        registerCommand<Params, std::optional<Result>>(
+            name, [this, func](const Params& params) -> std::optional<Result> {
+                if (!m_driver || !m_driver->comp) {
+                    return std::nullopt;
+                }
+                return func(*m_driver->comp, params);
+            });
+    }
 
     /// The diag client
     std::shared_ptr<ServerDiagClient> m_diagClient;
@@ -238,12 +252,6 @@ public:
 
     /// Get a list of RTL paths of the loads of a given RTL path
     std::vector<std::string> getLoads(const std::string&) final;
-
-    /// Get the drivers of a given RTL path, each with its RTL path and source location
-    std::optional<std::vector<ConeEntry>> getDriversWithLocation(const std::string&);
-
-    /// Get the loads of a given RTL path, each with its RTL path and source location
-    std::optional<std::vector<ConeEntry>> getLoadsWithLocation(const std::string&);
 
     /// Get the mutex to prevent collisions between LSP and WCP message handling
     std::mutex& getMutex() final { return mutex; };

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -239,13 +239,11 @@ public:
     /// Get a list of RTL paths of the loads of a given RTL path
     std::vector<std::string> getLoads(const std::string&) final;
 
-    /// Get drivers (incoming calls) of a given RTL path with full location info
-    std::optional<std::vector<lsp::CallHierarchyIncomingCall>> getDriversWithLocation(
-        const std::string&);
+    /// Get the drivers of a given RTL path, each with its RTL path and source location
+    std::optional<std::vector<ConeEntry>> getDriversWithLocation(const std::string&);
 
-    /// Get loads (outgoing calls) of a given RTL path with full location info
-    std::optional<std::vector<lsp::CallHierarchyOutgoingCall>> getLoadsWithLocation(
-        const std::string&);
+    /// Get the loads of a given RTL path, each with its RTL path and source location
+    std::optional<std::vector<ConeEntry>> getLoadsWithLocation(const std::string&);
 
     /// Get the mutex to prevent collisions between LSP and WCP message handling
     std::mutex& getMutex() final { return mutex; };

--- a/include/ast/ServerCompilation.h
+++ b/include/ast/ServerCompilation.h
@@ -20,6 +20,13 @@
 namespace server {
 using namespace slang;
 
+/// @brief A single endpoint of a driver/load cone: the hierarchical RTL path of the
+/// driver/load and the source location where it appears.
+struct ConeEntry {
+    std::string path;
+    lsp::Location location;
+};
+
 /// @brief A server compilation that is set via top level or a .f file.
 /// Manages the specification of the compilation, as well as the analysis state that gets refreshed
 /// on file saves.
@@ -69,33 +76,24 @@ public:
     /// Issue all semantic diagnostics from the compilation to the diagnostic engine
     void issueDiagnosticsTo(slang::DiagnosticEngine& diagEngine);
 
-    /// Populate incoming / outgoing (drivers / loads) call hierarchy LSP responses
-    template<typename P, typename R>
-    std::optional<std::vector<R>> getCallHierarchyCalls(const P& params) {
-        static constexpr bool isDriver =
-            std::is_same<P, lsp::CallHierarchyIncomingCallsParams>::value;
-        auto cone = m_analysis->getCone<isDriver>(params.item.name);
-
-        std::vector<R> result;
+    /// Return the drivers (isDrivers=true) or loads (isDrivers=false) of the signal at the
+    /// given path, each with the source location where it appears. Endpoints without a valid
+    /// source location are omitted.
+    template<bool isDrivers>
+    std::vector<ConeEntry> getConeLocations(const std::string& path) {
+        auto cone = m_analysis->getCone<isDrivers>(path);
+        std::vector<ConeEntry> result;
         for (const auto leaf : cone) {
-            std::string hier = leaf.getHierarchicalPath();
             auto range = leaf.getSourceRange();
             if (range.start().valid()) {
                 auto fullPath = std::filesystem::absolute(
                     m_sourceManager.getFileName(range.start()));
-                // only different by to / from field name . . . sigh
-                if constexpr (std::is_same_v<lsp::CallHierarchyIncomingCallsParams, P>) {
-                    result.push_back({.from = {.name = hier, .uri = URI::fromFile(fullPath)},
-                                      .fromRanges = {{toRange(range, m_sourceManager)}}});
-                }
-                else {
-                    result.push_back({.to = {.name = hier, .uri = URI::fromFile(fullPath)},
-                                      .fromRanges = {{toRange(range, m_sourceManager)}}});
-                }
+                result.push_back({.path = leaf.getHierarchicalPath(),
+                                  .location = {.uri = URI::fromFile(fullPath),
+                                               .range = toRange(range, m_sourceManager)}});
             }
         }
-
-        return std::optional(result);
+        return result;
     }
 
     /// Return list of RTL paths for a driver or load cone

--- a/include/lsp/LspServer.h
+++ b/include/lsp/LspServer.h
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <optional>
 #include <rfl/json.hpp>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -29,10 +30,11 @@ protected:
 
     // LspServer<Impl>(LspClient& lspClient) : m_lspClient(lspClient) {}
 
-    /// Register an rpc method with the given Params, Return, and Method (name)
-    template<typename P, typename R, auto Method>
-    void registerCommand(const std::string& name) {
-        m_commands[name] = [this](std::optional<rfl::Generic> paramsJson) -> rfl::Generic {
+    /// Register an rpc command with the given Params, Return, and handler
+    template<typename P, typename R, typename Func>
+    void registerCommand(const std::string& name, Func&& func) {
+        m_commands[name] = [func = std::forward<Func>(func)](
+                               std::optional<rfl::Generic> paramsJson) -> rfl::Generic {
             // Deserialize params
             R result;
             if constexpr (!std::is_same_v<P, std::nullopt_t>) {
@@ -41,10 +43,10 @@ protected:
                 if (!params) {
                     throw std::runtime_error(params.error().what());
                 }
-                result = (static_cast<Impl*>(this)->*Method)(params.value());
+                result = func(params.value());
             }
             else {
-                result = (static_cast<Impl*>(this)->*Method)(std::monostate{});
+                result = func(std::monostate{});
             }
 
             if constexpr (std::is_same_v<R, std::monostate>) {
@@ -55,6 +57,14 @@ protected:
             }
         };
         std::cerr << "Registered command: " << name << "\n";
+    }
+
+    /// Register an rpc method with the given Params, Return, and Method (name)
+    template<typename P, typename R, auto Method>
+    void registerCommand(const std::string& name) {
+        registerCommand<P, R>(name, [this](const auto& params) {
+            return (static_cast<Impl*>(this)->*Method)(params);
+        });
     }
 
     /// A request send from the client to the server to execute a command. The request might return

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -513,8 +513,8 @@ std::vector<std::string> SlangServer::getLoads(const std::string& path) {
     return m_driver->comp->getConePaths<false>(path);
 }
 
-std::optional<std::vector<server::ConeEntry>>
-SlangServer::getDriversWithLocation(const std::string& hierPath) {
+std::optional<std::vector<server::ConeEntry>> SlangServer::getDriversWithLocation(
+    const std::string& hierPath) {
     if (!m_driver->comp) {
         ERROR("No compilation available, cannot trace cones");
         return std::nullopt;
@@ -522,8 +522,8 @@ SlangServer::getDriversWithLocation(const std::string& hierPath) {
     return m_driver->comp->getConeLocations<true>(hierPath);
 }
 
-std::optional<std::vector<server::ConeEntry>>
-SlangServer::getLoadsWithLocation(const std::string& hierPath) {
+std::optional<std::vector<server::ConeEntry>> SlangServer::getLoadsWithLocation(
+    const std::string& hierPath) {
     if (!m_driver->comp) {
         ERROR("No compilation available, cannot trace cones");
         return std::nullopt;

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -107,10 +107,6 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     registerCommand<waves::ItemToWaveform, std::monostate, &SlangServer::addToWaveform>(
         "slang.addToWaveform");
     registerCommand<std::string, std::monostate, &SlangServer::openWaveform>("slang.openWaveform");
-    registerCommand<std::string, std::vector<std::string>, &SlangServer::getDrivers>(
-        "slang.getDrivers");
-    registerCommand<std::string, std::vector<std::string>, &SlangServer::getLoads>(
-        "slang.getLoads");
     registerCommand<std::string, std::optional<std::vector<server::ConeEntry>>,
                     &SlangServer::getDriversWithLocation>("slang.getDriversWithLocation");
     registerCommand<std::string, std::optional<std::vector<server::ConeEntry>>,

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -111,6 +111,12 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
         "slang.getDrivers");
     registerCommand<std::string, std::vector<std::string>, &SlangServer::getLoads>(
         "slang.getLoads");
+    registerCommand<std::string,
+                    std::optional<std::vector<lsp::CallHierarchyIncomingCall>>,
+                    &SlangServer::getDriversWithLocation>("slang.getDriversWithLocation");
+    registerCommand<std::string,
+                    std::optional<std::vector<lsp::CallHierarchyOutgoingCall>>,
+                    &SlangServer::getLoadsWithLocation>("slang.getLoadsWithLocation");
 
     // Hierarchy View (sidebar)
     registerCommand<std::string, std::vector<hier::HierItem_t>, &SlangServer::getScope>(
@@ -497,6 +503,46 @@ std::vector<std::string> SlangServer::getLoads(const std::string& path) {
         return {};
     }
     return m_driver->comp->getConePaths<false>(path);
+}
+
+std::optional<std::vector<lsp::CallHierarchyIncomingCall>>
+SlangServer::getDriversWithLocation(const std::string& hierPath) {
+    if (!m_driver->comp) {
+        ERROR("No compilation available, cannot trace cones");
+        return std::nullopt;
+    }
+    // Get URI if available for the CallHierarchyItem
+    URI uri;
+    auto docParams = m_driver->comp->getHierDocParams(hierPath);
+    if (docParams) {
+        uri = docParams->uri;
+    }
+    // Create minimal CallHierarchyItem with just name (and URI if available)
+    // The template only uses params.item.name, so other fields can be default-initialized
+    lsp::CallHierarchyItem item{.name = hierPath, .uri = uri};
+    lsp::CallHierarchyIncomingCallsParams params{.item = item};
+    return m_driver->comp->getCallHierarchyCalls<lsp::CallHierarchyIncomingCallsParams,
+                                                  lsp::CallHierarchyIncomingCall>(params);
+}
+
+std::optional<std::vector<lsp::CallHierarchyOutgoingCall>>
+SlangServer::getLoadsWithLocation(const std::string& hierPath) {
+    if (!m_driver->comp) {
+        ERROR("No compilation available, cannot trace cones");
+        return std::nullopt;
+    }
+    // Get URI if available for the CallHierarchyItem
+    URI uri;
+    auto docParams = m_driver->comp->getHierDocParams(hierPath);
+    if (docParams) {
+        uri = docParams->uri;
+    }
+    // Create minimal CallHierarchyItem with just name (and URI if available)
+    // The template only uses params.item.name, so other fields can be default-initialized
+    lsp::CallHierarchyItem item{.name = hierPath, .uri = uri};
+    lsp::CallHierarchyOutgoingCallsParams params{.item = item};
+    return m_driver->comp->getCallHierarchyCalls<lsp::CallHierarchyOutgoingCallsParams,
+                                                  lsp::CallHierarchyOutgoingCall>(params);
 }
 
 void SlangServer::loadConfig(const Config& config, bool forceIndexing) {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -107,6 +107,10 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     registerCommand<waves::ItemToWaveform, std::monostate, &SlangServer::addToWaveform>(
         "slang.addToWaveform");
     registerCommand<std::string, std::monostate, &SlangServer::openWaveform>("slang.openWaveform");
+    registerCommand<std::string, std::vector<std::string>, &SlangServer::getDrivers>(
+        "slang.getDrivers");
+    registerCommand<std::string, std::vector<std::string>, &SlangServer::getLoads>(
+        "slang.getLoads");
 
     // Hierarchy View (sidebar)
     registerCommand<std::string, std::vector<hier::HierItem_t>, &SlangServer::getScope>(

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -107,10 +107,15 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     registerCommand<waves::ItemToWaveform, std::monostate, &SlangServer::addToWaveform>(
         "slang.addToWaveform");
     registerCommand<std::string, std::monostate, &SlangServer::openWaveform>("slang.openWaveform");
-    registerCommand<std::string, std::optional<std::vector<server::ConeEntry>>,
-                    &SlangServer::getDriversWithLocation>("slang.getDriversWithLocation");
-    registerCommand<std::string, std::optional<std::vector<server::ConeEntry>>,
-                    &SlangServer::getLoadsWithLocation>("slang.getLoadsWithLocation");
+
+    registerDesignCommand<std::string, std::vector<server::ConeEntry>>(
+        "slang.getDriversWithLocation", [](ServerCompilation& comp, const std::string& hierPath) {
+            return comp.getConeLocations<true>(hierPath);
+        });
+    registerDesignCommand<std::string, std::vector<server::ConeEntry>>(
+        "slang.getLoadsWithLocation", [](ServerCompilation& comp, const std::string& hierPath) {
+            return comp.getConeLocations<false>(hierPath);
+        });
 
     // Hierarchy View (sidebar)
     registerCommand<std::string, std::vector<hier::HierItem_t>, &SlangServer::getScope>(
@@ -507,24 +512,6 @@ std::vector<std::string> SlangServer::getLoads(const std::string& path) {
         return {};
     }
     return m_driver->comp->getConePaths<false>(path);
-}
-
-std::optional<std::vector<server::ConeEntry>> SlangServer::getDriversWithLocation(
-    const std::string& hierPath) {
-    if (!m_driver->comp) {
-        ERROR("No compilation available, cannot trace cones");
-        return std::nullopt;
-    }
-    return m_driver->comp->getConeLocations<true>(hierPath);
-}
-
-std::optional<std::vector<server::ConeEntry>> SlangServer::getLoadsWithLocation(
-    const std::string& hierPath) {
-    if (!m_driver->comp) {
-        ERROR("No compilation available, cannot trace cones");
-        return std::nullopt;
-    }
-    return m_driver->comp->getConeLocations<false>(hierPath);
 }
 
 void SlangServer::loadConfig(const Config& config, bool forceIndexing) {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -111,11 +111,9 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
         "slang.getDrivers");
     registerCommand<std::string, std::vector<std::string>, &SlangServer::getLoads>(
         "slang.getLoads");
-    registerCommand<std::string,
-                    std::optional<std::vector<lsp::CallHierarchyIncomingCall>>,
+    registerCommand<std::string, std::optional<std::vector<server::ConeEntry>>,
                     &SlangServer::getDriversWithLocation>("slang.getDriversWithLocation");
-    registerCommand<std::string,
-                    std::optional<std::vector<lsp::CallHierarchyOutgoingCall>>,
+    registerCommand<std::string, std::optional<std::vector<server::ConeEntry>>,
                     &SlangServer::getLoadsWithLocation>("slang.getLoadsWithLocation");
 
     // Hierarchy View (sidebar)
@@ -475,8 +473,13 @@ std::optional<std::vector<lsp::CallHierarchyIncomingCall>> SlangServer::
         ERROR("No compilation available, cannot trace cones");
         return std::nullopt;
     }
-    return m_driver->comp->getCallHierarchyCalls<lsp::CallHierarchyIncomingCallsParams,
-                                                 lsp::CallHierarchyIncomingCall>(params);
+    // Drivers are presented as "incoming calls" in the call hierarchy view.
+    std::vector<lsp::CallHierarchyIncomingCall> result;
+    for (const auto& entry : m_driver->comp->getConeLocations<true>(params.item.name)) {
+        result.push_back({.from = {.name = entry.path, .uri = entry.location.uri},
+                          .fromRanges = {entry.location.range}});
+    }
+    return result;
 }
 
 std::optional<std::vector<lsp::CallHierarchyOutgoingCall>> SlangServer::
@@ -485,8 +488,13 @@ std::optional<std::vector<lsp::CallHierarchyOutgoingCall>> SlangServer::
         ERROR("No compilation available, cannot trace cones");
         return std::nullopt;
     }
-    return m_driver->comp->getCallHierarchyCalls<lsp::CallHierarchyOutgoingCallsParams,
-                                                 lsp::CallHierarchyOutgoingCall>(params);
+    // Loads are presented as "outgoing calls" in the call hierarchy view.
+    std::vector<lsp::CallHierarchyOutgoingCall> result;
+    for (const auto& entry : m_driver->comp->getConeLocations<false>(params.item.name)) {
+        result.push_back({.to = {.name = entry.path, .uri = entry.location.uri},
+                          .fromRanges = {entry.location.range}});
+    }
+    return result;
 }
 
 std::vector<std::string> SlangServer::getDrivers(const std::string& path) {
@@ -505,44 +513,22 @@ std::vector<std::string> SlangServer::getLoads(const std::string& path) {
     return m_driver->comp->getConePaths<false>(path);
 }
 
-std::optional<std::vector<lsp::CallHierarchyIncomingCall>>
+std::optional<std::vector<server::ConeEntry>>
 SlangServer::getDriversWithLocation(const std::string& hierPath) {
     if (!m_driver->comp) {
         ERROR("No compilation available, cannot trace cones");
         return std::nullopt;
     }
-    // Get URI if available for the CallHierarchyItem
-    URI uri;
-    auto docParams = m_driver->comp->getHierDocParams(hierPath);
-    if (docParams) {
-        uri = docParams->uri;
-    }
-    // Create minimal CallHierarchyItem with just name (and URI if available)
-    // The template only uses params.item.name, so other fields can be default-initialized
-    lsp::CallHierarchyItem item{.name = hierPath, .uri = uri};
-    lsp::CallHierarchyIncomingCallsParams params{.item = item};
-    return m_driver->comp->getCallHierarchyCalls<lsp::CallHierarchyIncomingCallsParams,
-                                                  lsp::CallHierarchyIncomingCall>(params);
+    return m_driver->comp->getConeLocations<true>(hierPath);
 }
 
-std::optional<std::vector<lsp::CallHierarchyOutgoingCall>>
+std::optional<std::vector<server::ConeEntry>>
 SlangServer::getLoadsWithLocation(const std::string& hierPath) {
     if (!m_driver->comp) {
         ERROR("No compilation available, cannot trace cones");
         return std::nullopt;
     }
-    // Get URI if available for the CallHierarchyItem
-    URI uri;
-    auto docParams = m_driver->comp->getHierDocParams(hierPath);
-    if (docParams) {
-        uri = docParams->uri;
-    }
-    // Create minimal CallHierarchyItem with just name (and URI if available)
-    // The template only uses params.item.name, so other fields can be default-initialized
-    lsp::CallHierarchyItem item{.name = hierPath, .uri = uri};
-    lsp::CallHierarchyOutgoingCallsParams params{.item = item};
-    return m_driver->comp->getCallHierarchyCalls<lsp::CallHierarchyOutgoingCallsParams,
-                                                  lsp::CallHierarchyOutgoingCall>(params);
+    return m_driver->comp->getConeLocations<false>(hierPath);
 }
 
 void SlangServer::loadConfig(const Config& config, bool forceIndexing) {


### PR DESCRIPTION
Recreating the PR as the original #409 accidentally closed

### New LSP commands
- `slang.getDriversWithLocation` / `slang.getLoadsWithLocation`:  return the RTL paths of the driver/load
  cone for a hierarchical path and its source location

### Refactor
- `ServerCompilation` no longer builds LSP CallHierarchy responses. The `getCallHierarchyCalls<P,R>` template is replaced by a direct `getConeLocations<isDrivers>()` returning `ConeEntry { path, location }`
- The incoming/outgoing call-hierarchy repackaging now lives in the LSP routes in `SlangServer.cpp`
- `getDrivers/LoadsWithLocation` return `ConeEntry` directly instead of synthesizing `CallHierarchyItem`