### PR TITLE
Add verilator lint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "external/slang"]
 	path = external/slang
-	url = https://github.com/AndrewNolte/slang.git
+	url = https://github.com/MikePopoloski/slang.git
 [submodule "external/reflect-cpp"]
 	path = external/reflect-cpp
 	url = https://github.com/getml/reflect-cpp.git
 [submodule "external/ctre"]
 	path = external/ctre
 	url = https://github.com/hanickadot/compile-time-regular-expressions.git
+[submodule "external/vscode-system-verilog"]
+	path = external/vscode-system-verilog
+	url = https://github.com/AndrewNolte/vscode-system-verilog.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# AGENTS.md
+
+SystemVerilog LSP server in C++20, built on the [Slang](https://github.com/MikePopoloski/slang) library.
+Also includes a VS Code extension (`clients/vscode/`, TypeScript) and Neovim plugin (`clients/neovim/`, Lua).
+
+## Build
+
+```bash
+cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j8
+```
+
+Or use a preset from `CMakePresets.json` (e.g. `cmake --preset clang-debug`, `cmake --preset win64-debug`).
+CI uses `--preset <name> -DSLANG_CI_BUILD=ON`.
+
+Key targets:
+- `slang_server` — the server binary (`build/bin/slang-server`)
+- `server_unittests` — primary C++ tests
+- `gen_config_schema` — config JSON schema generator
+
+## Test
+
+**Preferred: build + run server_unittests directly:**
+```bash
+cmake --build build -j8 --target server_unittests && build/bin/server_unittests
+```
+
+**Update golden files** when test output intentionally changes:
+```bash
+build/bin/server_unittests --update
+```
+Goldens live in `tests/cpp/golden/*.json` and `tests/cpp/golden/*.out`. They are excluded from formatting hooks.
+
+**CTest** (runs all discovered tests):
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+**Python system tests** (pygls-based, require built server binary):
+```bash
+uv venv && source .venv/bin/activate && uv sync
+pytest tests/system/ --binary build/bin/slang-server
+```
+
+**Neovim tests** require luarocks + busted (see `DEVELOPING.md` for setup).
+
+## Architecture
+
+```
+src/SlangServer.cpp        Main server class; LSP route handlers + HDL extensions
+src/ServerDriver.cpp       Slang driver wrapper; manages syntax trees and open documents
+src/ast/ServerCompilation  Wrapper around slang Compilation with incremental updates
+src/document/SlangDoc.cpp  File + SyntaxTree pair; token index + shallow compilation
+src/document/              Core per-document LSP features (indexer, inlay hints, etc.)
+src/completions/           Completion providers (members, instances, macros, keywords)
+src/codeactions/           Code actions (expand macro, add define)
+src/lsp/                   URI handling
+src/util/                  Converters, formatting, markdown, extensions
+include/                   Public headers mirroring src/ structure
+include/lsp/               LSP type stubs (generated from lsprotocol, rarely updated)
+```
+
+## Submodules & External
+
+All in `external/`:
+- `slang` — core parser/compiler library (git submodule)
+- `reflect-cpp` — JSON serialization (git submodule)
+- `ctre` — compile-time regex (git submodule)
+- `vscode-system-verilog` — grammar/snippets (git submodule)
+- Single-header libs: `BS_thread_pool.hpp`, `expected.hpp`, `boost_concurrent.hpp`, `boost_unordered.hpp`
+
+`external/` is excluded from all formatting and linting hooks.
+
+## Codegen & Schema Sync
+
+When `include/Config.h` changes:
+1. Pre-commit hook runs `python3 scripts/genconfig.py`
+2. This builds `gen_config_schema`, generates `clients/vscode/resources/config.schema.json`, then converts it to `clients/vscode/src/config.gen.ts`
+3. The VS Code extension's `package.json` is updated via the "Extdev: update config" command from the debugging VS Code window
+
+## Code Style
+
+- **C++20**, column limit 100, `#pragma once` (no ifdef guards)
+- **lowerCase** for functions, parameters, locals (not LLVM-style UpperCase)
+- clang-format v20 config: `.clang-format`
+- cmake-format for CMake files (2-space indent)
+- Prettier for TS/YAML, Ruff for Python
+- `external/` excluded from all formatters
+
+Install pre-commit hooks:
+```bash
+pip install prek && prek install
+```
+
+Run all hooks: `prek run --all-files`
+
+## VS Code Client
+
+Located in `clients/vscode/`. Uses pnpm, Node 20.
+```bash
+cd clients/vscode && pnpm install && pnpm run compile
+```
+
+Debug: copy `.vscode/launch.template.jsonc` to `.vscode/launch.json`, configure build with `cmake -B build/vscode -DCMAKE_BUILD_TYPE=Debug`.
+
+## Key Conventions
+
+- CI builds with `-Werror`; always build locally with the same warning level to avoid CI failures
+- Tests use Catch2 (fetched via FetchContent, v3.10.0)
+- Test data lives in `tests/data/` (subdirectories like `repo1/`, `basic_config/`, etc.)
+- Test harness: `ServerHarness` (C++) and `SlangClient` (Python) wrap the server for in-process/IO testing
+- Version lives in the `VERSION` file (currently `0.2.10`)
+- License: MIT, REUSE-compliant (see `REUSE.toml`)

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-slang",
   "displayName": "slang-server: Verilog/SystemVerilog LSP",
   "description": "Verilog and SystemVerilog support via the slang language server.",
-  "version": "0.2.17",
+  "version": "0.2.17-test.5",
   "publisher": "Hudson-River-Trading",
   "keywords": [
     "verilog",
@@ -378,6 +378,29 @@
         "slang.debugArgs": {
           "default": [],
           "description": "Arguments to pass to slang-server when debugging",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "slang.lint.enabled": {
+          "default": true,
+          "description": "Enable diagnostics from the slang language server",
+          "type": "boolean"
+        },
+        "slang.lintManager.verilator.enabled": {
+          "default": false,
+          "description": "Enable verilator lint",
+          "type": "boolean"
+        },
+        "slang.lintManager.verilator.path": {
+          "default": "verilator",
+          "description": "Path to the verilator executable",
+          "type": "string"
+        },
+        "slang.lintManager.verilator.args": {
+          "default": [],
+          "description": "Additional arguments to pass to verilator",
           "type": "array",
           "items": {
             "type": "string"

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -18,6 +18,7 @@ import {
   CommandNode,
   ConfigObject,
   EditorButton,
+  ExtensionComponent,
   ViewContainerSpec,
 } from './lib/libconfig'
 import { PathConfigObject } from './lib/pathConfig'
@@ -32,8 +33,16 @@ import {
 } from './utils'
 import { glob } from 'glob'
 import { InactiveRegionsFeature } from './lib/inactiveRegions'
+import { LintManager } from './linter/LintManager'
 
 export var ext: SlangExtension
+
+class LintComponent extends ExtensionComponent {
+  enabled: ConfigObject<boolean> = new ConfigObject({
+    default: true,
+    description: 'Enable diagnostics from the slang language server',
+  })
+}
 
 export class SlangExtension extends ActivityBarComponent {
   ////////////////////////////////////////////////
@@ -88,6 +97,9 @@ File input is sent to stdin, and formatted output is read from stdout.',
 
   // Inactive preprocessor region highlighting
   inactiveRegions: InactiveRegionsFeature = new InactiveRegionsFeature()
+
+  // External linters (e.g. verilator)
+  lintManager: LintManager = new LintManager()
 
   // Side bar
   project: ProjectComponent = new ProjectComponent()
@@ -161,6 +173,8 @@ File input is sent to stdin, and formatted output is read from stdout.',
     description: 'Arguments to pass to slang-server when debugging',
   })
 
+  lint: LintComponent = new LintComponent()
+
   /// The final config from slang-server json files
   slangConfig: slang.Config = {}
 
@@ -179,6 +193,15 @@ File input is sent to stdin, and formatted output is read from stdout.',
 
     const clientOptions: LanguageClientOptions = {
       documentSelector: anyVerilogSelector,
+      middleware: {
+        handleDiagnostics: (uri, diagnostics, next) => {
+          if (this.lint.enabled.getValue()) {
+            next(uri, diagnostics)
+          } else {
+            this.client?.diagnostics?.delete(uri)
+          }
+        },
+      },
     }
 
     this.client = new LanguageClient('slang-server', serverOptions, clientOptions)
@@ -352,6 +375,17 @@ File input is sent to stdin, and formatted output is read from stdout.',
       })
     )
     await this.setupLanguageClient()
+
+    // Clear slang diagnostics when lint is disabled
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration('slang.lint.enabled')) {
+          if (!this.lint.enabled.getValue() && this.client) {
+            this.client.diagnostics?.clear()
+          }
+        }
+      })
+    )
 
     if (context.storageUri !== undefined) {
       this.expandDir = vscode.Uri.joinPath(context.storageUri, 'expanded')

--- a/clients/vscode/src/linter/BaseLinter.ts
+++ b/clients/vscode/src/linter/BaseLinter.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+import * as child_process from 'child_process'
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { ConfigObject, ExtensionComponent } from '../lib/libconfig'
+
+export interface LintOutput {
+  stdout: string
+  stderr: string
+}
+
+export abstract class BaseLinter extends ExtensionComponent {
+  toolName: string
+  enabled: ConfigObject<boolean>
+  path: ConfigObject<string>
+  args: ConfigObject<string[]>
+
+  diagnostics: vscode.DiagnosticCollection
+
+  constructor(toolName: string, defaultEnabled: boolean = false) {
+    super()
+    this.toolName = toolName
+    this.enabled = new ConfigObject({
+      default: defaultEnabled,
+      description: `Enable ${toolName} lint`,
+    })
+    this.path = new ConfigObject({
+      default: toolName,
+      description: `Path to the ${toolName} executable`,
+    })
+    this.args = new ConfigObject({
+      default: [],
+      description: `Additional arguments to pass to ${toolName}`,
+    })
+    this.diagnostics = vscode.languages.createDiagnosticCollection(toolName)
+  }
+
+  async activate(context: vscode.ExtensionContext): Promise<void> {
+    context.subscriptions.push(this.diagnostics)
+  }
+
+  async lint(doc: vscode.TextDocument, workspaceFolder: string | undefined): Promise<void> {
+    const enabled = this.enabled.getValue()
+    if (!enabled) {
+      return
+    }
+
+    const toolPath = this.path.getValue()
+    if (!toolPath) {
+      return
+    }
+
+    const args = [...this.toolArgs(doc)]
+    args.push(...this.args.getValue())
+    args.push(doc.uri.fsPath)
+
+    const cwd = workspaceFolder ?? path.dirname(doc.uri.fsPath)
+
+    this.logger.info(`${toolPath} ${args.join(' ')}`)
+
+    try {
+      const output = await this.runTool(toolPath, args, cwd)
+      if (output.stderr) {
+        this.logger.info(output.stderr)
+      }
+      const diags = this.parseDiagnostics(doc, output)
+      this.diagnostics.set(doc.uri, diags)
+    } catch (e: any) {
+      this.logger.error(`${this.toolName} lint failed: ${e.message}`)
+    }
+  }
+
+  clear(doc: vscode.TextDocument) {
+    this.diagnostics.delete(doc.uri)
+  }
+
+  clearAll() {
+    this.diagnostics.clear()
+  }
+
+  protected abstract toolArgs(doc: vscode.TextDocument): string[]
+  protected abstract parseDiagnostics(doc: vscode.TextDocument, output: LintOutput): vscode.Diagnostic[]
+
+  private runTool(
+    command: string,
+    args: string[],
+    cwd: string
+  ): Promise<LintOutput> {
+    return new Promise((resolve, reject) => {
+      child_process.execFile(
+        command,
+        args,
+        { cwd, encoding: 'utf-8', timeout: 30000 },
+        (error, stdout, stderr) => {
+          if (error && error.killed) {
+            reject(new Error('Process timed out'))
+          } else {
+            resolve({ stdout: stdout ?? '', stderr: stderr ?? '' })
+          }
+        }
+      )
+    })
+  }
+}

--- a/clients/vscode/src/linter/LintManager.ts
+++ b/clients/vscode/src/linter/LintManager.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode'
+import { ExtensionComponent } from '../lib/libconfig'
+import { getWorkspaceFolder, isAnyVerilog } from '../utils'
+import { BaseLinter } from './BaseLinter'
+import { VerilatorLinter } from './VerilatorLinter'
+
+export class LintManager extends ExtensionComponent {
+  private linters: BaseLinter[] = []
+
+  verilator: VerilatorLinter = new VerilatorLinter()
+
+  async activate(context: vscode.ExtensionContext): Promise<void> {
+    this.linters = [this.verilator]
+    this.logger.info(`activating with ${this.linters.length} linter(s)`)
+
+    for (const linter of this.linters) {
+      this.logger.info(`activating linter: ${linter.toolName}`)
+      await linter.activate(context)
+    }
+
+    context.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor((editor) => {
+        if (editor) {
+          this.lint(editor.document)
+        }
+      })
+    )
+
+    context.subscriptions.push(
+      vscode.workspace.onDidSaveTextDocument((doc) => this.lint(doc))
+    )
+
+    context.subscriptions.push(
+      vscode.workspace.onDidCloseTextDocument((doc) => this.removeDiagnostics(doc))
+    )
+
+    this.onConfigUpdated(() => {
+      this.logger.info('config updated, clearing all linter diagnostics')
+      for (const linter of this.linters) {
+        linter.clearAll()
+      }
+    })
+  }
+
+  private async lint(doc: vscode.TextDocument): Promise<void> {
+    if (!isAnyVerilog(doc.languageId)) {
+      return
+    }
+    this.logger.info(`linting ${doc.uri.fsPath}`)
+    const workspaceFolder = getWorkspaceFolder()
+    await Promise.all(this.linters.map((l) => l.lint(doc, workspaceFolder)))
+  }
+
+  private removeDiagnostics(doc: vscode.TextDocument): void {
+    for (const linter of this.linters) {
+      linter.clear(doc)
+    }
+  }
+}

--- a/clients/vscode/src/linter/VerilatorLinter.ts
+++ b/clients/vscode/src/linter/VerilatorLinter.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode'
+import { isSystemVerilog } from '../utils'
+import { BaseLinter, LintOutput } from './BaseLinter'
+
+export class VerilatorLinter extends BaseLinter {
+  constructor() {
+    super('verilator')
+  }
+
+  protected toolArgs(doc: vscode.TextDocument): string[] {
+    const args = ['--lint-only']
+    if (isSystemVerilog(doc.languageId)) {
+      args.push('-sv')
+    }
+    return args
+  }
+
+  protected parseDiagnostics(_doc: vscode.TextDocument, output: LintOutput): vscode.Diagnostic[] {
+    const diagnostics: vscode.Diagnostic[] = []
+    const lines = output.stderr.split(/\r?\n/)
+
+    for (let n = 0; n < lines.length; n++) {
+      const line = lines[n]
+      if (!line.startsWith('%')) {
+        continue
+      }
+
+      // alternate:
+      // "%Error(-[A-Z0-9]+)?: ((\\S+):(\\d+):((\\d+):)? )?(.*)$",
+      const rex = line.match(/%(\w+)(-\w+)?: (\S+):(\d+):(\d+): (.+)/)
+      if (!rex || rex[0].length === 0) {
+        continue
+      }
+
+      const severity = rex[1]
+      const warningType = rex[2] !== undefined ? rex[2].substring(1) : ''
+      const lineNum = Number(rex[4]) - 1
+      const colNum = Number(rex[5]) - 1
+      const msg = rex[6]
+
+      const pline = lines[n + 2]
+      const pindex = pline.indexOf('^')
+      const elen = pline.length - pindex
+      n += 2
+
+      if (!isNaN(lineNum)) {
+        const diagnostic = new vscode.Diagnostic(
+          new vscode.Range(lineNum, colNum, lineNum, colNum + elen),
+          msg,
+          this.convertSeverity(severity)
+        )
+        if (warningType) {
+          diagnostic.code = warningType
+        }
+        diagnostic.source = 'verilator'
+        diagnostics.push(diagnostic)
+      }
+    }
+    if (diagnostics.length > 0) {
+      const summary = diagnostics
+        .map(
+          (d) =>
+            `${d.source} ${d.severity === 0 ? 'Error' : d.severity === 1 ? 'Warning' : 'Info'} [${d.range.start.line + 1}:${d.range.start.character}-${d.range.end.line + 1}:${d.range.end.character}] ${d.message}`
+        )
+        .join('\n')
+      this.logger.info(`Parsed ${diagnostics.length} diagnostic(s):\n${summary}`)
+    }
+    return diagnostics
+  }
+
+  private convertSeverity(severity: string): vscode.DiagnosticSeverity {
+    if (severity === 'Error') {
+      return vscode.DiagnosticSeverity.Error
+    } else if (severity === 'Warning') {
+      return vscode.DiagnosticSeverity.Warning
+    }
+    return vscode.DiagnosticSeverity.Information
+  }
+}

--- a/clients/vscode/src/utils.ts
+++ b/clients/vscode/src/utils.ts
@@ -30,6 +30,10 @@ export function isAnyVerilog(langid: string): boolean {
   return AnyVerilogLanguages.includes(langid)
 }
 
+export function isSystemVerilog(langid: string): boolean {
+  return langid === 'systemverilog' || langid === 'systemverilogheader'
+}
+
 /**
  * Get the basename of a path without extension
  * @param filePath - Path string to extract basename from


### PR DESCRIPTION
Add slang lint toggle and verilator lint support

- Add slang.lint.enabled setting to suppress slang-server diagnostics via LSP middleware
- Add verilator linter (slang.lintManager.verilator.{enabled,path,args}) with --lint-only -sv parsing
- Add LintManager component for external linter orchestration (triggers on save/editor change)