### PR TITLE
Better support for incomplete struct types

### DIFF
--- a/include/util/SlangExtensions.h
+++ b/include/util/SlangExtensions.h
@@ -13,6 +13,10 @@
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/SourceManager.h"
 
+namespace slang::ast {
+class Type;
+}
+
 namespace server {
 
 /// @brief Check if a syntax tree has valid (latest) buffers in the source manager
@@ -21,5 +25,8 @@ namespace server {
 /// @return true if all buffers in the tree are up-to-date
 bool hasValidBuffers(const slang::SourceManager& sm,
                      const std::shared_ptr<slang::syntax::SyntaxTree>& tree);
+
+/// Return the canonical type, unwrapping a recoverable error type when available.
+const slang::ast::Type& unwrapErrorType(const slang::ast::Type& type);
 
 } // namespace server

--- a/src/completions/MemberCompletions.cpp
+++ b/src/completions/MemberCompletions.cpp
@@ -18,6 +18,7 @@
 #include "util/Converters.h"
 #include "util/Formatting.h"
 #include "util/Logging.h"
+#include "util/SlangExtensions.h"
 #include <fmt/format.h>
 #include <rfl/UnderlyingEnums.hpp>
 #include <rfl/from_generic.hpp>
@@ -62,9 +63,9 @@ public:
         if (!inspect(symbol))
             return;
         if constexpr (std::is_base_of_v<ast::ValueSymbol, T>) {
-            auto type = &symbol.getType().getCanonicalType();
+            auto type = &unwrapErrorType(symbol.getType());
             while (type->isArray())
-                type = &type->getArrayElementType()->getCanonicalType();
+                type = &unwrapErrorType(*type->getArrayElementType());
             if (type->isStruct() || type->isUnion())
                 type->visit(*this);
         }
@@ -328,7 +329,7 @@ std::string getMemberCompletionDetail(const slang::ast::Symbol& symbol) {
     }
     else if (symbol.kind == slang::ast::SymbolKind::TypeAlias) {
         auto& typeAlias = symbol.as<slang::ast::TypeAliasType>();
-        auto& unwrapped = typeAlias.getCanonicalType();
+        auto& unwrapped = unwrapErrorType(typeAlias);
         if (unwrapped.kind != ast::SymbolKind::ErrorType) {
             detailStr = toString(unwrapped.kind);
         }

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -13,6 +13,7 @@
 #include "util/Converters.h"
 #include "util/Formatting.h"
 #include "util/Markdown.h"
+#include "util/SlangExtensions.h"
 #include <algorithm>
 #include <filesystem>
 #include <type_traits>
@@ -32,6 +33,7 @@
 #include "slang/text/SourceLocation.h"
 #include "slang/text/SourceManager.h"
 #include "slang/util/OS.h"
+#include "slang/util/SmallMap.h"
 #include "slang/util/SmallVector.h"
 
 namespace server {
@@ -127,6 +129,77 @@ void renderSymbolHeaderName(markup::Paragraph& infoPg, const ast::Symbol& symbol
     }
 
     infoPg.appendBold(toString(symbol.kind)).appendCode(symbol.name);
+}
+
+void appendSourceLink(markup::Paragraph& paragraph, SourceLocation location,
+                      const SourceManager& sourceManager, std::string_view label = {});
+
+struct IncompleteSubtype {
+    std::string type;
+    SourceLocation location;
+};
+
+bool collectIncompleteSubtypes(const ast::Type& type, std::vector<IncompleteSubtype>& subtypes,
+                               SmallSet<const ast::Type*, 8>& seenTypes,
+                               std::vector<const ast::Type*>& activeTypes) {
+    if (!type.isError())
+        return false;
+
+    const auto& recoveredType = unwrapErrorType(type);
+    if ((!recoveredType.isStruct() && !recoveredType.isUnion()) ||
+        std::ranges::find(activeTypes, &recoveredType) != activeTypes.end()) {
+        return false;
+    }
+
+    bool found = false;
+    activeTypes.push_back(&recoveredType);
+    for (const auto& member : recoveredType.as<ast::Scope>().members()) {
+        auto* field = member.as_if<ast::FieldSymbol>();
+        if (!field || !field->getType().isError())
+            continue;
+
+        if (!collectIncompleteSubtypes(field->getType(), subtypes, seenTypes, activeTypes)) {
+            std::string typeText = "Incomplete type";
+            SourceLocation typeLocation = field->location;
+            if (auto* fieldSyntax = field->getSyntax()) {
+                if (auto* declarator = fieldSyntax->as_if<syntax::DeclaratorSyntax>()) {
+                    if (auto* memberSyntax =
+                            declarator->parent->as_if<syntax::StructUnionMemberSyntax>()) {
+                        typeText = detailFormat(*memberSyntax->type);
+                        typeLocation = memberSyntax->type->getFirstToken().location();
+                    }
+                }
+            }
+            if (field->getType().kind == ast::SymbolKind::TypeAlias)
+                typeLocation = field->getType().location;
+            if (seenTypes.insert(&field->getType()).second)
+                subtypes.emplace_back(std::move(typeText), typeLocation);
+        }
+        found = true;
+    }
+    activeTypes.pop_back();
+    return found;
+}
+
+void renderIncompleteSubtypes(markup::Paragraph& infoPg, const ast::Type& type,
+                              const SourceManager& sourceManager) {
+    if (!type.isError())
+        return;
+
+    std::vector<IncompleteSubtype> subtypes;
+    SmallSet<const ast::Type*, 8> seenTypes;
+    std::vector<const ast::Type*> activeTypes;
+    collectIncompleteSubtypes(type, subtypes, seenTypes, activeTypes);
+    if (subtypes.empty())
+        return;
+
+    infoPg.appendText("Incomplete subtypes: ");
+    for (size_t i = 0; i < subtypes.size(); i++) {
+        if (i > 0)
+            infoPg.appendText(", ");
+        appendSourceLink(infoPg, subtypes[i].location, sourceManager, subtypes[i].type);
+    }
+    infoPg.newLine();
 }
 
 void renderSymbolType(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
@@ -291,7 +364,7 @@ const syntax::SyntaxNode* getDriverDisplayNode(const analysis::ValueDriver& driv
 }
 
 void appendSourceLink(markup::Paragraph& paragraph, SourceLocation location,
-                      const SourceManager& sourceManager) {
+                      const SourceManager& sourceManager, std::string_view label) {
     const auto originalLoc = sourceManager.getFullyOriginalLoc(location);
     if (!sourceManager.isFileLoc(originalLoc))
         return;
@@ -302,9 +375,13 @@ void appendSourceLink(markup::Paragraph& paragraph, SourceLocation location,
 
     const auto line = sourceManager.getRawLineNumber(originalLoc);
     const auto column = sourceManager.getColumnNumber(originalLoc);
-    const auto label = fmt::format("{}:{}:{}", path.filename().string(), line, column);
+    const auto linkLabel = label.empty()
+                               ? fmt::format("{}:{}:{}", path.filename().string(), line, column)
+                               : fmt::format("`{}`", label);
     const auto target = fmt::format("{}#L{},{}", URI::fromFile(path), line, column);
-    paragraph.appendText(" at ").appendText(fmt::format("[{}](<{}>)", label, target));
+    if (label.empty())
+        paragraph.appendText(" at ");
+    paragraph.appendText(fmt::format("[{}](<{}>)", linkLabel, target));
 }
 
 void renderDrivers(markup::Document& doc, const ast::Symbol& symbol, ShallowAnalysis& analysis,
@@ -408,7 +485,8 @@ void renderDrivers(markup::Document& doc, const ast::Symbol& symbol, ShallowAnal
                       renderedGroupSyntaxes);
 }
 
-void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
+void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol,
+                       const SourceManager& sourceManager) {
     auto appendTypeParameterValue = [&](const ast::Type& type) {
         if (!type.isError()) {
             infoPg.appendText("Value: ").appendText(getHoverTypeString(type)).newLine();
@@ -436,10 +514,13 @@ void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol) {
     }
     else if (ast::Type::isKind(symbol.kind)) {
         auto& type = symbol.as<ast::Type>();
-        if (!type.isError()) {
+        if (!unwrapErrorType(type).isError()) {
             auto typeString = getHoverTypeString(type);
             infoPg.appendText("Resolved Type: ").appendText(typeString).newLine();
-            if (type.getBitWidth() > 0) {
+            if (type.isError()) {
+                renderIncompleteSubtypes(infoPg, type, sourceManager);
+            }
+            else if (type.getBitWidth() > 0) {
                 infoPg.appendText("Resolved Width: ")
                     .appendCode(fmt::format("{}", type.getBitWidth()))
                     .newLine();
@@ -529,7 +610,7 @@ RenderedSymbolHover renderSymbolHover(const DefinitionInfo::SymbolTarget& target
             .appendCode(fmt::format("{}", target.generatedSignalCount))
             .newLine();
     }
-    renderSymbolValue(result.value, *target.symbol);
+    renderSymbolValue(result.value, *target.symbol, sm);
     renderSymbolSyntaxes(result.syntaxes, target, sm, hovers);
     renderDrivers(result.drivers, getDriverSymbol(target), *target.analysis, sm,
                   target.renderInputPortDriver, followPortDriver);

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -217,13 +217,13 @@ const ast::Scope* ShallowAnalysis::getScopeFromSym(const ast::Symbol* symbol) co
     }
 
     if (symbol->isType()) {
-        auto& type = symbol->as<ast::Type>().getCanonicalType();
+        auto& type = unwrapErrorType(symbol->as<ast::Type>());
         if (type.isScope()) {
             return &type.as<ast::Scope>();
         }
     }
     else if (ast::ValueSymbol::isKind(symbol->kind)) {
-        auto& type = symbol->as<ast::ValueSymbol>().getType().getCanonicalType();
+        auto& type = unwrapErrorType(symbol->as<ast::ValueSymbol>().getType());
         if (type.isScope()) {
             return &type.as<ast::Scope>();
         }

--- a/src/util/Formatting.cpp
+++ b/src/util/Formatting.cpp
@@ -6,6 +6,7 @@
 #include "Config.h"
 #include "lsp/LspTypes.h"
 #include "util/Markdown.h"
+#include "util/SlangExtensions.h"
 #include <cctype>
 #include <fmt/format.h>
 #include <sstream>
@@ -493,7 +494,8 @@ std::string toCamelCase(std::string_view str) {
 
 template<bool ForHover>
 std::string getTypeStringImpl(const ast::Type& declType) {
-    if (declType.isError()) {
+    auto& type = unwrapErrorType(declType);
+    if (type.isError()) {
         return "Incomplete type";
     }
 
@@ -506,9 +508,7 @@ std::string getTypeStringImpl(const ast::Type& declType) {
     printer.options.skipTypeDefs = true;
     printer.options.printAKA = true;
     printer.options.printIntegralRange = true;
-    printer.append(declType);
-
-    auto& type = declType.getCanonicalType();
+    printer.append(declType.kind == ast::SymbolKind::ErrorType ? type : declType);
 
     if (type.isStruct() || type.isUnion() || type.isEnum()) {
         auto kindStr = toString(type.kind);

--- a/src/util/SlangExtensions.cpp
+++ b/src/util/SlangExtensions.cpp
@@ -8,6 +8,8 @@
 
 #include "util/SlangExtensions.h"
 
+#include "slang/ast/types/AllTypes.h"
+
 namespace server {
 
 using namespace slang;
@@ -25,6 +27,15 @@ bool hasValidBuffers(const SourceManager& sm, const std::shared_ptr<syntax::Synt
     }
 
     return true;
+}
+
+const ast::Type& unwrapErrorType(const ast::Type& type) {
+    auto& canonicalType = type.getCanonicalType();
+    if (canonicalType.kind == ast::SymbolKind::ErrorType) {
+        if (auto* child = canonicalType.as<ast::ErrorType>().child)
+            return child->getCanonicalType();
+    }
+    return canonicalType;
 }
 
 } // namespace server

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -1047,6 +1047,67 @@ TEST_CASE("HierarchicalInterfacePortArrayCompletionWithUnresolvedBounds") {
     CHECK(definitions[1].targetSelectionRange.start.line == 7);
 }
 
+TEST_CASE("HierarchicalStructCompletionWithUnresolvedWidth") {
+    ServerHarness server("comp_repo");
+    auto doc = server.openFile("unused_mod.sv");
+
+    auto findCompletion = [](auto& items, std::string_view label) {
+        return std::ranges::find(items, label,
+                                 [](const CompletionHandle& item) { return item.m_item.label; });
+    };
+
+    auto rootMembers = doc.after("partial_value.").getCompletions(".");
+    CHECK(findCompletion(rootMembers, "middle") != rootMembers.end());
+    CHECK(findCompletion(rootMembers, "root_known") != rootMembers.end());
+
+    auto middleMembers = doc.after("partial_value.middle.").getCompletions(".");
+    CHECK(findCompletion(middleMembers, "leaf") != middleMembers.end());
+    CHECK(findCompletion(middleMembers, "middle_known") != middleMembers.end());
+
+    auto leafMembers = doc.after("partial_value.middle.leaf.").getCompletions(".");
+    CHECK(findCompletion(leafMembers, "variable_width") != leafMembers.end());
+    auto knownCompletion = findCompletion(leafMembers, "known");
+    REQUIRE(knownCompletion != leafMembers.end());
+    knownCompletion->resolve();
+    CHECK(knownCompletion->m_item.documentation);
+
+    auto middleUse = doc.before("middle.leaf.known");
+    auto middleHover = doc.getHoverAt(middleUse.m_offset);
+    REQUIRE(middleHover);
+    auto middleContent = rfl::get<lsp::MarkupContent>(middleHover->contents).value;
+    CHECK(middleContent.find("**Field** `middle`") != std::string::npos);
+    CHECK(middleContent.find("Type:") != std::string::npos);
+    CHECK(middleContent.find("middle_t") != std::string::npos);
+    CHECK(middleContent.find("PackedStruct") != std::string::npos);
+    CHECK(middleContent.find("Incomplete subtypes:") == std::string::npos);
+    CHECK(middleContent.find("Incomplete type") == std::string::npos);
+
+    auto rootTypeUse = doc.before("root_t partial_value");
+    auto rootTypeHover = doc.getHoverAt(rootTypeUse.m_offset);
+    REQUIRE(rootTypeHover);
+    auto rootTypeContent = rfl::get<lsp::MarkupContent>(rootTypeHover->contents).value;
+    CHECK(rootTypeContent.find("**TypeAlias** `root_t`") != std::string::npos);
+    CHECK(rootTypeContent.find("Resolved Type: PackedStruct `root_t`") != std::string::npos);
+    CHECK(rootTypeContent.find("Incomplete subtypes: [`variable_width_t`](<file:") !=
+          std::string::npos);
+    CHECK(rootTypeContent.find("unused_mod.sv#L72,45") != std::string::npos);
+    auto subtypeLineStart = rootTypeContent.find("Incomplete subtypes:");
+    REQUIRE(subtypeLineStart != std::string::npos);
+    auto subtypeLineEnd = rootTypeContent.find('\n', subtypeLineStart);
+    auto subtypeLine = rootTypeContent.substr(subtypeLineStart, subtypeLineEnd - subtypeLineStart);
+    auto firstSubtype = subtypeLine.find("variable_width_t");
+    REQUIRE(firstSubtype != std::string::npos);
+    CHECK(subtypeLine.find("variable_width_t", firstSubtype + 1) == std::string::npos);
+    CHECK(rootTypeContent.find("middle.leaf.variable_width") == std::string::npos);
+
+    auto knownUse = doc.before("leaf.known").after("leaf.");
+    auto knownHover = doc.getHoverAt(knownUse.m_offset);
+    REQUIRE(knownHover);
+    auto knownContent = rfl::get<lsp::MarkupContent>(knownHover->contents).value;
+    CHECK(knownContent.find("**Field** `known`") != std::string::npos);
+    CHECK(knownContent.find("Type: `logic`") != std::string::npos);
+}
+
 TEST_CASE("HierarchicalStructCompletion") {
     ServerHarness server("repo1");
     JsonGoldenTest golden;

--- a/tests/cpp/golden/CompletionCoverageCompRepo/unused_mod.out.sv
+++ b/tests/cpp/golden/CompletionCoverageCompRepo/unused_mod.out.sv
@@ -93,6 +93,28 @@ module unused_mod
     endgenerate
 
     initial begin
+        typedef logic [unknown_width - 1:0] variable_width_t;
+
+        typedef struct packed {
+            variable_width_t variable_width;
+            variable_width_t second_variable_width;
+            logic known;
+        } leaf_t;
+
+        typedef struct packed {
+            leaf_t leaf;
+            logic middle_known;
+        } middle_t;
+
+        typedef struct packed {
+            middle_t middle;
+            logic root_known;
+        } root_t;
+
+        root_t partial_value;
+
         $display("This module is not instantiated");
+        partial_value.root_known = partial_value.middle.middle_known;
+        partial_value.middle.leaf.known = partial_value.middle.leaf.variable_width[0];
     end
 endmodule

--- a/tests/data/comp_repo/unused_mod.sv
+++ b/tests/data/comp_repo/unused_mod.sv
@@ -69,6 +69,28 @@ module unused_mod
     endgenerate
 
     initial begin
+        typedef logic [unknown_width - 1:0] variable_width_t;
+
+        typedef struct packed {
+            variable_width_t variable_width;
+            variable_width_t second_variable_width;
+            logic known;
+        } leaf_t;
+
+        typedef struct packed {
+            leaf_t leaf;
+            logic middle_known;
+        } middle_t;
+
+        typedef struct packed {
+            middle_t middle;
+            logic root_known;
+        } root_t;
+
+        root_t partial_value;
+
         $display("This module is not instantiated");
+        partial_value.root_known = partial_value.middle.middle_known;
+        partial_value.middle.leaf.known = partial_value.middle.leaf.variable_width[0];
     end
 endmodule


### PR DESCRIPTION
Modifies slang to store incomplete types in ErrorType, similar to InvalidExpressions.

Now we don't need all the fields in a struct resolved to supply hovers/gotos/completions for struct fields.
A common example is a parameter is unset and then used in a struct.