### PR TITLE
Completions: Resolve interface port arrays with unevaluated bounds

### DIFF
--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -147,7 +147,7 @@ public:
     /// @brief Gets the appropriate scope from a symbol for member access traversal
     /// @param symbol The symbol to get the scope from
     /// @return Pointer to the scope, or nullptr if the symbol doesn't have an accessible scope
-    static const slang::ast::Scope* getScopeFromSym(const slang::ast::Symbol* symbol);
+    const slang::ast::Scope* getScopeFromSym(const slang::ast::Symbol* symbol) const;
 
     std::vector<lsp::InlayHint> getInlayHints(lsp::Range range,
                                               const struct Config::InlayHints& config);
@@ -204,6 +204,9 @@ private:
     };
     mutable slang::flat_hash_map<const slang::syntax::LoopGenerateSyntax*, GenvarElaboration>
         m_genvarElaborations;
+
+    mutable slang::flat_hash_map<const slang::ast::DefinitionSymbol*, const slang::ast::Scope*>
+        m_interfaceFallbackScopes;
 
     const GenvarElaboration* getGenvarElaborationAtToken(const slang::parsing::Token* node) const;
 

--- a/src/completions/MemberCompletions.cpp
+++ b/src/completions/MemberCompletions.cpp
@@ -176,7 +176,7 @@ public:
             }
         }
 
-        auto* targetScope = ShallowAnalysis::getScopeFromSym(symbol);
+        auto* targetScope = context.analysis->getScopeFromSym(symbol);
         if (!targetScope) {
             WARN("No scope found for sym {}: {}", symbol->getHierarchicalPath(),
                  toString(symbol->kind));
@@ -225,7 +225,7 @@ public:
         auto* receiver = analysis->getSymbolAtToken(receiverToken);
         if (!receiver)
             receiver = analysis->getCompilation()->getPackage(receiverToken->valueText());
-        auto* targetScope = ShallowAnalysis::getScopeFromSym(receiver);
+        auto* targetScope = analysis->getScopeFromSym(receiver);
         if (!targetScope) {
             WARN("No scoped completion target found for {}", receiverToken->valueText());
             return;
@@ -342,6 +342,14 @@ std::string getMemberCompletionDetail(const slang::ast::Symbol& symbol) {
         if (!port.modport.empty()) {
             detailStr += ".";
             detailStr += port.modport;
+        }
+        if (auto portSyntax = port.getSyntax()) {
+            if (auto declarator = portSyntax->as_if<syntax::DeclaratorSyntax>()) {
+                for (auto dimension : declarator->dimensions) {
+                    detailStr +=
+                        syntax::SyntaxPrinter().setIncludeComments(false).print(*dimension).str();
+                }
+            }
         }
     }
     else if (slang::ast::PortSymbol::isKind(symbol.kind)) {

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -207,7 +207,7 @@ const ast::Symbol* ShallowAnalysis::handleInterfacePortHeader(const parsing::Tok
     return inst.body.lookupName(header.modport->member.valueText());
 }
 
-const ast::Scope* ShallowAnalysis::getScopeFromSym(const ast::Symbol* symbol) {
+const ast::Scope* ShallowAnalysis::getScopeFromSym(const ast::Symbol* symbol) const {
     if (!symbol) {
         return nullptr;
     }
@@ -235,6 +235,29 @@ const ast::Scope* ShallowAnalysis::getScopeFromSym(const ast::Symbol* symbol) {
         auto& port = symbol->as<ast::InterfacePortSymbol>();
         auto [connSym, modport] = port.getConnection();
         auto scope = getScopeFromSym(connSym);
+
+        auto instanceArray = connSym ? connSym->as_if<ast::InstanceArraySymbol>() : nullptr;
+        if ((!connSym || (instanceArray && instanceArray->elements.empty())) && port.interfaceDef) {
+            auto parentScope = port.getParentScope();
+            if (!parentScope)
+                return nullptr;
+
+            auto [it, inserted] = m_interfaceFallbackScopes.try_emplace(port.interfaceDef, nullptr);
+            if (inserted) {
+                auto& fallback = ast::InstanceSymbol::createDefault(parentScope->getCompilation(),
+                                                                    *port.interfaceDef);
+                fallback.name = "";
+                it->second = &fallback.body;
+            }
+            scope = it->second;
+            if (!port.modport.empty()) {
+                auto fallbackModport = scope->find(port.modport);
+                if (fallbackModport && fallbackModport->kind == ast::SymbolKind::Modport)
+                    return &fallbackModport->as<ast::Scope>();
+            }
+            return scope;
+        }
+
         if (!modport) {
             return scope;
         }
@@ -467,6 +490,32 @@ slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
         return symbols;
     }
 
+    auto recoverMembers = [&](const syntax::SyntaxNode& left, std::string_view name) {
+        auto leftToken = syntaxes.getTokenAt(left.getLastToken().location());
+        for (auto* receiver : getSymbolsAtToken(leftToken)) {
+            if (auto* receiverScope = getScopeFromSym(receiver))
+                addSymbol(receiverScope->find(name));
+        }
+    };
+
+    if (syntax->kind == syntax::SyntaxKind::MemberAccessExpression) {
+        auto& access = syntax->as<syntax::MemberAccessExpressionSyntax>();
+        if (access.name == *declTok) {
+            recoverMembers(*access.left, access.name.valueText());
+            if (!symbols.empty())
+                return symbols;
+        }
+    }
+    else if (syntax->kind == syntax::SyntaxKind::IdentifierName && syntax->parent) {
+        auto scoped = syntax->parent->as_if<syntax::ScopedNameSyntax>();
+        if (scoped && scoped->right == syntax &&
+            scoped->separator.kind == parsing::TokenKind::Dot) {
+            recoverMembers(*scoped->left, declTok->valueText());
+            if (!symbols.empty())
+                return symbols;
+        }
+    }
+
     auto scopes = m_symbolIndexer.getScopesForSyntax(*syntax);
 
     if (syntax->kind == syntax::SyntaxKind::LoopGenerate &&
@@ -510,12 +559,34 @@ slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
         if (result.found) {
             if (isOverSelector(declTok, result)) {
                 const slang::ast::Symbol* cur = result.found;
+                size_t remainingInterfaceDimensions = 0;
+                bool hasInterfaceDimensions = false;
+
+                auto loadInterfaceDimensions = [&] {
+                    if (hasInterfaceDimensions)
+                        return true;
+
+                    auto portSyntax = cur->getSyntax();
+                    auto declarator = portSyntax ? portSyntax->as_if<syntax::DeclaratorSyntax>()
+                                                 : nullptr;
+                    if (!declarator)
+                        return false;
+
+                    remainingInterfaceDimensions = declarator->dimensions.size();
+                    hasInterfaceDimensions = true;
+                    return true;
+                };
 
                 // Proper selector resolution is in
                 // Expression::bindLookupResult, however that modifies the compilation at the
                 // moment
                 for (auto& sel : result.selectors) {
                     if (auto member = std::get_if<ast::LookupResult::MemberSelector>(&sel)) {
+                        if (ast::InterfacePortSymbol::isKind(cur->kind) &&
+                            (!loadInterfaceDimensions() || remainingInterfaceDimensions != 0)) {
+                            return nullptr;
+                        }
+
                         const ast::Scope* scope = getScopeFromSym(cur);
                         if (!scope) {
                             INFO("No scope found for sym {} : {}", cur->getHierarchicalPath(),
@@ -523,12 +594,25 @@ slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
                             return nullptr;
                         }
                         cur = scope->find(member->name);
+                        hasInterfaceDimensions = false;
 
                         if (member->nameRange == declTok->range()) {
                             return cur;
                         }
                     }
                     else {
+                        if (ast::InterfacePortSymbol::isKind(cur->kind)) {
+                            // Preserve the port while consuming unevaluated interface dimensions.
+                            auto* select = std::get<const syntax::ElementSelectSyntax*>(sel);
+                            if (!loadInterfaceDimensions() || remainingInterfaceDimensions == 0 ||
+                                !select->selector ||
+                                select->selector->kind != syntax::SyntaxKind::BitSelect) {
+                                return nullptr;
+                            }
+                            remainingInterfaceDimensions--;
+                            continue;
+                        }
+
                         const ast::Type* type = nullptr;
                         if (cur->isType()) {
                             type = &cur->as<ast::Type>();
@@ -543,6 +627,7 @@ slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
                         else {
                             return nullptr;
                         }
+                        hasInterfaceDimensions = false;
                     }
                     if (!cur) {
                         WARN("No members found in scope {}",
@@ -550,6 +635,8 @@ slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
                         return nullptr;
                     }
                 }
+                if (hasInterfaceDimensions && remainingInterfaceDimensions != 0)
+                    return nullptr;
                 return cur;
             }
             // with IdentifierSelectNameSyntax (instance arrays) result.found will be the final

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -957,6 +957,96 @@ TEST_CASE("HierarchicalInterfacePortCompletion") {
     CHECK(!hasCompletion(producerCompletions, "hidden"));
 }
 
+TEST_CASE("HierarchicalInterfacePortArrayCompletionWithUnresolvedBounds") {
+    ServerHarness server("repo1");
+
+    auto doc = server.openFile("invalid_iface_port_completion.sv", R"(
+    interface valid_data_if #(
+        parameter type data_type,
+        parameter int data_width = 8
+    );
+        data_type data;
+        logic [data_width - 1:0] payload;
+        logic valid;
+
+        modport source(output data, payload, valid);
+    endinterface
+
+    module iface_port_completion #(
+        parameter int num_ports
+    ) (
+        valid_data_if.source requests[num_ports],
+        valid_data_if.source matrix[num_ports][num_ports]
+    );
+        for (genvar index = 0; index < num_ports; index++) begin
+            always_comb begin
+                requests[index].valid;
+                requests[index].payload;
+                requests[index][index].valid;
+                requests[index:index].valid;
+                matrix[index].valid;
+                matrix[index][index].valid;
+            end
+        end
+    endmodule
+    )");
+
+    auto findCompletion = [](auto& items, std::string_view label) {
+        return std::find_if(items.begin(), items.end(), [label](const CompletionHandle& item) {
+            return item.m_item.label == label;
+        });
+    };
+
+    auto members = doc.after("requests[index].").getCompletions(".");
+    CHECK(findCompletion(members, "data") != members.end());
+    CHECK(findCompletion(members, "payload") != members.end());
+    CHECK(findCompletion(members, "valid") != members.end());
+
+    auto matrixMembers = doc.after("matrix[index][index].").getCompletions(".");
+    CHECK(findCompletion(matrixMembers, "valid") != matrixMembers.end());
+
+    for (auto invalidAccess :
+         {"requests[index][index].", "requests[index:index].", "matrix[index]."}) {
+        auto invalidMembers = doc.after(invalidAccess).getCompletions(".");
+        CHECK(findCompletion(invalidMembers, "valid") == invalidMembers.end());
+    }
+
+    auto lexical = doc.before("requests[index].valid").getCompletions();
+    auto requests = findCompletion(lexical, "requests");
+    REQUIRE(requests != lexical.end());
+    REQUIRE(requests->m_item.labelDetails);
+    CHECK(requests->m_item.labelDetails->detail == " valid_data_if.source[num_ports]");
+
+    auto matrix = findCompletion(lexical, "matrix");
+    REQUIRE(matrix != lexical.end());
+    REQUIRE(matrix->m_item.labelDetails);
+    CHECK(matrix->m_item.labelDetails->detail == " valid_data_if.source[num_ports][num_ports]");
+
+    auto prefixed = doc.after("requests[index].valid").getCompletions();
+    auto valid = findCompletion(prefixed, "valid");
+    REQUIRE(valid != prefixed.end());
+    valid->resolve();
+    CHECK(valid->m_item.documentation);
+
+    auto validUse = doc.after("requests[index].");
+    auto hover = doc.getHoverAt(validUse.m_offset);
+    REQUIRE(hover);
+    auto hoverContent = rfl::get<lsp::MarkupContent>(hover->contents);
+    CHECK(hoverContent.value.find("output data, payload, valid") != std::string::npos);
+
+    auto payloadUse = doc.before("requests[index].payload");
+    auto payloadHover = doc.getHoverAt(payloadUse.m_offset +
+                                       std::string_view("requests[index].").size());
+    REQUIRE(payloadHover);
+    auto payloadContent = rfl::get<lsp::MarkupContent>(payloadHover->contents);
+    CHECK(payloadContent.value.find("Type: `logic[7:0]`") != std::string::npos);
+
+    auto definitions = validUse.getDefinitions();
+    REQUIRE(definitions.size() == 2);
+    CHECK(definitions[0].targetSelectionRange.start.line == 9);
+    CHECK(definitions[1].targetSelectionRange.start.line == 7);
+}
+
 TEST_CASE("HierarchicalStructCompletion") {
     ServerHarness server("repo1");
     JsonGoldenTest golden;

--- a/tests/cpp/utils/CompletionCoverageScanner.cpp
+++ b/tests/cpp/utils/CompletionCoverageScanner.cpp
@@ -74,7 +74,8 @@ std::optional<CompletionCoverageScanner::CompletionIssue> CompletionCoverageScan
     }
 
     auto definition = hdl.getDefinitionInfoAt(static_cast<lsp::uint>(token.location().offset()));
-    if (!definition || !definition->symbol()) {
+    auto definitionSymbol = definition ? definition->symbol() : nullptr;
+    if (!definitionSymbol) {
         return std::nullopt;
     }
     if (definition->nameToken().location() == token.location()) {
@@ -99,7 +100,7 @@ std::optional<CompletionCoverageScanner::CompletionIssue> CompletionCoverageScan
             return std::nullopt;
 
         auto expected = completion->m_item;
-        server::completions::MemberCompletionQuery::resolve(*definition->symbol(), expected, true);
+        server::completions::MemberCompletionQuery::resolve(*definitionSymbol, expected, true);
         completion->resolve();
 
         auto documentationText = [](const lsp::CompletionItem& item) -> std::optional<std::string> {


### PR DESCRIPTION
Recover member completions, hover, and definition lookup when shallow compilation cannot evaluate parameterized interface-port array bounds. Reuse a default-elaborated representative interface scope, honor modports, and require scalar selection of every declared dimension before resolving members.

Include source array dimensions in completion details and add coverage for defaulted interface parameters, multidimensional selectors, and invalid partial, excess, and range selections.