### PR TITLE
Build: Give SyntaxTarget an explicit ctor for GCC 13

### DIFF
--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -41,7 +41,14 @@ struct DefinitionInfo {
         // found.
         slang::parsing::Token nameToken;
         // Optional original source range; exists if it's behind a macro expansion.
-        slang::SourceRange macroUsageRange = slang::SourceRange::NoLocation;
+        slang::SourceRange macroUsageRange;
+
+        // Don't default-init macroUsageRange in-class: GCC 13 can't see that initializer when
+        // SyntaxTarget is used in a std::variant of the enclosing type.
+        SyntaxTarget(const slang::syntax::SyntaxNode* node, slang::parsing::Token nameToken,
+                     slang::SourceRange macroUsageRange = slang::SourceRange::NoLocation) :
+            node(node), nameToken(nameToken), macroUsageRange(macroUsageRange) {}
+        SyntaxTarget() : SyntaxTarget(nullptr, {}, slang::SourceRange::NoLocation) {}
 
         bool operator==(const SyntaxTarget& other) const {
             return node == other.node && nameToken.location() == other.nameToken.location() &&


### PR DESCRIPTION
Fixes #407

GCC 13 rejects the default member initializer on `SyntaxTarget::macroUsageRange` because `SyntaxTarget` is a nested class used as a `std::variant` alternative of the enclosing type. The default-ctor check needs that initializer before the enclosing class is complete.

Move the `SourceRange::NoLocation` default onto the constructor instead. Clang / GCC 14 already built this; this just unblocks GCC 13.