### PR TITLE
Add features around struct assignment patterns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ add_library(
   src/codeactions/AddDefine.cpp
   src/codeactions/CodeActionDispatch.cpp
   src/codeactions/ExpandMacro.cpp
+  src/completions/AssignmentPatternCompletions.cpp
   src/completions/CompletionContext.cpp
   src/completions/CompletionDispatch.cpp
   src/completions/InstanceCompletions.cpp

--- a/clients/vscode/resources/config.schema.json
+++ b/clients/vscode/resources/config.schema.json
@@ -186,6 +186,10 @@
           "description": "Hints for port types",
           "type": "boolean"
         },
+        "assignmentPatternTypes": {
+          "description": "Hints for inferred assignment pattern types",
+          "type": "boolean"
+        },
         "orderedInstanceNames": {
           "description": "Hints for names of ordered ports and params",
           "type": "boolean"

--- a/clients/vscode/src/config.gen.ts
+++ b/clients/vscode/src/config.gen.ts
@@ -64,6 +64,8 @@ export interface Config__IndexConfig {
 export interface Config__InlayHints {
   /** Hints for port types */
   portTypes?: boolean
+  /** Hints for inferred assignment pattern types */
+  assignmentPatternTypes?: boolean
   /** Hints for names of ordered ports and params */
   orderedInstanceNames?: boolean
   /** Hints for port names in wildcard (.*) ports */

--- a/docs/start/config.md
+++ b/docs/start/config.md
@@ -171,6 +171,8 @@ All configuration options are optional and have sensible defaults. In VSCode, th
     interface InlayHints {
       /** Hints for port types */
       portTypes?: boolean           // default: false
+      /** Hints for inferred assignment pattern types */
+      assignmentPatternTypes?: boolean // default: true
       /** Hints for names of ordered ports and params */
       orderedInstanceNames?: boolean // default: true
       /** Hints for port names in wildcard (.*) ports */
@@ -185,6 +187,7 @@ All configuration options are optional and have sensible defaults. In VSCode, th
     Controls inline hints displayed in the editor for things like ordered arguments, wildcard ports, and others.
 
     - **`portTypes`**: Show type hints on ports. Off by default.
+    - **`assignmentPatternTypes`**: Show the inferred struct or union type before untyped assignment patterns.
     - **`orderedInstanceNames`**: Show parameter/port name hints on ordered (positional) instance connections.
     - **`wildcardNames`**: Show port name hints on wildcard (`.*`) connections.
     - **`funcArgNames`**: Show argument name hints on function calls. Set to `0` to disable, or `N` to only show hints for calls with N or more arguments.

--- a/include/Config.h
+++ b/include/Config.h
@@ -102,6 +102,8 @@ struct Config {
 
     struct InlayHints {
         rfl::Description<"Hints for port types", bool> portTypes = false;
+        rfl::Description<"Hints for inferred assignment pattern types", bool>
+            assignmentPatternTypes = true;
         rfl::Description<"Hints for names of ordered ports and params", bool> orderedInstanceNames =
             true;
         rfl::Description<"Hints for port names in wildcard (.*) ports", bool> wildcardNames = true;

--- a/include/completions/AssignmentPatternCompletions.h
+++ b/include/completions/AssignmentPatternCompletions.h
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+// AssignmentPatternCompletions.h
+// Assignment pattern completions.
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include "completions/MemberCompletions.h"
+#include <memory>
+
+namespace server::completions {
+
+/// Query for the whole-struct snippet offered when an assignment pattern is opened.
+class StructAssignCompletionQuery : public CompletionQuery {
+public:
+    static std::unique_ptr<CompletionQuery> create(lsp::Range replacementRange,
+                                                   slang::SourceLocation cursor);
+
+protected:
+    using CompletionQuery::CompletionQuery;
+};
+
+/// Query for individual assignment pattern key completions.
+class StructMemberCompletionQuery : public MemberCompletionQuery {
+public:
+    static std::unique_ptr<CompletionQuery> create(lsp::Range replacementRange,
+                                                   slang::SourceLocation cursor,
+                                                   bool followedByColon);
+
+protected:
+    using MemberCompletionQuery::MemberCompletionQuery;
+};
+
+} // namespace server::completions

--- a/include/completions/CompletionContext.h
+++ b/include/completions/CompletionContext.h
@@ -44,8 +44,9 @@ class ShallowAnalysis;
 SLANG_ENUM(CompletionContextKind, CCK)
 #undef CCK
 
-#define CQK(x) \
-    x(Lexical) x(MemberAccess) x(ScopedAccess) x(Macro) x(SystemSubroutine) x(InstantiationSuffix)
+#define CQK(x)                                                                          \
+    x(Lexical) x(MemberAccess) x(ScopedAccess) x(StructAssign) x(StructMember) x(Macro) \
+        x(SystemSubroutine) x(InstantiationSuffix)
 SLANG_ENUM(CompletionQueryKind, CQK)
 #undef CQK
 
@@ -65,10 +66,10 @@ public:
     /// Apply the query's replacement range and existing-source shape to a completion item.
     void setCompletionEdit(lsp::CompletionItem& item) const;
 
-    /// Create the appropriate query from the lexer tokens surrounding the cursor.
+    /// Create the appropriate query from the request context and tokens surrounding the cursor.
     static std::unique_ptr<CompletionQuery> fromLocation(
         const SlangDoc& doc, const std::shared_ptr<ShallowAnalysis>& analysis,
-        slang::SourceLocation cursor);
+        slang::SourceLocation cursor, const lsp::CompletionContext& lspContext);
 
 protected:
     CompletionQuery(lsp::Range replacementRange, bool followedByCall = false,

--- a/include/document/InlayHintCollector.h
+++ b/include/document/InlayHintCollector.h
@@ -43,6 +43,7 @@ private:
 
     // Cached config values
     bool m_portTypes;
+    bool m_assignmentPatternTypes;
     bool m_orderedInstanceNames;
     bool m_wildcardNames;
     int m_funcArgNames;
@@ -59,6 +60,8 @@ private:
     void handle(const slang::syntax::MacroUsageSyntax& syntax);
 
     void handle(const slang::syntax::ClassNameSyntax& syntax);
+
+    void handle(const slang::syntax::AssignmentPatternExpressionSyntax& syntax);
 };
 
 } // namespace server

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -149,6 +149,12 @@ public:
     /// @return Pointer to the scope, or nullptr if the symbol doesn't have an accessible scope
     const slang::ast::Scope* getScopeFromSym(const slang::ast::Symbol* symbol) const;
 
+    /// Gets the target struct scope when the location is an assignment pattern key.
+    const slang::ast::Scope* getAssignmentPatternKeyScope(slang::SourceLocation loc) const;
+
+    /// Gets the target struct scope at a possible assignment pattern key completion site.
+    const slang::ast::Scope* getAssignmentPatternCompletionScope(slang::SourceLocation loc) const;
+
     std::vector<lsp::InlayHint> getInlayHints(lsp::Range range,
                                               const struct Config::InlayHints& config);
 
@@ -209,6 +215,15 @@ private:
         m_interfaceFallbackScopes;
 
     const GenvarElaboration* getGenvarElaborationAtToken(const slang::parsing::Token* node) const;
+
+    const slang::ast::Symbol* getAssignmentPatternTargetSymbol(
+        const slang::syntax::AssignmentPatternExpressionSyntax& pattern) const;
+
+    const slang::ast::Scope* getAssignmentPatternTargetScope(
+        const slang::syntax::AssignmentPatternExpressionSyntax& pattern) const;
+
+    const slang::ast::Scope* getAssignmentPatternScopeAt(slang::SourceLocation loc,
+                                                         bool allowIncompleteKey) const;
 
     /// @brief Helper method to check if a token is positioned over a selector
     bool isOverSelector(const slang::parsing::Token* node,

--- a/src/completions/AssignmentPatternCompletions.cpp
+++ b/src/completions/AssignmentPatternCompletions.cpp
@@ -1,0 +1,280 @@
+//------------------------------------------------------------------------------
+// AssignmentPatternCompletions.cpp
+// Assignment pattern completions.
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+
+#include "completions/AssignmentPatternCompletions.h"
+
+#include "completions/MemberCompletions.h"
+#include "document/ShallowAnalysis.h"
+#include "document/SlangDoc.h"
+#include "lsp/SnippetString.h"
+#include "util/Converters.h"
+#include "util/SlangExtensions.h"
+#include <unordered_set>
+
+#include "slang/ast/types/AllTypes.h"
+#include "slang/parsing/TokenKind.h"
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxFacts.h"
+
+namespace server::completions {
+using namespace slang;
+
+namespace {
+
+const syntax::AssignmentPatternExpressionSyntax* findPatternExpression(
+    const CompletionContext& context, SourceLocation cursor) {
+    auto* syntax = context.analysis->syntaxes.getSyntaxAt(cursor);
+    if (!syntax) {
+        auto* previous = context.analysis->syntaxes.getTokenBefore(cursor);
+        syntax = context.analysis->syntaxes.getTokenParent(previous);
+    }
+    for (; syntax; syntax = syntax->parent) {
+        if (auto* expression = syntax->as_if<syntax::AssignmentPatternExpressionSyntax>())
+            return expression;
+    }
+    return nullptr;
+}
+
+class StructAssignCompletionQueryImpl final : public StructAssignCompletionQuery {
+public:
+    StructAssignCompletionQueryImpl(lsp::Range replacementRange, SourceLocation cursor) :
+        StructAssignCompletionQuery(replacementRange), cursor(cursor) {}
+
+    CompletionQueryKind kind() const final { return CompletionQueryKind::StructAssign; }
+
+    void getCompletions(std::vector<lsp::CompletionItem>& results, CompletionDispatch&,
+                        const std::shared_ptr<SlangDoc>&,
+                        const CompletionContext& context) const final {
+        auto* targetScope = context.analysis->getAssignmentPatternCompletionScope(cursor);
+        if (!targetScope)
+            return;
+
+        auto* patternExpression = findPatternExpression(context, cursor);
+        if (!patternExpression)
+            return;
+        auto* simplePattern =
+            patternExpression->pattern->as_if<syntax::SimpleAssignmentPatternSyntax>();
+        if (!simplePattern || !std::ranges::all_of(simplePattern->items, [](const auto* item) {
+                return item->getFirstToken().isMissing();
+            })) {
+            return;
+        }
+
+        auto* targetType = targetScope->asSymbol().as_if<ast::Type>();
+        if (!targetType || !unwrapErrorType(*targetType).isStruct())
+            return;
+
+        SnippetString snippet;
+        auto& sourceManager = context.analysis->getSourceManager();
+        auto position = toPosition(cursor, sourceManager);
+        snippet.appendText("\n\t");
+
+        // Preserve delimiters absorbed by the parser while the pattern is incomplete.
+        auto needsComma = [&]() {
+            auto* item =
+                patternExpression->parent
+                    ? patternExpression->parent->as_if<syntax::AssignmentPatternItemSyntax>()
+                    : nullptr;
+            auto* outerPattern =
+                item && item->parent
+                    ? item->parent->as_if<syntax::StructuredAssignmentPatternSyntax>()
+                    : nullptr;
+            return item && item->expr.get() == patternExpression && outerPattern &&
+                   outerPattern->closeBrace.isMissing();
+        }();
+        auto needsSemicolon = [&]() {
+            auto* parent = patternExpression->parent.get();
+            if (!parent)
+                return false;
+            if (auto* assignment = parent->as_if<syntax::BinaryExpressionSyntax>();
+                assignment && assignment->right.get() == patternExpression &&
+                syntax::SyntaxFacts::isAssignmentOperator(assignment->kind)) {
+                parent = assignment->parent.get();
+                if (!parent)
+                    return false;
+                if (auto* continuous = parent->as_if<syntax::ContinuousAssignSyntax>())
+                    return continuous->semi.isMissing();
+                if (auto* statement = parent->as_if<syntax::ExpressionStatementSyntax>())
+                    return statement->semi.isMissing();
+                return false;
+            }
+
+            auto* value = parent->as_if<syntax::EqualsValueClauseSyntax>();
+            if (!value || value->expr.get() != patternExpression || !value->parent)
+                return false;
+            auto* declarator = value->parent->as_if<syntax::DeclaratorSyntax>();
+            if (!declarator || !declarator->parent)
+                return false;
+            parent = declarator->parent.get();
+            if (auto* declaration = parent->as_if<syntax::DataDeclarationSyntax>())
+                return declaration->semi.isMissing();
+            if (auto* declaration = parent->as_if<syntax::NetDeclarationSyntax>())
+                return declaration->semi.isMissing();
+            if (auto* declaration = parent->as_if<syntax::LocalVariableDeclarationSyntax>())
+                return declaration->semi.isMissing();
+            return false;
+        }();
+        std::string_view trailingDelimiter;
+        if (needsComma)
+            trailingDelimiter = ",";
+        else if (needsSemicolon)
+            trailingDelimiter = ";";
+
+        bool first = true;
+        std::string label = "'{";
+        for (auto& member : targetScope->members()) {
+            if (!ast::FieldSymbol::isKind(member.kind) || member.name.empty())
+                continue;
+            if (!first) {
+                snippet.appendText(",\n\t");
+                label += ", ";
+            }
+            first = false;
+            snippet.appendText(member.name).appendText(": ").appendTabstop();
+            label += member.name;
+        }
+        if (first)
+            return;
+        label += "}";
+
+        auto closeBraceMissing = simplePattern->closeBrace.isMissing();
+        if (closeBraceMissing ||
+            toPosition(simplePattern->closeBrace.location(), sourceManager).line == position.line) {
+            snippet.appendText("\n");
+            if (closeBraceMissing) {
+                snippet.appendText("}");
+                snippet.appendText(trailingDelimiter);
+            }
+        }
+        lsp::CompletionItem item{
+            .label = label,
+            .kind = lsp::CompletionItemKind::Snippet,
+            .sortText = "0",
+            .filterText = label,
+            .insertText = std::string(snippet.getValue()),
+            .insertTextFormat = lsp::InsertTextFormat::Snippet,
+            .insertTextMode = lsp::InsertTextMode::adjustIndentation,
+        };
+        auto* tokenAfterClose = closeBraceMissing ? nullptr
+                                                  : context.analysis->syntaxes.getTokenAfter(
+                                                        simplePattern->closeBrace.range().end());
+        auto hasTrailingDelimiter =
+            tokenAfterClose && !tokenAfterClose->isMissing() &&
+            ((trailingDelimiter == "," && tokenAfterClose->kind == parsing::TokenKind::Comma) ||
+             (trailingDelimiter == ";" && tokenAfterClose->kind == parsing::TokenKind::Semicolon));
+        if (!trailingDelimiter.empty() && !closeBraceMissing && !hasTrailingDelimiter) {
+            auto insertPosition = toPosition(simplePattern->closeBrace.range().end(),
+                                             sourceManager);
+            item.additionalTextEdits = std::vector<lsp::TextEdit>{lsp::TextEdit{
+                .range = lsp::Range{.start = insertPosition, .end = insertPosition},
+                .newText = std::string(trailingDelimiter),
+            }};
+        }
+        results.push_back(std::move(item));
+    }
+
+private:
+    SourceLocation cursor;
+};
+
+class StructMemberCompletionQueryImpl final : public StructMemberCompletionQuery {
+public:
+    StructMemberCompletionQueryImpl(lsp::Range replacementRange, SourceLocation cursor,
+                                    bool followedByColon) :
+        StructMemberCompletionQuery(replacementRange), cursor(cursor),
+        followedByColon(followedByColon) {}
+
+    CompletionQueryKind kind() const final { return CompletionQueryKind::StructMember; }
+
+    void getCompletions(std::vector<lsp::CompletionItem>& results, CompletionDispatch& dispatch,
+                        const std::shared_ptr<SlangDoc>& doc,
+                        const CompletionContext& context) const final {
+        auto* targetScope = context.analysis->getAssignmentPatternCompletionScope(cursor);
+        if (!targetScope)
+            return;
+
+        auto* patternExpression = findPatternExpression(context, cursor);
+
+        // Avoid suggesting keys already present elsewhere in a structured pattern.
+        std::unordered_set<std::string_view> existingFields;
+        bool hasDefault = false;
+        if (patternExpression) {
+            if (auto* pattern = patternExpression->pattern
+                                    ->as_if<syntax::StructuredAssignmentPatternSyntax>()) {
+                for (auto* item : pattern->items) {
+                    auto range = item->key->sourceRange();
+                    if (range.start() <= cursor && cursor <= range.end())
+                        continue;
+
+                    if (item->key->kind == syntax::SyntaxKind::DefaultPatternKeyExpression) {
+                        hasDefault = true;
+                        continue;
+                    }
+
+                    auto* key = item->key->as_if<syntax::IdentifierNameSyntax>();
+                    if (!key || key->identifier.isMissing())
+                        continue;
+                    existingFields.emplace(key->identifier.valueText());
+                }
+            }
+        }
+
+        for (auto& member : targetScope->members()) {
+            if (!ast::FieldSymbol::isKind(member.kind) || member.name.empty() ||
+                existingFields.contains(member.name)) {
+                continue;
+            }
+
+            auto item = getHierarchicalCompletion(targetScope->asSymbol(), member,
+                                                  doc->getURI().str(), false,
+                                                  resolvesCompletionEdits(dispatch));
+            item.kind = lsp::CompletionItemKind::Field;
+            if (!followedByColon) {
+                SnippetString snippet;
+                snippet.appendText(member.name).appendText(": ").appendTabstop();
+                item.insertText = snippet.getValue();
+                item.insertTextFormat = lsp::InsertTextFormat::Snippet;
+            }
+            results.push_back(std::move(item));
+        }
+
+        if (!hasDefault) {
+            lsp::CompletionItem item{
+                .label = "default",
+                .kind = lsp::CompletionItemKind::Keyword,
+            };
+            if (!followedByColon) {
+                SnippetString snippet;
+                snippet.appendText("default: ").appendTabstop();
+                item.insertText = snippet.getValue();
+                item.insertTextFormat = lsp::InsertTextFormat::Snippet;
+            }
+            results.push_back(std::move(item));
+        }
+    }
+
+private:
+    SourceLocation cursor;
+    bool followedByColon;
+};
+
+} // namespace
+
+std::unique_ptr<CompletionQuery> StructAssignCompletionQuery::create(lsp::Range replacementRange,
+                                                                     SourceLocation cursor) {
+    return std::make_unique<StructAssignCompletionQueryImpl>(std::move(replacementRange), cursor);
+}
+
+std::unique_ptr<CompletionQuery> StructMemberCompletionQuery::create(lsp::Range replacementRange,
+                                                                     SourceLocation cursor,
+                                                                     bool followedByColon) {
+    return std::make_unique<StructMemberCompletionQueryImpl>(std::move(replacementRange), cursor,
+                                                             followedByColon);
+}
+
+} // namespace server::completions

--- a/src/completions/CompletionContext.cpp
+++ b/src/completions/CompletionContext.cpp
@@ -117,7 +117,7 @@ CompletionContext CompletionContext::fromLocation(SlangDoc& doc, SourceLocation 
     ctx.analysis = doc.getAnalysis();
     ctx.scope = ctx.analysis->getScopeAt(loc);
     ctx.syntax = ctx.analysis->syntaxes.getSyntaxAt(loc);
-    ctx.query = CompletionQuery::fromLocation(doc, ctx.analysis, loc);
+    ctx.query = CompletionQuery::fromLocation(doc, ctx.analysis, loc, ctx.lspContext);
 
     if (!ctx.syntax) {
         // No syntax node at location - assume module item context if we have a scope

--- a/src/completions/CompletionDispatch.cpp
+++ b/src/completions/CompletionDispatch.cpp
@@ -8,6 +8,7 @@
 
 #include "completions/CompletionDispatch.h"
 
+#include "completions/AssignmentPatternCompletions.h"
 #include "completions/InstanceCompletions.h"
 #include "completions/MacroCompletions.h"
 #include "completions/MemberCompletions.h"
@@ -35,6 +36,7 @@ const std::vector<std::string>& completionTriggerCharacters() {
         ":", // package scope (::), wire width
         "[", // wire width, array indexing
         "$", // system tasks and functions
+        "{", // assignment patterns
     };
     return triggerCharacters;
 }
@@ -141,7 +143,7 @@ void setCompletionEdit(lsp::CompletionItem& item, const lsp::Range& replacementR
 
 std::unique_ptr<CompletionQuery> CompletionQuery::fromLocation(
     const SlangDoc& doc, const std::shared_ptr<ShallowAnalysis>& analysis,
-    slang::SourceLocation cursor) {
+    slang::SourceLocation cursor, const lsp::CompletionContext& lspContext) {
     using slang::parsing::TokenKind;
 
     auto site = getCompletionSite(doc, *analysis, cursor);
@@ -151,6 +153,7 @@ std::unique_ptr<CompletionQuery> CompletionQuery::fromLocation(
                                    isSeparatedOnlyByWhitespace(*site.tokenAfter) &&
                                    (site.tokenAfter->kind == TokenKind::Identifier ||
                                     site.tokenAfter->kind == TokenKind::Hash);
+    auto followedByColon = site.tokenAfter && site.tokenAfter->kind == TokenKind::Colon;
 
     if (site.targetToken && site.targetToken->rawText().starts_with('$')) {
         return completions::SystemSubroutineCompletionQuery::create(
@@ -175,6 +178,15 @@ std::unique_ptr<CompletionQuery> CompletionQuery::fromLocation(
         return completions::InstanceCompletionQuery::create(std::move(site.replacementRange),
                                                             analysis->syntaxes.getTokenBefore(
                                                                 site.tokenBefore->location()));
+    }
+    if (analysis->getAssignmentPatternCompletionScope(cursor)) {
+        if (lspContext.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter &&
+            lspContext.triggerCharacter == "{") {
+            return completions::StructAssignCompletionQuery::create(
+                std::move(site.replacementRange), cursor);
+        }
+        return completions::StructMemberCompletionQuery::create(std::move(site.replacementRange),
+                                                                cursor, followedByColon);
     }
 
     return completions::MemberCompletionQuery::createLexical(std::move(site.replacementRange),
@@ -225,6 +237,12 @@ void CompletionDispatch::getCompletions(std::vector<lsp::CompletionItem>& result
                                         std::shared_ptr<SlangDoc> doc,
                                         const CompletionContext& context) {
     SLANG_ASSERT(context.query);
+    if (context.lspContext.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter &&
+        context.lspContext.triggerCharacter == "{" &&
+        context.query->kind() != CompletionQueryKind::StructAssign) {
+        return;
+    }
+
     context.query->getCompletions(results, *this, doc, context);
 
     for (auto& item : results)

--- a/src/completions/MemberCompletions.cpp
+++ b/src/completions/MemberCompletions.cpp
@@ -15,7 +15,6 @@
 #include "lsp/LspTypes.h"
 #include "lsp/SnippetString.h"
 #include "lsp/URI.h"
-#include "util/Converters.h"
 #include "util/Formatting.h"
 #include "util/Logging.h"
 #include "util/SlangExtensions.h"

--- a/src/document/InlayHintCollector.cpp
+++ b/src/document/InlayHintCollector.cpp
@@ -8,6 +8,7 @@
 #include "util/Converters.h"
 #include "util/Formatting.h"
 #include "util/Logging.h"
+#include "util/SlangExtensions.h"
 
 #include "slang/ast/Symbol.h"
 #include "slang/ast/symbols/ClassSymbols.h"
@@ -37,6 +38,7 @@ static SourceLocation getArgumentHintLoc(const ArgumentSyntax& syntax,
 InlayHintCollector::InlayHintCollector(const ShallowAnalysis& analysis, lsp::Range range,
                                        const Config::InlayHints& config) :
     m_analysis(analysis), m_range(range), m_portTypes(config.portTypes.value()),
+    m_assignmentPatternTypes(config.assignmentPatternTypes.value()),
     m_orderedInstanceNames(config.orderedInstanceNames.value()),
     m_wildcardNames(config.wildcardNames.value()), m_funcArgNames(config.funcArgNames.value()),
     m_macroArgNames(config.macroArgNames.value()) {
@@ -357,6 +359,58 @@ void InlayHintCollector::handle(const ClassNameSyntax& syntax) {
     }
 }
 
+void InlayHintCollector::handle(const AssignmentPatternExpressionSyntax& syntax) {
+    if (!m_assignmentPatternTypes || syntax.type)
+        return;
+
+    auto* target = m_analysis.getAssignmentPatternTargetSymbol(syntax);
+    if (!target)
+        return;
+
+    const ast::Type* type = nullptr;
+    if (target->isType())
+        type = &target->as<ast::Type>();
+    else if (ast::ValueSymbol::isKind(target->kind))
+        type = &target->as<ast::ValueSymbol>().getType();
+    if (!type || (!unwrapErrorType(*type).isStruct() && !unwrapErrorType(*type).isUnion()))
+        return;
+
+    const ast::Symbol* namedType = nullptr;
+    if (auto* declaredType = target->getDeclaredType()) {
+        if (auto* typeSyntax = declaredType->getTypeSyntax()) {
+            auto* token = m_analysis.syntaxes.getTokenAt(typeSyntax->getLastToken().location());
+            namedType = m_analysis.getSymbolAtToken(token);
+        }
+    }
+    if (!namedType && !type->name.empty())
+        namedType = type;
+    if (!namedType || !namedType->isType() || namedType->name.empty())
+        return;
+
+    auto label = std::string(namedType->name);
+    if (auto* parent = namedType->getParentScope()) {
+        auto parentKind = parent->asSymbol().kind;
+        if (parentKind == ast::SymbolKind::Package || parentKind == ast::SymbolKind::ClassType)
+            label = namedType->getLexicalPath();
+    }
+
+    auto location = syntax.pattern->getFirstToken().location();
+    auto position = toPosition(location, m_analysis.m_sourceManager);
+    auto typeLocation = toLocation(SourceRange(namedType->location,
+                                               namedType->location + namedType->name.size()),
+                                   m_analysis.m_sourceManager);
+    result.push_back(lsp::InlayHint{
+        .position = position,
+        .label = std::vector<lsp::InlayHintLabelPart>{lsp::InlayHintLabelPart{
+            .value = label,
+            .location = std::move(typeLocation),
+        }},
+        .kind = lsp::InlayHintKind::Type,
+        .textEdits = std::vector<lsp::TextEdit>{lsp::TextEdit{
+            .range = lsp::Range{.start = position, .end = position}, .newText = std::move(label)}},
+    });
+}
+
 void InlayHintCollector::collectHints() {
 
     auto slangStart = toSourceLocation(m_analysis.m_buffer, m_range.start,
@@ -392,6 +446,10 @@ void InlayHintCollector::collectHints() {
                 break;
             case syntax::SyntaxKind::ClassName:
                 handle(it->second->as<ClassNameSyntax>());
+                break;
+            case syntax::SyntaxKind::AssignmentPatternExpression:
+                handle(it->second->as<AssignmentPatternExpressionSyntax>());
+                break;
             default:
                 break;
         }

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -35,6 +35,7 @@
 #include "slang/parsing/Token.h"
 #include "slang/parsing/TokenKind.h"
 #include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxFacts.h"
 #include "slang/syntax/SyntaxKind.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/SourceLocation.h"
@@ -274,6 +275,165 @@ const ast::Scope* ShallowAnalysis::getScopeFromSym(const ast::Symbol* symbol) co
     return nullptr;
 }
 
+const ast::Symbol* ShallowAnalysis::getAssignmentPatternTargetSymbol(
+    const syntax::AssignmentPatternExpressionSyntax& pattern) const {
+    auto getSymbolFromSyntax = [&](const syntax::SyntaxNode& target) {
+        auto* token = syntaxes.getTokenAt(target.getLastToken().location());
+        return getSymbolAtToken(token);
+    };
+
+    if (pattern.type)
+        return getSymbolFromSyntax(*pattern.type);
+
+    auto* parent = pattern.parent.get();
+    if (!parent)
+        return nullptr;
+
+    if (auto* assignment = parent->as_if<syntax::BinaryExpressionSyntax>();
+        assignment && assignment->right.get() == &pattern &&
+        syntax::SyntaxFacts::isAssignmentOperator(assignment->kind)) {
+        return getSymbolFromSyntax(*assignment->left);
+    }
+
+    if (auto* value = parent->as_if<syntax::EqualsValueClauseSyntax>();
+        value && value->expr.get() == &pattern && value->parent) {
+        if (auto* declarator = value->parent->as_if<syntax::DeclaratorSyntax>())
+            return getSymbolAtToken(&declarator->name);
+    }
+
+    if (auto* item = parent->as_if<syntax::AssignmentPatternItemSyntax>();
+        item && item->expr.get() == &pattern && item->parent && item->parent->parent) {
+        auto* outerPattern =
+            item->parent->parent->as_if<syntax::AssignmentPatternExpressionSyntax>();
+        if (!outerPattern)
+            return nullptr;
+
+        auto* outerTarget = getAssignmentPatternTargetSymbol(*outerPattern);
+        if (!outerTarget)
+            return nullptr;
+
+        const ast::Type* outerType = nullptr;
+        if (outerTarget->isType())
+            outerType = &outerTarget->as<ast::Type>();
+        else if (ast::ValueSymbol::isKind(outerTarget->kind))
+            outerType = &outerTarget->as<ast::ValueSymbol>().getType();
+
+        if (outerType) {
+            if (auto* elementType = unwrapErrorType(*outerType).getArrayElementType())
+                return elementType;
+        }
+
+        auto* key = item->key->as_if<syntax::IdentifierNameSyntax>();
+        if (!key)
+            return nullptr;
+        auto* outerScope = getScopeFromSym(outerTarget);
+        return outerScope ? outerScope->find(key->identifier.valueText()) : nullptr;
+    }
+
+    const syntax::SyntaxNode* node = parent;
+    if (auto* sequence = node->as_if<syntax::SimpleSequenceExprSyntax>();
+        sequence && sequence->expr.get() == &pattern) {
+        node = sequence->parent.get();
+    }
+    if (auto* property = node ? node->as_if<syntax::SimplePropertyExprSyntax>() : nullptr;
+        property && property->expr.get() == parent) {
+        node = property->parent.get();
+    }
+
+    auto* argument = node ? node->as_if<syntax::ArgumentSyntax>() : nullptr;
+    auto* arguments = argument && argument->parent
+                          ? argument->parent->as_if<syntax::ArgumentListSyntax>()
+                          : nullptr;
+    auto* invocation = arguments && arguments->parent
+                           ? arguments->parent->as_if<syntax::InvocationExpressionSyntax>()
+                           : nullptr;
+    if (!argument || !arguments || !invocation)
+        return nullptr;
+
+    auto* targetToken = invocation->left->getLastTokenPtr();
+    auto* target = getSymbolAtToken(targetToken);
+    auto* subroutine = target ? target->as_if<ast::SubroutineSymbol>() : nullptr;
+    if (!subroutine)
+        return nullptr;
+
+    auto formals = subroutine->getArguments();
+    if (auto* named = argument->as_if<syntax::NamedArgumentSyntax>()) {
+        auto formal = std::ranges::find(formals, named->name.valueText(),
+                                        [](const auto* arg) { return arg->name; });
+        return formal != formals.end() ? *formal : nullptr;
+    }
+
+    for (size_t index = 0; index < arguments->parameters.size(); index++) {
+        if (arguments->parameters[index] == argument)
+            return index < formals.size() ? formals[index] : nullptr;
+    }
+    return nullptr;
+}
+
+const ast::Scope* ShallowAnalysis::getAssignmentPatternTargetScope(
+    const syntax::AssignmentPatternExpressionSyntax& pattern) const {
+    return getScopeFromSym(getAssignmentPatternTargetSymbol(pattern));
+}
+
+const ast::Scope* ShallowAnalysis::getAssignmentPatternKeyScope(SourceLocation loc) const {
+    return getAssignmentPatternScopeAt(loc, false);
+}
+
+const ast::Scope* ShallowAnalysis::getAssignmentPatternCompletionScope(SourceLocation loc) const {
+    return getAssignmentPatternScopeAt(loc, true);
+}
+
+const ast::Scope* ShallowAnalysis::getAssignmentPatternScopeAt(SourceLocation loc,
+                                                               bool allowIncompleteKey) const {
+    auto* syntax = syntaxes.getSyntaxAt(loc);
+    if (!syntax) {
+        auto* previous = syntaxes.getTokenBefore(loc);
+        syntax = syntaxes.getTokenParent(previous);
+        if (!syntax)
+            return nullptr;
+    }
+
+    const syntax::AssignmentPatternExpressionSyntax* expression = nullptr;
+    const syntax::AssignmentPatternSyntax* pattern = nullptr;
+    const syntax::SyntaxNode* child = syntax;
+    bool isKey = false;
+    bool isValue = false;
+
+    for (auto* node = syntax; node; child = node, node = node->parent) {
+        if (auto* item = node->as_if<syntax::AssignmentPatternItemSyntax>()) {
+            isKey = child == item->key.get() || (child == item && loc <= item->colon.location());
+            isValue = !isKey;
+        }
+        if (syntax::AssignmentPatternSyntax::isKind(node->kind))
+            pattern = &node->as<syntax::AssignmentPatternSyntax>();
+        if (auto* candidate = node->as_if<syntax::AssignmentPatternExpressionSyntax>()) {
+            expression = candidate;
+            break;
+        }
+    }
+
+    if (!expression || !pattern || isValue)
+        return nullptr;
+
+    if (!isKey && allowIncompleteKey) {
+        auto* previous = syntaxes.getTokenBefore(loc);
+        isKey = previous && (previous->kind == parsing::TokenKind::ApostropheOpenBrace ||
+                             previous->kind == parsing::TokenKind::OpenBrace ||
+                             previous->kind == parsing::TokenKind::Comma);
+
+        if (!isKey && pattern->kind == syntax::SyntaxKind::SimpleAssignmentPattern) {
+            for (auto* node = syntax; node && node != pattern; node = node->parent) {
+                if (node->parent.get() == pattern && syntax::ExpressionSyntax::isKind(node->kind)) {
+                    isKey = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    return isKey ? getAssignmentPatternTargetScope(*expression) : nullptr;
+}
+
 /// @brief Visitor that finds and stores a specific token and its syntax node at an offset
 struct OffsetFinder {
     OffsetFinder(uint32_t targetOffset) : targetOffset(targetOffset) {}
@@ -466,6 +626,13 @@ slang::SmallVector<const ast::Symbol*, 2> ShallowAnalysis::getSymbolsAtToken(
             addSymbol(pkg->find(declTok->valueText()));
         }
         return symbols;
+    }
+    else if (auto* patternScope = getAssignmentPatternKeyScope(declTok->location())) {
+        auto* member = patternScope->find(declTok->valueText());
+        if (member && ast::FieldSymbol::isKind(member->kind)) {
+            addSymbol(member);
+            return symbols;
+        }
     }
     else if (auto indexed = m_symbolIndexer.getSymbols(declTok); !indexed.empty()) {
         if (syntax->kind == syntax::SyntaxKind::NamedPortConnection &&

--- a/src/document/SyntaxIndexer.cpp
+++ b/src/document/SyntaxIndexer.cpp
@@ -55,6 +55,7 @@ void SyntaxIndexer::visit(const slang::syntax::SyntaxNode& node) {
         case syntax::SyntaxKind::InvocationExpression:
         case syntax::SyntaxKind::HierarchyInstantiation:
         case syntax::SyntaxKind::ClassName:
+        case syntax::SyntaxKind::AssignmentPatternExpression:
             collectedHints.emplace(static_cast<uint32_t>(node.getFirstToken().location().offset()),
                                    &node);
             break;
@@ -277,7 +278,8 @@ const syntax::SyntaxNode* SyntaxIndexer::getSyntaxAt(slang::SourceLocation loc) 
     auto beforeToken = collected[beforeIndex];
 
     // Inside a token
-    if (loc < beforeToken->range().end()) {
+    if (loc < beforeToken->range().end() ||
+        (beforeToken->isMissing() && loc == beforeToken->location())) {
         return getTokenParent(beforeToken);
     }
 

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -1109,6 +1109,317 @@ TEST_CASE("HierarchicalStructCompletionWithUnresolvedWidth") {
     CHECK(knownContent.find("Type: `logic`") != std::string::npos);
 }
 
+TEST_CASE("AssignmentPatternStructFieldsWithUnresolvedWidth") {
+    ServerHarness server("repo1");
+    auto doc = server.openFile("assignment_pattern_fields.sv", R"(
+    typedef logic [missing_width - 1:0] incomplete_t;
+
+    typedef struct packed {
+        incomplete_t payload;
+        logic valid;
+    } packet_t;
+
+    typedef struct packed {
+        packet_t packet;
+        logic ready;
+    } wrapper_t;
+
+    module assignment_patterns;
+        packet_t packet;
+        wrapper_t wrapper;
+        wire packet_t packet_wire;
+        logic source;
+        logic payload;
+        logic valid;
+
+        function automatic void consume(packet_t value);
+        endfunction
+
+        assign packet_wire = '{
+        };
+
+        initial begin
+            packet = '{payload: source, valid: source};
+            packet = '{payload, valid};
+            packet = {source, source};
+            packet = '{ };
+            packet = '{pay: source, valid: source};
+            packet = '{payload: source, };
+            packet = '{default: source, };
+            wrapper = '{packet: '{payload: source, valid: source}, ready: source};
+            consume('{});
+        end
+    endmodule
+    )");
+
+    auto findCompletion = [](auto& items, std::string_view label) {
+        return std::ranges::find(items, label,
+                                 [](const CompletionHandle& item) { return item.m_item.label; });
+    };
+    constexpr std::string_view allFieldsLabel = "'{payload, valid}";
+
+    auto& triggerCharacters = completions::completionTriggerCharacters();
+    CHECK(std::ranges::find(triggerCharacters, "{") != triggerCharacters.end());
+
+    auto emptyPattern = doc.before("packet = '{ }").after("'{").getCompletions("{");
+    REQUIRE(emptyPattern.size() == 1);
+    auto triggeredAllFields = findCompletion(emptyPattern, allFieldsLabel);
+    REQUIRE(triggeredAllFields != emptyPattern.end());
+    CHECK(triggeredAllFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n");
+    CHECK(!triggeredAllFields->m_item.additionalTextEdits);
+
+    auto ordinaryBrace = doc.after("packet = {").getCompletions("{");
+    CHECK(ordinaryBrace.empty());
+
+    auto invokedPattern = doc.after("assign packet_wire = '{\n        ").getCompletions();
+    REQUIRE(invokedPattern.size() == 3);
+    CHECK(findCompletion(invokedPattern, allFieldsLabel) == invokedPattern.end());
+    auto invokedPayload = findCompletion(invokedPattern, "payload");
+    REQUIRE(invokedPayload != invokedPattern.end());
+    CHECK(invokedPayload->m_item.insertText == "payload: $1");
+    CHECK(findCompletion(invokedPattern, "valid") != invokedPattern.end());
+    CHECK(findCompletion(invokedPattern, "default") != invokedPattern.end());
+
+    auto unfinished = server.openFile("unfinished_assignment_pattern.sv", R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    module unfinished_assignment_pattern;
+        wire packet_t packet_wire;
+        assign packet_wire = '{)");
+    auto unfinishedCompletions = unfinished.end().getCompletions("{");
+    REQUIRE(unfinishedCompletions.size() == 1);
+    auto allFields = findCompletion(unfinishedCompletions, allFieldsLabel);
+    REQUIRE(allFields != unfinishedCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n\\};");
+    CHECK(!allFields->m_item.additionalTextEdits);
+
+    auto initializer = server.openFile("unfinished_assignment_pattern_initializer.sv", R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    module unfinished_assignment_pattern_initializer;
+        packet_t initialized = '{)");
+    auto initializerCompletions = initializer.end().getCompletions("{");
+    REQUIRE(initializerCompletions.size() == 1);
+    allFields = findCompletion(initializerCompletions, allFieldsLabel);
+    REQUIRE(allFields != initializerCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n\\};");
+
+    auto paired = server.openFile("paired_assignment_pattern.sv", R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    module paired_assignment_pattern;
+        wire packet_t packet_wire;
+        assign packet_wire = '{}
+    endmodule
+    )");
+    auto pairedCompletions = paired.after("assign packet_wire = '{").getCompletions("{");
+    REQUIRE(pairedCompletions.size() == 1);
+    allFields = findCompletion(pairedCompletions, allFieldsLabel);
+    REQUIRE(allFields != pairedCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n");
+    REQUIRE(allFields->m_item.additionalTextEdits);
+    REQUIRE(allFields->m_item.additionalTextEdits->size() == 1);
+    CHECK(allFields->m_item.additionalTextEdits->front().newText == ";");
+
+    auto alwaysComb = server.openFile("always_comb_assignment_pattern.sv", R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    module always_comb_assignment_pattern;
+        packet_t packet;
+        always_comb packet = '{}
+    endmodule
+    )");
+    auto alwaysCombCompletions = alwaysComb.after("always_comb packet = '{").getCompletions("{");
+    REQUIRE(alwaysCombCompletions.size() == 1);
+    allFields = findCompletion(alwaysCombCompletions, allFieldsLabel);
+    REQUIRE(allFields != alwaysCombCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n");
+    CHECK(allFields->m_item.insertTextMode == lsp::InsertTextMode::adjustIndentation);
+    REQUIRE(allFields->m_item.additionalTextEdits);
+
+    auto nestedPatternDoc = server.openFile("nested_assignment_pattern.sv", R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    typedef struct packed {
+        packet_t packet;
+        logic ready;
+    } wrapper_t;
+    module nested_unfinished_assignment_pattern;
+        wrapper_t wrapper;
+        initial begin
+            wrapper = '{ready: 1'b0, packet: '{}};
+        end
+    endmodule
+    )");
+    auto nestedPatternCompletions = nestedPatternDoc.after("packet: '{").getCompletions("{");
+    REQUIRE(nestedPatternCompletions.size() == 1);
+    allFields = findCompletion(nestedPatternCompletions, allFieldsLabel);
+    REQUIRE(allFields != nestedPatternCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n");
+    CHECK(!allFields->m_item.additionalTextEdits);
+
+    auto nestedUnfinished = server.openFile("nested_unfinished_assignment_pattern.sv", R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    typedef struct packed {
+        packet_t packet;
+        logic ready;
+    } wrapper_t;
+    module nested_unfinished_assignment_pattern;
+        wrapper_t wrapper;
+        initial begin
+            wrapper = '{packet: '{)");
+    auto nestedUnfinishedCompletions = nestedUnfinished.end().getCompletions("{");
+    REQUIRE(nestedUnfinishedCompletions.size() == 1);
+    allFields = findCompletion(nestedUnfinishedCompletions, allFieldsLabel);
+    REQUIRE(allFields != nestedUnfinishedCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n\\},");
+    CHECK(!allFields->m_item.additionalTextEdits);
+
+    auto nestedPairedUnfinished = server.openFile("nested_paired_unfinished_assignment_pattern.sv",
+                                                  R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    typedef struct packed {
+        packet_t packet;
+        logic ready;
+    } wrapper_t;
+    module nested_paired_unfinished_assignment_pattern;
+        wrapper_t wrapper;
+        initial begin
+            wrapper = '{packet: '{})");
+    auto nestedPairedUnfinishedCompletions =
+        nestedPairedUnfinished.after("wrapper = '{packet: '{").getCompletions("{");
+    REQUIRE(nestedPairedUnfinishedCompletions.size() == 1);
+    allFields = findCompletion(nestedPairedUnfinishedCompletions, allFieldsLabel);
+    REQUIRE(allFields != nestedPairedUnfinishedCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n");
+    REQUIRE(allFields->m_item.additionalTextEdits);
+    REQUIRE(allFields->m_item.additionalTextEdits->size() == 1);
+    CHECK(allFields->m_item.additionalTextEdits->front().newText == ",");
+
+    auto nestedWithComma = server.openFile("nested_assignment_pattern_with_comma.sv", R"(
+    typedef struct packed {
+        logic [7:0] payload;
+        logic valid;
+    } packet_t;
+    typedef struct packed {
+        packet_t packet;
+        logic ready;
+    } wrapper_t;
+    module nested_assignment_pattern_with_comma;
+        wrapper_t wrapper;
+        initial begin
+            wrapper = '{packet: '{}, ready: 1'b0};
+        end
+    endmodule
+    )");
+    auto nestedWithCommaCompletions =
+        nestedWithComma.after("wrapper = '{packet: '{").getCompletions("{");
+    REQUIRE(nestedWithCommaCompletions.size() == 1);
+    allFields = findCompletion(nestedWithCommaCompletions, allFieldsLabel);
+    REQUIRE(allFields != nestedWithCommaCompletions.end());
+    CHECK(!allFields->m_item.additionalTextEdits);
+
+    auto callPatternCompletions = doc.after("consume('{").getCompletions("{");
+    REQUIRE(callPatternCompletions.size() == 1);
+    allFields = findCompletion(callPatternCompletions, allFieldsLabel);
+    REQUIRE(allFields != callPatternCompletions.end());
+    CHECK(allFields->m_item.insertText == "\n\tpayload: $1,\n\tvalid: $2\n");
+    CHECK(!allFields->m_item.additionalTextEdits);
+
+    auto partialPattern = doc.after("packet = '{ }").after("packet = '{pay").getCompletions();
+    auto payload = findCompletion(partialPattern, "payload");
+    REQUIRE(payload != partialPattern.end());
+    CHECK(findCompletion(partialPattern, "valid") == partialPattern.end());
+    auto defaultKey = findCompletion(partialPattern, "default");
+    REQUIRE(defaultKey != partialPattern.end());
+    CHECK(defaultKey->m_item.kind == lsp::CompletionItemKind::Keyword);
+    CHECK(!defaultKey->m_item.insertText);
+    CHECK(!payload->m_item.insertText);
+    CHECK(getCompletionTextEdit(payload->m_item).newText == "payload");
+
+    auto nextKey = doc.after("packet = '{pay: source, valid: source};")
+                       .after("packet = '{payload: source, ")
+                       .getCompletions();
+    REQUIRE(nextKey.size() == 2);
+    auto valid = findCompletion(nextKey, "valid");
+    REQUIRE(valid != nextKey.end());
+    CHECK(findCompletion(nextKey, "payload") == nextKey.end());
+    defaultKey = findCompletion(nextKey, "default");
+    REQUIRE(defaultKey != nextKey.end());
+    CHECK(defaultKey->m_item.insertText == "default: $1");
+    CHECK(valid->m_item.insertText == "valid: $1");
+
+    auto afterDefault = doc.after("packet = '{default: source, ").getCompletions();
+    CHECK(findCompletion(afterDefault, "default") == afterDefault.end());
+    CHECK(findCompletion(afterDefault, "payload") != afterDefault.end());
+    CHECK(findCompletion(afterDefault, "valid") != afterDefault.end());
+
+    auto nestedPattern = doc.after("wrapper = '{packet: '{").getCompletions();
+    CHECK(findCompletion(nestedPattern, "payload") != nestedPattern.end());
+    CHECK(findCompletion(nestedPattern, "valid") == nestedPattern.end());
+    CHECK(findCompletion(nestedPattern, "ready") == nestedPattern.end());
+
+    auto positionalPayload = doc.before("payload, valid};");
+    auto positionalHover = doc.getHoverAt(positionalPayload.m_offset);
+    REQUIRE(positionalHover);
+    auto positionalContent = rfl::get<lsp::MarkupContent>(positionalHover->contents).value;
+    CHECK(positionalContent.find("**Variable** `payload`") != std::string::npos);
+
+    auto positionalDefinitions = positionalPayload.getDefinitions();
+    REQUIRE(positionalDefinitions.size() == 1);
+    auto localPayload = doc.after("module assignment_patterns;").before("payload;");
+    CHECK(positionalDefinitions[0].targetSelectionRange.start == localPayload.getPosition());
+
+    auto payloadKey = doc.before("payload: source");
+    auto hover = doc.getHoverAt(payloadKey.m_offset);
+    REQUIRE(hover);
+    auto hoverContent = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(hoverContent.find("**Field** `payload`") != std::string::npos);
+    CHECK(hoverContent.find("incomplete_t") != std::string::npos);
+
+    auto definitions = payloadKey.getDefinitions();
+    REQUIRE(definitions.size() == 1);
+    auto declaration = doc.before("payload;").getPosition();
+    CHECK(definitions[0].targetSelectionRange.start.line == declaration.line);
+    CHECK(definitions[0].targetSelectionRange.start.character == declaration.character);
+}
+
+TEST_CASE("StructAssignmentCompletionForUnpackedArrayElement") {
+    ServerHarness server("repo1");
+    auto doc = server.openFile("unpacked_array_struct_assignment.sv", R"(
+    typedef struct packed {
+        logic value;
+        logic valid;
+    } entry_t;
+
+    module unpacked_array_struct_assignment;
+        entry_t entries [2];
+        initial entries = '{0: '{}};
+    endmodule
+    )");
+
+    auto completions = doc.after("entries = '{0: '{").getCompletions("{");
+    REQUIRE(completions.size() == 1);
+    CHECK(completions.front().m_item.label == "'{value, valid}");
+    CHECK(completions.front().m_item.insertText == "\n\tvalue: $1,\n\tvalid: $2\n");
+}
+
 TEST_CASE("HierarchicalStructCompletion") {
     ServerHarness server("repo1");
     JsonGoldenTest golden;

--- a/tests/cpp/InlayHintTests.cpp
+++ b/tests/cpp/InlayHintTests.cpp
@@ -5,6 +5,7 @@
 #include "utils/InlayHintScanner.h"
 #include "utils/ServerHarness.h"
 #include <algorithm>
+#include <array>
 
 using namespace slang;
 
@@ -154,6 +155,95 @@ endmodule
     const auto& edit = hint->textEdits->front();
     CHECK(edit.range.start.line == 9);
     CHECK_FALSE(edit.newText.starts_with('\n'));
+}
+
+TEST_CASE("InlayHintsAssignmentPatternTypes") {
+    ServerHarness server("");
+    auto hdl = server.openFile("inlay_assignment_patterns.sv", R"(
+package Pkg;
+    typedef logic [missing_width - 1:0] incomplete_t;
+    typedef struct packed {
+        incomplete_t payload;
+        logic valid;
+    } packet_t;
+    typedef struct packed {
+        packet_t packet;
+        logic ready;
+    } wrapper_t;
+endpackage
+
+module top;
+    Pkg::packet_t packet;
+    Pkg::wrapper_t wrapper;
+    wire Pkg::packet_t packet_wire;
+    logic source;
+    Pkg::packet_t initialized = '{payload: source, valid: source};
+    assign packet_wire = '{payload: source, valid: source};
+
+    function automatic void consume(Pkg::packet_t value);
+    endfunction
+
+    initial begin
+        packet = '{payload: source, valid: source};
+        wrapper = '{packet: '{payload: source, valid: source}, ready: source};
+        packet = Pkg::packet_t'{payload: source, valid: source};
+        consume('{payload: source, valid: source});
+    end
+endmodule
+)");
+
+    auto hints = hdl.getAllInlayHints();
+    REQUIRE(hints.size() == 6);
+
+    std::array expectedLabels{"Pkg::packet_t",  "Pkg::packet_t", "Pkg::packet_t",
+                              "Pkg::wrapper_t", "Pkg::packet_t", "Pkg::packet_t"};
+    auto packetType = hdl.before("packet_t;");
+    auto wrapperType = hdl.before("wrapper_t;");
+    std::array expectedTypePositions{packetType.getPosition(), packetType.getPosition(),
+                                     packetType.getPosition(), wrapperType.getPosition(),
+                                     packetType.getPosition(), packetType.getPosition()};
+    for (size_t i = 0; i < hints.size(); i++) {
+        REQUIRE(rfl::holds_alternative<std::vector<lsp::InlayHintLabelPart>>(hints[i].label));
+        const auto& labelParts = rfl::get<std::vector<lsp::InlayHintLabelPart>>(hints[i].label);
+        REQUIRE(labelParts.size() == 1);
+        CHECK(labelParts[0].value == expectedLabels[i]);
+        REQUIRE(labelParts[0].location);
+        CHECK(labelParts[0].location->uri == hdl.doc->getURI());
+        CHECK(labelParts[0].location->range.start == expectedTypePositions[i]);
+        auto expectedEnd = expectedTypePositions[i];
+        expectedEnd.character += i == 3 ? std::string_view("wrapper_t").size()
+                                        : std::string_view("packet_t").size();
+        CHECK(labelParts[0].location->range.end == expectedEnd);
+        CHECK(hints[i].kind == lsp::InlayHintKind::Type);
+        REQUIRE(hints[i].textEdits);
+        REQUIRE(hints[i].textEdits->size() == 1);
+        auto& edit = hints[i].textEdits->front();
+        CHECK(edit.range.start == hints[i].position);
+        CHECK(edit.range.end == hints[i].position);
+        CHECK(edit.newText == expectedLabels[i]);
+    }
+
+    auto typeHover = hdl.getHoverAt(packetType.m_offset);
+    REQUIRE(typeHover);
+    auto hoverContent = rfl::get<lsp::MarkupContent>(typeHover->contents).value;
+    CHECK(hoverContent.find("**TypeAlias** `packet_t`") != std::string::npos);
+
+    auto typeDefinitions = packetType.getDefinitions();
+    REQUIRE(typeDefinitions.size() == 1);
+    CHECK(typeDefinitions[0].targetSelectionRange.start == packetType.getPosition());
+
+    auto initializedPattern = hdl.after("initialized = ").getPosition();
+    auto continuousPattern = hdl.after("packet_wire = ").getPosition();
+    auto assignedPattern = hdl.after("packet = ").getPosition();
+    auto outerPattern = hdl.after("wrapper = ").getPosition();
+    auto nestedPattern = hdl.after("wrapper = '").after("packet: ").getPosition();
+    auto argumentPattern = hdl.after("initial begin").after("consume(").getPosition();
+    CHECK(hints[0].position == initializedPattern);
+    CHECK(hints[1].position == continuousPattern);
+    CHECK(hints[2].position == assignedPattern);
+    CHECK(hints[3].position == outerPattern);
+    CHECK(hints[4].position == nestedPattern);
+    CHECK(hints[5].position == argumentPattern);
 }
 
 TEST_CASE("InlayHintsParameters") {

--- a/tests/cpp/utils/CompletionCoverageScanner.cpp
+++ b/tests/cpp/utils/CompletionCoverageScanner.cpp
@@ -33,6 +33,8 @@ std::optional<std::string> triggerForTokenKind(slang::parsing::TokenKind kind) {
             return "[";
         case slang::parsing::TokenKind::Dollar:
             return "$";
+        case slang::parsing::TokenKind::ApostropheOpenBrace:
+            return "{";
         default:
             return std::nullopt;
     }


### PR DESCRIPTION
- Hovers/Gotos for struct keys
- Inlay hint for type - like the type_t in `type_t'{...}` is filled in
- Completions on typing `'{'`, individual keys, and 'default' keyword.