### PR TITLE
Respect linkSupport capability in gotos

### DIFF
--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -104,12 +104,6 @@ public:
     std::optional<DefinitionInfo> getDefinitionInfoAt(const URI& uri,
                                                       const lsp::Position& position);
 
-    /// @brief Gets LSP definition links for a position in a document
-    /// @param uri The URI of the document
-    /// @param position The LSP position to query
-    /// @return Vector of location links to definitions
-    std::vector<lsp::LocationLink> getDocDefinition(const URI& uri, const lsp::Position& position);
-
     /// @brief Gets hover information for a symbol at an LSP position
     /// @param uri The URI of the document
     /// @param position The LSP position to query

--- a/include/SlangLspClient.h
+++ b/include/SlangLspClient.h
@@ -9,29 +9,55 @@
 
 #include "Config.h"
 #include "lsp/LspClient.h"
+#include "lsp/LspTypeExtensions.h"
 #include <algorithm>
+#include <rfl/from_generic.hpp>
+#include <string_view>
 
 class SlangLspClient : public lsp::LspClient {
     /// Helper functions to send things to the client
 
 public:
-    struct {
+    struct Capabilities {
+        /// Experimental slang-server inactive-regions extension.
         bool inactiveRegionsSupported = false;
-    } experimentalCapabilities;
 
-    bool supportsCompletionEditResolve(const lsp::ClientCapabilities& capabilities) const {
-        if (!capabilities.textDocument || !capabilities.textDocument->completion ||
-            !capabilities.textDocument->completion->completionItem ||
-            !capabilities.textDocument->completion->completionItem->resolveSupport)
-            return false;
+        /// [`textDocument.definition.linkSupport`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#definitionClientCapabilities)
+        bool definitionLinksSupported = false;
 
-        auto& properties =
-            capabilities.textDocument->completion->completionItem->resolveSupport->properties;
-        auto supports = [&](std::string_view property) {
-            return std::ranges::find(properties, property) != properties.end();
-        };
-        return supports("insertText") && supports("insertTextFormat") && supports("textEdit");
-    }
+        /// [`textDocument.completion.completionItem.resolveSupport`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionClientCapabilities)
+        bool completionEditResolveSupported = false;
+
+        Capabilities() = default;
+
+        explicit Capabilities(const lsp::ClientCapabilities& capabilities) {
+            const auto& textDocument = capabilities.textDocument;
+            definitionLinksSupported = textDocument && textDocument->definition &&
+                                       textDocument->definition->linkSupport.value_or(false);
+
+            if (textDocument && textDocument->completion &&
+                textDocument->completion->completionItem &&
+                textDocument->completion->completionItem->resolveSupport) {
+                const auto& properties =
+                    textDocument->completion->completionItem->resolveSupport->properties;
+                auto supports = [&](std::string_view property) {
+                    return std::ranges::find(properties, property) != properties.end();
+                };
+                completionEditResolveSupported = supports("insertText") &&
+                                                 supports("insertTextFormat") &&
+                                                 supports("textEdit");
+            }
+
+            if (!capabilities.experimental)
+                return;
+
+            auto experimental = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
+                *capabilities.experimental);
+            inactiveRegionsSupported = experimental && experimental->inactiveRegions &&
+                                       experimental->inactiveRegions->inactiveRegions.value_or(
+                                           false);
+        }
+    } capabilities;
 
     virtual void setConfig(const Config& params) {
         lsp::sendNotification("slang/setConfig", rfl::to_generic(params));

--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -11,6 +11,7 @@
 #include "document/ShallowAnalysis.h"
 #include "lsp/LspTypes.h"
 #include <cstddef>
+#include <functional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -160,9 +161,14 @@ struct DefinitionInfo {
 
     // The things this token resolves to, in semantic / elaboration order.
     std::vector<Target> targets;
+    std::reference_wrapper<const slang::SourceManager> sourceManager;
 
-    explicit DefinitionInfo(Target target) { targets.push_back(std::move(target)); }
-    explicit DefinitionInfo(std::vector<Target> targets) : targets(std::move(targets)) {}
+    DefinitionInfo(const slang::SourceManager& sourceManager, Target target) :
+        sourceManager(sourceManager) {
+        targets.push_back(std::move(target));
+    }
+    DefinitionInfo(const slang::SourceManager& sourceManager, std::vector<Target> targets) :
+        targets(std::move(targets)), sourceManager(sourceManager) {}
 
     const Target& primaryTarget() const { return targets.front(); }
     Target& primaryTarget() { return targets.front(); }
@@ -194,11 +200,13 @@ struct DefinitionInfo {
     bool operator!=(const DefinitionInfo& other) const { return !(*this == other); }
 
     /// Render the hover markup for this definition.
-    lsp::MarkupContent getHover(const slang::SourceManager& sm, slang::BufferID docBuffer,
-                                const Config::HoverConfig& hovers) const;
+    lsp::MarkupContent getHover(slang::BufferID docBuffer, const Config::HoverConfig& hovers) const;
 
     /// Resolve and deduplicate goto-definition links for every target and declaration site.
-    std::vector<lsp::LocationLink> getDefinition(const slang::SourceManager& sm) const;
+    std::vector<lsp::LocationLink> getDefinitionLspLinks() const;
+
+    /// Resolve and deduplicate legacy goto-definition locations.
+    std::vector<lsp::Location> getDefinitionLspLocs() const;
 };
 
 } // namespace server

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -571,7 +571,7 @@ std::optional<DefinitionInfo> ServerDriver::getMacroDefinitionInfo(
         targets.emplace_back(
             DefinitionInfo::MacroTarget{std::move(macroDefinition), referenceSyntax, analysis});
     }
-    return DefinitionInfo{std::move(targets)};
+    return DefinitionInfo{sm, std::move(targets)};
 }
 
 std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
@@ -626,8 +626,8 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         if (!sub || !sysDoc)
             return {};
 
-        return DefinitionInfo{DefinitionInfo::SystemSubroutineTarget{
-            *declTok, sysDoc, sub->kind == ast::SubroutineKind::Task}};
+        return DefinitionInfo{sm, DefinitionInfo::SystemSubroutineTarget{
+                                      *declTok, sysDoc, sub->kind == ast::SubroutineKind::Task}};
     }
     auto symbolsEquivalent = [&](const ast::Symbol* left, const ast::Symbol* right) {
         if (left == right)
@@ -870,7 +870,7 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
             }
         }
         if (!targets.empty())
-            return DefinitionInfo{std::move(targets)};
+            return DefinitionInfo{sm, std::move(targets)};
     }
 
     std::vector<DefinitionInfo::Target> targets;
@@ -897,7 +897,7 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
 
     if (targets.empty())
         return {};
-    return DefinitionInfo{std::move(targets)};
+    return DefinitionInfo{sm, std::move(targets)};
 }
 
 std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::Position& position) {
@@ -921,15 +921,7 @@ std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::P
         return {};
     }
     const auto& info = *maybeInfo;
-    return lsp::Hover{.contents = info.getHover(sm, doc->getBuffer(), m_config.hovers.value())};
-}
-
-std::vector<lsp::LocationLink> ServerDriver::getDocDefinition(const URI& uri,
-                                                              const lsp::Position& position) {
-    auto maybeInfo = getDefinitionInfoAt(uri, position);
-    if (!maybeInfo)
-        return {};
-    return maybeInfo->getDefinition(sm);
+    return lsp::Hover{.contents = info.getHover(doc->getBuffer(), m_config.hovers.value())};
 }
 
 std::optional<std::vector<lsp::DocumentHighlight>> ServerDriver::getDocDocumentHighlight(
@@ -1284,7 +1276,7 @@ std::optional<lsp::WorkspaceEdit> ServerDriver::getDocRename(const URI& uri,
 }
 
 void ServerDriver::publishInactiveRegions(SlangDoc& doc) {
-    if (!client.experimentalCapabilities.inactiveRegionsSupported)
+    if (!client.capabilities.inactiveRegionsSupported)
         return;
 
     auto regions = doc.getInactiveRegions();

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -13,7 +13,6 @@
 #include "ast/WcpClient.h"
 #include "completions/CompletionContext.h"
 #include "completions/CompletionDispatch.h"
-#include "lsp/LspTypeExtensions.h"
 #include "lsp/LspTypes.h"
 #include "lsp/URI.h"
 #include "util/Converters.h"
@@ -27,7 +26,6 @@
 #include <optional>
 #include <ranges>
 #include <rfl/Variant.hpp>
-#include <rfl/from_generic.hpp>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -166,19 +164,10 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
         WARN("No workspace folder or root provided");
     }
 
-    auto resolveCompletionEdits = m_client.supportsCompletionEditResolve(params.capabilities);
+    m_client.capabilities = SlangLspClient::Capabilities(params.capabilities);
 
     loadConfig();
-    m_driver->completions.resolveEdits = resolveCompletionEdits;
-
-    if (params.capabilities.experimental) {
-        auto exp = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
-            *params.capabilities.experimental);
-
-        if (exp && exp->inactiveRegions && exp->inactiveRegions->inactiveRegions.value_or(false)) {
-            m_client.experimentalCapabilities.inactiveRegionsSupported = true;
-        }
-    }
+    m_driver->completions.resolveEdits = m_client.capabilities.completionEditResolveSupported;
 
     auto result = lsp::InitializeResult{
         .capabilities =
@@ -638,7 +627,11 @@ std::monostate SlangServer::addDefine(const std::string& macroName) {
 
 rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate> SlangServer::
     getDocDefinition(const lsp::DefinitionParams& params) {
-    return m_driver->getDocDefinition(params.textDocument.uri, params.position);
+    auto info = m_driver->getDefinitionInfoAt(params.textDocument.uri, params.position);
+    if (m_client.capabilities.definitionLinksSupported)
+        return info ? info->getDefinitionLspLinks() : std::vector<lsp::DefinitionLink>{};
+
+    return lsp::Definition(info ? info->getDefinitionLspLocs() : std::vector<lsp::Location>{});
 }
 
 std::optional<lsp::Hover> SlangServer::getDocHover(const lsp::HoverParams& params) {

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -923,8 +923,9 @@ std::vector<lsp::LocationLink> DefinitionInfo::SystemSubroutineTarget::getDefini
     return {};
 }
 
-lsp::MarkupContent DefinitionInfo::getHover(const SourceManager& sm, BufferID docBuffer,
+lsp::MarkupContent DefinitionInfo::getHover(BufferID docBuffer,
                                             const Config::HoverConfig& hovers) const {
+    const auto& sm = sourceManager.get();
     if (auto parameterSummary = renderElaboratedParameterSummary(targets, sm, hovers))
         return std::move(*parameterSummary);
     if (auto parameterValues = renderElaboratedParameterValues(targets, sm, hovers))
@@ -951,7 +952,8 @@ lsp::MarkupContent DefinitionInfo::getHover(const SourceManager& sm, BufferID do
     return result.build();
 }
 
-std::vector<lsp::LocationLink> DefinitionInfo::getDefinition(const SourceManager& sm) const {
+std::vector<lsp::LocationLink> DefinitionInfo::getDefinitionLspLinks() const {
+    const auto& sm = sourceManager.get();
     std::vector<lsp::LocationLink> result;
     for (const auto& target : targets) {
         auto links = std::visit([&](const auto& t) { return t.getDefinition(sm); }, target);
@@ -964,6 +966,15 @@ std::vector<lsp::LocationLink> DefinitionInfo::getDefinition(const SourceManager
                 result.push_back(std::move(link));
         }
     }
+    return result;
+}
+
+std::vector<lsp::Location> DefinitionInfo::getDefinitionLspLocs() const {
+    auto links = getDefinitionLspLinks();
+    std::vector<lsp::Location> result;
+    result.reserve(links.size());
+    for (auto& link : links)
+        result.emplace_back(std::move(link.targetUri), link.targetRange);
     return result;
 }
 

--- a/tests/cpp/GotoTests.cpp
+++ b/tests/cpp/GotoTests.cpp
@@ -129,6 +129,38 @@ TEST_CASE("GotoDefinition_IfdefUndefinedMacro") {
     CHECK(defs.empty());
 }
 
+TEST_CASE("GotoDefinition_HonorsLinkSupport") {
+    auto checkResultType = [](std::optional<bool> linkSupport) {
+        lsp::InitializeParams params;
+        params.capabilities.textDocument.emplace();
+        params.capabilities.textDocument->definition = lsp::DefinitionClientCapabilities{
+            .linkSupport = linkSupport};
+        ServerHarness server(std::move(params));
+
+        auto doc = server.openFile("test.sv", R"(
+module top;
+    int value;
+    initial value = value;
+endmodule
+)");
+        auto cursor = doc.after("initial value = ");
+        auto result = server.getDocDefinition(lsp::DefinitionParams{
+            .textDocument = {.uri = doc.m_uri}, .position = cursor.getPosition()});
+
+        if (linkSupport.value_or(false)) {
+            CHECK(rfl::holds_alternative<std::vector<lsp::DefinitionLink>>(result));
+        }
+        else {
+            CHECK(rfl::holds_alternative<lsp::Definition>(result));
+            const auto& definition = rfl::get<lsp::Definition>(result);
+            CHECK(rfl::holds_alternative<std::vector<lsp::Location>>(definition));
+        }
+    };
+
+    checkResultType(std::nullopt);
+    checkResultType(true);
+}
+
 TEST_CASE("GotoDefinition_AllIndexedModuleDefinitions") {
     ServerHarness server;
 

--- a/tests/cpp/InactiveRegionsTests.cpp
+++ b/tests/cpp/InactiveRegionsTests.cpp
@@ -15,6 +15,32 @@ struct RegionInfo {
     std::string text;
 };
 
+TEST_CASE("ClientCapabilities_ExtractsSupportedFeatures") {
+    auto capabilities = rfl::json::read<lsp::ClientCapabilities>(R"(
+{
+  "textDocument": {
+    "definition": {"linkSupport": true},
+    "completion": {
+      "completionItem": {
+        "resolveSupport": {
+          "properties": ["insertText", "insertTextFormat", "textEdit"]
+        }
+      }
+    }
+  },
+  "experimental": {
+    "inactiveRegions": {"inactiveRegions": true}
+  }
+}
+)");
+    REQUIRE(capabilities);
+
+    SlangLspClient::Capabilities extracted(*capabilities);
+    CHECK(extracted.definitionLinksSupported);
+    CHECK(extracted.completionEditResolveSupported);
+    CHECK(extracted.inactiveRegionsSupported);
+}
+
 TEST_CASE("InactiveRegions_SyntaxIndexer") {
     using namespace slang;
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -268,7 +268,13 @@ async def client(my_options: Flags) -> AsyncGenerator[SlangClient, None]:
 
     response = await client.initialize_async(
         types.InitializeParams(
-            capabilities=types.ClientCapabilities(),  # Ignored for now
+            capabilities=types.ClientCapabilities(
+                text_document=types.TextDocumentClientCapabilities(
+                    definition=types.DefinitionClientCapabilities(
+                        link_support=True,
+                    ),
+                ),
+            ),
             root_uri=client.get_root_uri(),
         )
     )


### PR DESCRIPTION
Should fix support for qt and kate editors - https://github.com/hudson-trading/slang-server/issues/395