### PR TITLE
Build/Diagnostics: GCC 13 ctor + keep design diags on didOpen

### DIFF
--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -41,7 +41,14 @@ struct DefinitionInfo {
         // found.
         slang::parsing::Token nameToken;
         // Optional original source range; exists if it's behind a macro expansion.
-        slang::SourceRange macroUsageRange = slang::SourceRange::NoLocation;
+        slang::SourceRange macroUsageRange;
+
+        // Don't default-init macroUsageRange in-class: GCC 13 can't see that initializer when
+        // SyntaxTarget is used in a std::variant of the enclosing type.
+        SyntaxTarget(const slang::syntax::SyntaxNode* node, slang::parsing::Token nameToken,
+                     slang::SourceRange macroUsageRange = slang::SourceRange::NoLocation) :
+            node(node), nameToken(nameToken), macroUsageRange(macroUsageRange) {}
+        SyntaxTarget() : SyntaxTarget(nullptr, {}, slang::SourceRange::NoLocation) {}
 
         bool operator==(const SyntaxTarget& other) const {
             return node == other.node && nameToken.location() == other.nameToken.location() &&

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -181,15 +181,19 @@ std::unique_ptr<ServerDriver> ServerDriver::create(Indexer& indexer, SlangLspCli
             // Only copy if the URI isn't already in the new driver's docs
             auto newDocit = newDriver->docs.find(uri);
             if (newDocit == newDriver->docs.end()) {
-                // Open the document in the new driver using the text from the old document
-                newDriver->openDocument(uri, docIt->second->getText());
-                // Trigger diagnostics for the newly opened document
+                // Open the document in the new driver using the text from the old document.
+                // getText() includes the trailing NUL that SourceManager stores.
+                auto text = docIt->second->getText();
+                if (!text.empty() && text.back() == '\0')
+                    text.remove_suffix(1);
+                newDriver->openDocument(uri, text);
             }
             else {
-                // Publish diags for the existing document
-                // Add to open doc set
+                // Already loaded from the build — keep design diagnostics. createCompilation()
+                // (if the caller makes one) will publish them; a shallow pass here would
+                // overwrite them first.
                 newDriver->m_openDocs.insert(uri);
-                newDriver->updateDoc(*newDocit->second, FileUpdateType::OPEN);
+                newDriver->publishInactiveRegions(*newDocit->second);
             }
         }
     }
@@ -200,14 +204,18 @@ std::unique_ptr<ServerDriver> ServerDriver::create(Indexer& indexer, SlangLspCli
 void ServerDriver::openDocument(const URI& uri, const std::string_view text) {
     auto docIter = docs.find(uri);
     std::shared_ptr<SlangDoc> doc;
-    bool alreadyInBuild = false;
-    if (docIter != docs.end() && docIter->second->textMatches(text)) {
+    // A document loaded from the build is already in `docs`, even if the editor buffer
+    // doesn't byte-match (trailing newline, restored dirty tabs, SourceManager's NUL).
+    const bool alreadyInBuild = docIter != docs.end();
+    if (alreadyInBuild) {
         doc = docIter->second;
-        alreadyInBuild = true;
+        if (!doc->textMatches(text)) {
+            WARN("Document {} text does not match, updating", uri.getPath());
+            doc = SlangDoc::fromText(*this, uri, text);
+            docs[uri] = doc;
+        }
     }
     else {
-        if (docIter != docs.end())
-            WARN("Document {} text does not match, updating", uri.getPath());
         doc = SlangDoc::fromText(*this, uri, text);
         docs[uri] = doc;
     }

--- a/src/document/SlangDoc.cpp
+++ b/src/document/SlangDoc.cpp
@@ -126,17 +126,12 @@ std::shared_ptr<ShallowAnalysis> SlangDoc::getAnalysis(bool refreshDependencies)
 }
 
 bool SlangDoc::textMatches(std::string_view text) {
-    // Just compute line offsets to validate UTF-8
-    auto bufText = getText();
-    if (bufText.size() != text.size() + 1) {
-        ERROR("Text size mismatch: have {}, expected {}", bufText.size(), text.size() + 1);
-        return false;
-    }
-    if (std::memcmp(bufText.data(), text.data(), bufText.size()) != 0) {
-        ERROR("Text content mismatch");
-        return false;
-    }
-    return true;
+    auto stripNul = [](std::string_view s) {
+        if (!s.empty() && s.back() == '\0')
+            s.remove_suffix(1);
+        return s;
+    };
+    return stripNul(getText()) == stripNul(text);
 }
 
 void SlangDoc::onChange(const std::vector<lsp::TextDocumentContentChangeEvent>& contentChanges) {

--- a/tests/cpp/DiagTests.cpp
+++ b/tests/cpp/DiagTests.cpp
@@ -365,6 +365,27 @@ TEST_CASE("OpenBuildFileDoesNotOverwriteCompilationDiags") {
     }
 }
 
+TEST_CASE("OpenBuildFileMismatchedTextDoesNotOverwriteCompilationDiags") {
+    ServerHarness server("comp_repo");
+    server.setBuildFile("cpu_design.f");
+
+    auto cpuUri = URI::fromFile(fs::current_path() / "cpu.sv");
+    auto compDiags = server.client.getDiagnostics(cpuUri);
+    REQUIRE(!compDiags.empty());
+
+    // didOpen after a window reload can send a buffer that doesn't byte-match what the
+    // build loaded (final newline, unsaved restore). That used to force a shallow
+    // re-analysis and wipe the design diagnostics.
+    server.openFile("cpu.sv", "module cpu; endmodule\n");
+    auto afterOpenDiags = server.client.getDiagnostics(cpuUri);
+
+    REQUIRE(afterOpenDiags.size() == compDiags.size());
+    for (size_t i = 0; i < compDiags.size(); i++) {
+        CHECK(compDiags[i].message == afterOpenDiags[i].message);
+        CHECK(compDiags[i].range.start.line == afterOpenDiags[i].range.start.line);
+    }
+}
+
 TEST_CASE("OpenNonBuildFileGetsShallowDiags") {
     ServerHarness server("comp_repo");
     server.setBuildFile("cpu_design.f");


### PR DESCRIPTION
Fixes #407
Fixes #428

Two small, independent fixes:

- **#407** — `SyntaxTarget` is a nested class used in a `std::variant` of the enclosing type. GCC 13 rejects the in-class default for `macroUsageRange`. Move that default onto the constructor.
- **#428** — Restored tabs on window reload ran a shallow `didOpen` pass and overwrote full-build diagnostics. The skip only fired on an exact buffer match (including SourceManager's trailing NUL). Skip the shallow pass whenever the URI is already in the compilation.

`server_unittests`: 241/241 passed.