### PR TITLE
Build: Give SyntaxTarget an explicit ctor for GCC 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,9 +83,7 @@ jobs:
             preset: gcc-release
             os: ubuntu-24.04
             skip_upload: true
-          # Explicit GCC 13 coverage: gcc-release presets g++-14, so without this
-          # job we would not catch nested-class / std::variant default-init bugs
-          # that only fail on GCC 13 (see #407).
+          # gcc-release pins g++-14; keep explicit GCC 13 coverage (#407).
           - name: linux-x64-ubuntu-24.04-gcc-13
             preset: gcc-release
             os: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,16 @@ jobs:
             preset: gcc-release
             os: ubuntu-24.04
             skip_upload: true
+          # Explicit GCC 13 coverage: gcc-release presets g++-14, so without this
+          # job we would not catch nested-class / std::variant default-init bugs
+          # that only fail on GCC 13 (see #407).
+          - name: linux-x64-ubuntu-24.04-gcc-13
+            preset: gcc-release
+            os: ubuntu-24.04
+            cmake_args: -DCMAKE_CXX_COMPILER=g++-13
+            skip_pytests: true
+            skip_neovim_tests: true
+            skip_upload: true
           - name: macos
             preset: macos-release
             os: macos-15
@@ -115,6 +125,11 @@ jobs:
           sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main"
           sudo apt-get update
           sudo apt-get install -y clang-21
+      - name: Install GCC 13 (Ubuntu)
+        if: contains(matrix.name, 'gcc-13')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-13
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}

--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -44,8 +44,6 @@ struct DefinitionInfo {
         // Optional original source range; exists if it's behind a macro expansion.
         slang::SourceRange macroUsageRange;
 
-        // Don't default-init macroUsageRange in-class: GCC 13 can't see that initializer when
-        // SyntaxTarget is used in a std::variant of the enclosing type.
         SyntaxTarget(const slang::syntax::SyntaxNode* node, slang::parsing::Token nameToken,
                      slang::SourceRange macroUsageRange = slang::SourceRange::NoLocation) :
             node(node), nameToken(nameToken), macroUsageRange(macroUsageRange) {}

--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -42,7 +42,14 @@ struct DefinitionInfo {
         // found.
         slang::parsing::Token nameToken;
         // Optional original source range; exists if it's behind a macro expansion.
-        slang::SourceRange macroUsageRange = slang::SourceRange::NoLocation;
+        slang::SourceRange macroUsageRange;
+
+        // Don't default-init macroUsageRange in-class: GCC 13 can't see that initializer when
+        // SyntaxTarget is used in a std::variant of the enclosing type.
+        SyntaxTarget(const slang::syntax::SyntaxNode* node, slang::parsing::Token nameToken,
+                     slang::SourceRange macroUsageRange = slang::SourceRange::NoLocation) :
+            node(node), nameToken(nameToken), macroUsageRange(macroUsageRange) {}
+        SyntaxTarget() : SyntaxTarget(nullptr, {}, slang::SourceRange::NoLocation) {}
 
         bool operator==(const SyntaxTarget& other) const {
             return node == other.node && nameToken.location() == other.nameToken.location() &&


### PR DESCRIPTION
## Summary
- Fixes #407: GCC 13 rejects the in-class default for `SyntaxTarget::macroUsageRange` when the nested class is a `std::variant` alternative of the enclosing type. Move that default onto an explicit constructor.
- Adds an Ubuntu `g++-13` CI job. The existing `gcc-release` preset pins `g++-14`, so that matrix entry never exercised the failure mode from the issue.

## Notes
- Split out of closed #480 per review feedback. Leaving #428 to the focused-instance work.

## Test plan
- [ ] `linux-x64-ubuntu-24.04-gcc-13` CI job passes (build + ctest)
- [ ] Existing GCC/Clang CI jobs still pass


Made with [Cursor](https://cursor.com)