### PR TITLE
skip block clauses tokens in `textDocument/references`

### DIFF
--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -129,7 +129,8 @@ public:
     std::optional<std::vector<lsp::Location>> getDocReferences(const URI& uri,
                                                                const lsp::Position& position,
                                                                bool includeDeclaration,
-                                                               const lsp::RequestContext& ctx = {});
+                                                               const lsp::RequestContext& ctx = {},
+                                                               bool excludeEndBlockClauses = false);
 
     /// @brief Renames a symbol in a document
     /// @param uri The URI of the document

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -168,8 +168,8 @@ public:
     /// @param targetLocation The source location of the target symbol
     /// @param targetName The name of the symbol to match
     void addLocalReferences(std::vector<lsp::Location>& references,
-                            slang::SourceLocation targetLocation,
-                            std::string_view targetName) const;
+                            slang::SourceLocation targetLocation, std::string_view targetName,
+                            bool excludeEndBlockClauses = false) const;
 
     /// @brief Runs analysis on the shallow compilation and returns diagnostics
     /// @return The analysis diagnostics (owned by internal AnalysisManager)

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -1027,7 +1027,7 @@ void ServerDriver::addMemberReferences(std::vector<lsp::Location>& references,
 
 std::optional<std::vector<lsp::Location>> ServerDriver::getDocReferences(
     const URI& srcUri, const lsp::Position& position, bool includeDeclaration,
-    const lsp::RequestContext& ctx) {
+    const lsp::RequestContext& ctx, bool excludeEndBlockClauses) {
     ctx.throwIfCancelled("before finding references");
     auto doc = getDocument(srcUri);
     if (!doc) {
@@ -1149,7 +1149,8 @@ std::optional<std::vector<lsp::Location>> ServerDriver::getDocReferences(
         // Add refs in declaration file, and remove declaration if requested
         if (targetDoc) {
             auto targetAnalysis = targetDoc->getAnalysis(false, ctx);
-            targetAnalysis->addLocalReferences(references, targetSymbol->location, targetName);
+            targetAnalysis->addLocalReferences(references, targetSymbol->location, targetName,
+                                               excludeEndBlockClauses);
             if (!includeDeclaration) {
                 auto targetLspLoc = lsp::Location{
                     .uri = URI::fromFile(sm.getFullPath(targetLoc.buffer())),
@@ -1211,7 +1212,7 @@ std::optional<std::vector<lsp::Location>> ServerDriver::getDocReferences(
                 }
                 else if (targetLoc.buffer() != target.analysisBuffer) {
                     target.analysis->addLocalReferences(references, targetSymbol->location,
-                                                        targetName);
+                                                        targetName, excludeEndBlockClauses);
                 }
             }
         }

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -859,7 +859,8 @@ std::optional<std::vector<lsp::InlayHint>> SlangServer::getDocInlayHint(
 std::optional<std::vector<lsp::Location>> SlangServer::getDocReferences(
     const lsp::ReferenceParams& params, lsp::RequestContext ctx) {
     auto references = m_driver->getDocReferences(params.textDocument.uri, params.position,
-                                                 params.context.includeDeclaration, ctx);
+                                                 params.context.includeDeclaration, ctx,
+                                                 /* excludeEndBlockClauses */ true);
     auto doc = m_driver->getDocument(params.textDocument.uri);
     ctx.info("Found {} references for {}", references ? references->size() : 0,
              doc ? doc->getWsRelativePath() : params.textDocument.uri.getPath());

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -914,8 +914,8 @@ std::vector<lsp::InlayHint> ShallowAnalysis::getInlayHints(lsp::Range range,
 }
 
 void ShallowAnalysis::addLocalReferences(std::vector<lsp::Location>& references,
-                                         SourceLocation targetLocation,
-                                         std::string_view targetName) const {
+                                         SourceLocation targetLocation, std::string_view targetName,
+                                         bool excludeEndBlockClauses) const {
     // Get the token and symbol at the target location (may be in a different buffer)
 
     auto it = syntaxes.collected.begin();
@@ -969,7 +969,8 @@ void ShallowAnalysis::addLocalReferences(std::vector<lsp::Location>& references,
         auto* tokenParent = syntaxes.getTokenParent(token);
         auto parentKind = tokenParent && tokenParent->parent ? tokenParent->parent->kind
                                                              : syntax::SyntaxKind::Unknown;
-        if (tokenParent && tokenParent->kind == syntax::SyntaxKind::NamedBlockClause &&
+        if (excludeEndBlockClauses && tokenParent &&
+            tokenParent->kind == syntax::SyntaxKind::NamedBlockClause &&
             parentKind != syntax::SyntaxKind::SequentialBlockStatement &&
             parentKind != syntax::SyntaxKind::ParallelBlockStatement &&
             parentKind != syntax::SyntaxKind::GenerateBlock) {

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -964,8 +964,15 @@ void ShallowAnalysis::addLocalReferences(std::vector<lsp::Location>& references,
         // module MODULE_NAME;
         //   ...
         // endmodule : MODULE_NAME <-- Skip this token
+        //
+        // However it does not skip references for begin...end blocks.
         auto* tokenParent = syntaxes.getTokenParent(token);
-        if (tokenParent && tokenParent->kind == syntax::SyntaxKind::NamedBlockClause) {
+        auto parentKind = tokenParent && tokenParent->parent ? tokenParent->parent->kind
+                                                             : syntax::SyntaxKind::Unknown;
+        if (tokenParent && tokenParent->kind == syntax::SyntaxKind::NamedBlockClause &&
+            parentKind != syntax::SyntaxKind::SequentialBlockStatement &&
+            parentKind != syntax::SyntaxKind::ParallelBlockStatement &&
+            parentKind != syntax::SyntaxKind::GenerateBlock) {
             continue;
         }
 

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -959,6 +959,16 @@ void ShallowAnalysis::addLocalReferences(std::vector<lsp::Location>& references,
             continue;
         }
 
+        // Skip tokens that are part of a module declaration's named block clause
+        // ie:
+        // module MODULE_NAME;
+        //   ...
+        // endmodule : MODULE_NAME <-- Skip this token
+        auto* tokenParent = syntaxes.getTokenParent(token);
+        if (tokenParent && tokenParent->kind == syntax::SyntaxKind::NamedBlockClause) {
+            continue;
+        }
+
         references.push_back(lsp::Location{
             .uri = URI::fromFile(path),
             .range = toRange(token->range(), m_sourceManager),

--- a/tests/cpp/ReferencesTests.cpp
+++ b/tests/cpp/ReferencesTests.cpp
@@ -154,6 +154,95 @@ TEST_CASE("FindReferences - Module Name") {
     CHECK(refs->size() >= 1);
 }
 
+TEST_CASE("FindReferences - EndModuleLabel") {
+    JsonGoldenTest golden;
+    ServerHarness server;
+    auto hdl = server.openFile("test.sv", R"(
+module child;
+endmodule : child
+
+module top;
+    child instance();
+endmodule : top
+)");
+
+    auto refs = server.getDocReferences(lsp::ReferenceParams{
+        .context = {.includeDeclaration = true},
+        .textDocument = {.uri = hdl.m_uri},
+        .position = hdl.after("module ").getPosition(),
+    });
+
+    REQUIRE(refs.has_value());
+    golden.record(*refs);
+}
+
+TEST_CASE("FindReferences - EndInterfaceLabel") {
+    JsonGoldenTest golden;
+    ServerHarness server;
+    auto hdl = server.openFile("test.sv", R"(
+interface bus;
+endinterface : bus
+
+module top;
+    bus bus_instance();
+endmodule : top
+)");
+
+    auto refs = server.getDocReferences(lsp::ReferenceParams{
+        .context = {.includeDeclaration = true},
+        .textDocument = {.uri = hdl.m_uri},
+        .position = hdl.after("interface ").getPosition(),
+    });
+
+    REQUIRE(refs.has_value());
+    golden.record(*refs);
+}
+
+TEST_CASE("FindReferences - EndFunctionLabel") {
+    JsonGoldenTest golden;
+    ServerHarness server;
+    auto hdl = server.openFile("test.sv", R"(
+module top;
+    function automatic logic compute(input logic value);
+        return value;
+    endfunction : compute
+
+    logic result;
+    assign result = compute(1'b1);
+endmodule : top
+)");
+
+    auto refs = server.getDocReferences(lsp::ReferenceParams{
+        .context = {.includeDeclaration = true},
+        .textDocument = {.uri = hdl.m_uri},
+        .position = hdl.after("function automatic logic ").getPosition(),
+    });
+
+    REQUIRE(refs.has_value());
+    golden.record(*refs);
+}
+
+TEST_CASE("FindReferences - BeginEndBlockLabels") {
+    JsonGoldenTest golden;
+    ServerHarness server;
+    auto hdl = server.openFile("test.sv", R"(
+module top;
+    initial begin : work
+        disable work;
+    end : work
+endmodule : top
+)");
+
+    auto refs = server.getDocReferences(lsp::ReferenceParams{
+        .context = {.includeDeclaration = true},
+        .textDocument = {.uri = hdl.m_uri},
+        .position = hdl.after("begin : ").getPosition(),
+    });
+
+    REQUIRE(refs.has_value());
+    golden.record(*refs);
+}
+
 TEST_CASE("Rename - Simple Variable") {
     ServerHarness server("indexer_test");
     auto hdl = server.openFile("references_test.sv");

--- a/tests/cpp/ReferencesTests.cpp
+++ b/tests/cpp/ReferencesTests.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "utils/ServerHarness.h"
+#include <catch2/catch_test_macros.hpp>
 
 using namespace slang;
 
@@ -271,6 +272,34 @@ TEST_CASE("Rename - Simple Variable") {
     for (const auto& textEdit : changes[uriStr]) {
         CHECK(textEdit.newText == "my_data");
     }
+}
+
+TEST_CASE("Rename - End Module Label") {
+    JsonGoldenTest golden;
+    ServerHarness server;
+    auto hdl = server.openFile("test.sv", R"(
+module child;
+endmodule : child
+
+module top;
+    child instance();
+endmodule : top
+)");
+
+    auto cursor = hdl.after("module ");
+    auto edit = server.getDocRename(lsp::RenameParams{
+        .textDocument = {.uri = hdl.m_uri},
+        .position = cursor.getPosition(),
+        .newName = "my_new_module",
+    });
+
+    REQUIRE(edit.has_value());
+    REQUIRE(edit->changes.has_value());
+
+    // 3 changes for each reference of child
+    CHECK(edit->changes->size() == 3);
+
+    golden.record(*edit);
 }
 
 TEST_CASE("Rename - Parameter") {

--- a/tests/cpp/ReferencesTests.cpp
+++ b/tests/cpp/ReferencesTests.cpp
@@ -296,8 +296,15 @@ endmodule : top
     REQUIRE(edit.has_value());
     REQUIRE(edit->changes.has_value());
 
-    // 3 changes for each reference of child
-    CHECK(edit->changes->size() == 3);
+    // One file
+    CHECK(edit->changes->size() == 1);
+
+    auto& changes = *edit->changes;
+    auto uriStr = hdl.m_uri.str();
+    REQUIRE(changes.find(uriStr) != changes.end());
+
+    // Should have at least 3 references
+    CHECK(changes[uriStr].size() >= 3);
 
     golden.record(*edit);
 }

--- a/tests/cpp/ReferencesTests.cpp
+++ b/tests/cpp/ReferencesTests.cpp
@@ -303,8 +303,8 @@ endmodule : top
     auto uriStr = hdl.m_uri.str();
     REQUIRE(changes.find(uriStr) != changes.end());
 
-    // Should have at least 3 references
-    CHECK(changes[uriStr].size() >= 3);
+    // Should have 3 references
+    CHECK(changes[uriStr].size() == 3);
 
     golden.record(*edit);
 }

--- a/tests/cpp/golden/FindReferences - BeginEndBlockLabels.json
+++ b/tests/cpp/golden/FindReferences - BeginEndBlockLabels.json
@@ -1,0 +1,43 @@
+[
+  [
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 20
+        },
+        "end": {
+          "line": 2,
+          "character": 24
+        }
+      }
+    },
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 20
+        }
+      }
+    },
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 10
+        },
+        "end": {
+          "line": 4,
+          "character": 14
+        }
+      }
+    }
+  ]
+]

--- a/tests/cpp/golden/FindReferences - EndFunctionLabel.json
+++ b/tests/cpp/golden/FindReferences - EndFunctionLabel.json
@@ -1,0 +1,30 @@
+[
+  [
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 29
+        },
+        "end": {
+          "line": 2,
+          "character": 36
+        }
+      }
+    },
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 20
+        },
+        "end": {
+          "line": 7,
+          "character": 27
+        }
+      }
+    }
+  ]
+]

--- a/tests/cpp/golden/FindReferences - EndInterfaceLabel.json
+++ b/tests/cpp/golden/FindReferences - EndInterfaceLabel.json
@@ -1,0 +1,30 @@
+[
+  [
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 10
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
+      }
+    },
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 4
+        },
+        "end": {
+          "line": 5,
+          "character": 7
+        }
+      }
+    }
+  ]
+]

--- a/tests/cpp/golden/FindReferences - EndModuleLabel.json
+++ b/tests/cpp/golden/FindReferences - EndModuleLabel.json
@@ -1,0 +1,30 @@
+[
+  [
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 7
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
+      }
+    },
+    {
+      "uri": "file://test.sv",
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 4
+        },
+        "end": {
+          "line": 5,
+          "character": 9
+        }
+      }
+    }
+  ]
+]

--- a/tests/cpp/golden/FindReferencesAllTokens_all.sv.out
+++ b/tests/cpp/golden/FindReferencesAllTokens_all.sv.out
@@ -151,12 +151,12 @@ endinterface
 
 
 extern macromodule m3;
-                   ^^ Refs[10]
+                   ^^ Refs[9]
 
 
 
 macromodule m3;
-            ^^ Refs[10]
+            ^^ Refs[9]
 
     wire b;
          ^ Refs[5]
@@ -280,7 +280,7 @@ macromodule m3;
         wait fork;
 
         wait_order (m3.ev) f++;
-                    ^^ Refs[10]
+                    ^^ Refs[9]
                        ^^ Refs[2]
                            ^ Refs[7]
 
@@ -299,7 +299,7 @@ macromodule m3;
 
 
         disable m3.foo;
-                ^^ Refs[10]
+                ^^ Refs[9]
                    ^^^ Refs[3]
 
 
@@ -656,7 +656,7 @@ macromodule m3;
 
 
     defparam m3.m.i = 1:1:1;
-             ^^ Refs[10]
+             ^^ Refs[9]
                 ^ Refs[3]
                   ^ Refs[4]
 
@@ -690,17 +690,17 @@ macromodule m3;
 
 
 endmodule : m3
-            ^^ Refs[10]
+            ^^ Refs[9]
 
 
 
 extern program p(a, b);
-               ^ Refs[4]
+               ^ Refs[3]
 
 
 
 program p(a, b);
-        ^ Refs[4]
+        ^ Refs[3]
           ^ Refs[2]
              ^ Refs[2]
 
@@ -709,7 +709,7 @@ program p(a, b);
              ^ Refs[2]
 
 endprogram : p
-             ^ Refs[4]
+             ^ Refs[3]
 
 
 
@@ -736,7 +736,7 @@ endprimitive
 
 
 (* attr = 3.14 *) bind m3.m m1 #(1) bound('x, , , );
-                       ^^ Refs[10]
+                       ^^ Refs[9]
                           ^ Refs[3]
                             ^^ Refs[2]
                                     ^^^^^ Refs[1]
@@ -750,13 +750,13 @@ config cfg;
                ^ Refs[1]
 
     design work.m3;
-                ^^ Refs[10]
+                ^^ Refs[9]
 
     default liblist a b;
 
     cell m3 use work.m3;
-         ^^ Refs[10]
-                     ^^ Refs[10]
+         ^^ Refs[9]
+                     ^^ Refs[9]
 
 endconfig
 
@@ -970,7 +970,7 @@ typedef enum {
 
 
 checker assert_window1 (
-        ^^^^^^^^^^^^^^ Refs[3]
+        ^^^^^^^^^^^^^^ Refs[2]
 
     logic test_expr,
           ^^^^^^^^^ Refs[2]
@@ -1103,7 +1103,7 @@ checker assert_window1 (
     endgenerate
 
 endchecker : assert_window1
-             ^^^^^^^^^^^^^^ Refs[3]
+             ^^^^^^^^^^^^^^ Refs[2]
 
 
 
@@ -1135,7 +1135,7 @@ module m5;
     initial begin
 
         assert_window1 aw2(1 + 1, a, b);
-        ^^^^^^^^^^^^^^ Refs[3]
+        ^^^^^^^^^^^^^^ Refs[2]
                        ^^^ Refs[1]
                                   ^ Refs[4]
                                      ^ Refs[4]
@@ -1273,7 +1273,7 @@ endfunction
 
 class H #(int p);
       ^ Refs[1]
-              ^ Refs[4]
+              ^ Refs[3]
 
     extern function int foo;
 

--- a/tests/cpp/golden/FindReferencesAllTokens_references_test.sv.out
+++ b/tests/cpp/golden/FindReferencesAllTokens_references_test.sv.out
@@ -4,7 +4,7 @@
 
 
 module test_module #(
-       ^^^^^^^^^^^ Refs[2]
+       ^^^^^^^^^^^ Refs[1]
 
     parameter WIDTH = 8
               ^^^^^ Refs[4]
@@ -71,4 +71,4 @@ module test_module #(
 
 
 endmodule : test_module
-            ^^^^^^^^^^^ Refs[2]
+            ^^^^^^^^^^^ Refs[1]

--- a/tests/cpp/golden/Rename - End Module Label.json
+++ b/tests/cpp/golden/Rename - End Module Label.json
@@ -1,0 +1,47 @@
+[
+  {
+    "changes": {
+      "file:///home/evanp/slang-server/test.sv": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 7
+            },
+            "end": {
+              "line": 1,
+              "character": 12
+            }
+          },
+          "newText": "my_new_module"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 12
+            },
+            "end": {
+              "line": 2,
+              "character": 17
+            }
+          },
+          "newText": "my_new_module"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 4
+            },
+            "end": {
+              "line": 5,
+              "character": 9
+            }
+          },
+          "newText": "my_new_module"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cpp/golden/Rename - End Module Label.json
+++ b/tests/cpp/golden/Rename - End Module Label.json
@@ -1,7 +1,7 @@
 [
   {
     "changes": {
-      "file:///home/evanp/slang-server/test.sv": [
+      "file://test.sv": [
         {
           "range": {
             "start": {

--- a/tests/cpp/utils/GoldenTest.h
+++ b/tests/cpp/utils/GoldenTest.h
@@ -143,7 +143,8 @@ public:
             rfl::to_generic(std::unordered_map<std::string, T>{{label, (some_struct)}}));
     }
 
-    /// Helper to convert file:// URIs to just filename in a Generic value
+    /// Helper to convert file:// URIs to just filename in a Generic value.
+    /// URIs can occur as either values or object keys (for example, WorkspaceEdit::changes).
     static void makeUrisRelative(rfl::Generic& g) {
         std::visit(
             [](auto& val) {
@@ -159,6 +160,9 @@ public:
                 }
                 else if constexpr (std::is_same_v<T, rfl::Generic::Object>) {
                     for (auto& [key, child] : val) {
+                        rfl::Generic keyValue = key;
+                        makeUrisRelative(keyValue);
+                        key = std::get<std::string>(keyValue.get());
                         makeUrisRelative(child);
                     }
                 }


### PR DESCRIPTION
Consider I have a module:

```
module MODULE_NAME;

endmodule : MODULE_NAME // <-- I really like adding this but I don't need it 
                        //       popping up in my references since it clogs 
                        //       up the list.
```

This is a personal preference (though I think its a sensible preference), so I'm okay with adding a entry in the config file to opt into this.

Also I made it so that it doesn't skip the clauses for begin end blocks, though I'm not sure why you'd ever want to look at the references for these.