### PR TITLE
Hovers: Show drivers propagated through ports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,8 @@
 									python3
 									boost
 									fmt
+									catch2_3
+									uv
 								]
 								++ lib.optionals (!llvmPkgs.stdenv.hostPlatform.isDarwin) [gdb];
 						};

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -243,6 +243,11 @@ bool isPortDriver(const analysis::ValueDriver& driver) {
            driver.flags.has(analysis::DriverFlags::ViaIndirectPort);
 }
 
+bool isLogicThroughPort(const analysis::ValueDriver& driver) {
+    return driver.flags.has(analysis::DriverFlags::ViaIndirectPort) &&
+           !driver.isUnidirectionalPort();
+}
+
 std::string getDriverInstanceDescription(const DriverGroup& group) {
     const ast::InstanceSymbol* instance = nullptr;
     if (group.containingSymbol->kind == ast::SymbolKind::Instance) {
@@ -258,25 +263,40 @@ std::string getDriverInstanceDescription(const DriverGroup& group) {
     return fmt::format("{} {}", instance->getDefinition().name, instance->getArrayName());
 }
 
-std::string getDriverDescription(const analysis::ValueDriver& driver) {
-    if (isPortDriver(driver))
-        return "via port";
-
+std::string getDriverSourceDescription(const analysis::ValueDriver& driver) {
     if (driver.flags.has(analysis::DriverFlags::Initializer))
-        return "by initializer";
+        return "initializer";
 
     if (driver.source == analysis::DriverSource::Subroutine)
-        return "by subroutine";
+        return "subroutine";
 
     if (driver.source != analysis::DriverSource::Other) {
-        return fmt::format("by {}", ast::SemanticFacts::getProcedureKindStr(
-                                        static_cast<ast::ProceduralBlockKind>(driver.source)));
+        return std::string(ast::SemanticFacts::getProcedureKindStr(
+            static_cast<ast::ProceduralBlockKind>(driver.source)));
     }
 
     if (driver.kind == analysis::DriverKind::Continuous)
-        return "by continuous assignment";
+        return "continuous assignment";
 
-    return "by procedural assignment";
+    return "procedural assignment";
+}
+
+std::string getDriverDescription(const analysis::ValueDriver& driver) {
+    // When the logic is assigned directly through the module:
+    // ie:
+    // assign MODULE_INSTANCE_NAME.MODULE_PORT = LOGIC;
+    if (isLogicThroughPort(driver))
+        return fmt::format("through port by {}", getDriverSourceDescription(driver));
+
+    // When the logic is assigned through a port:
+    // ie:
+    // MODULE_DEFINITION_NAME MODULE_INSTANCE_NAME (
+    //    .MODULE_PORT(LOGIC)
+    // )
+    if (isPortDriver(driver))
+        return "via port";
+
+    return fmt::format("by {}", getDriverSourceDescription(driver));
 }
 
 std::string getDriverGroupHeader(const DriverGroup& group) {
@@ -284,8 +304,9 @@ std::string getDriverGroupHeader(const DriverGroup& group) {
     const auto instanceDescription = getDriverInstanceDescription(group);
     for (const auto* driver : group.drivers) {
         auto description = getDriverDescription(*driver);
-        if (isPortDriver(*driver) && !instanceDescription.empty())
+        if (!isLogicThroughPort(*driver) && isPortDriver(*driver) && !instanceDescription.empty())
             description += fmt::format(" from `{}`", instanceDescription);
+
         if (std::ranges::find(descriptions, description) == descriptions.end())
             descriptions.push_back(std::move(description));
     }
@@ -341,7 +362,7 @@ const syntax::SyntaxNode* getDriverDisplayNode(const analysis::ValueDriver& driv
     if (!node)
         return nullptr;
 
-    if (isPortDriver(driver)) {
+    if (!isLogicThroughPort(driver) && isPortDriver(driver)) {
         for (auto* current = node; current; current = current->parent) {
             switch (current->kind) {
                 case syntax::SyntaxKind::ExplicitAnsiPort:

--- a/tests/cpp/HoverTests.cpp
+++ b/tests/cpp/HoverTests.cpp
@@ -14,6 +14,24 @@ static size_t countSubstring(std::string_view text, std::string_view substring) 
     return count;
 }
 
+static void normalizeHoverOutput(std::string& text, const DocumentHandle& doc) {
+    const auto uri = doc.m_uri.str();
+    for (size_t pos = 0; (pos = text.find(uri, pos)) != std::string::npos;) {
+        text.replace(pos, uri.size(), "file:///test.sv");
+        pos += std::string_view("file:///test.sv").size();
+    }
+
+    for (size_t newline = 0; (newline = text.find('\n', newline)) != std::string::npos;) {
+        auto whitespaceStart = newline;
+        while (whitespaceStart > 0 &&
+               (text[whitespaceStart - 1] == ' ' || text[whitespaceStart - 1] == '\t')) {
+            whitespaceStart--;
+        }
+        text.erase(whitespaceStart, newline - whitespaceStart);
+        newline = whitespaceStart + 1;
+    }
+}
+
 TEST_CASE("HoverMacroExpansion") {
     ServerHarness server;
 
@@ -621,6 +639,92 @@ endmodule
     CHECK(countSubstring(content, "Type: `logic[7:0]`") == 1);
     CHECK(countSubstring(content, "Width: `8`") == 1);
     CHECK(countSubstring(content, "Driven by continuous assignment") == 1);
+}
+
+TEST_CASE("Hover - Modport - Continuous Assignment") {
+    ServerHarness server;
+    GoldenTest golden;
+
+    auto doc = server.openFile("test.sv", R"(
+interface interrupt_if;
+    logic hblank_req;
+    modport PPU_side(output hblank_req);
+endinterface
+
+module PPU(interrupt_if.PPU_side interrupt_bus, interrupt_if.PPU_side interrupt_bus2);
+    logic [8:0] scan_x;
+    logic cycle;
+    assign interrupt_bus.hblank_req = (scan_x == 240 && cycle == 0);
+    assign interrupt_bus2.hblank_req = (scan_x == 240 && cycle == 0);
+endmodule
+
+module top;
+    interrupt_if interrupt_bus();
+    PPU ppu(interrupt_bus);
+endmodule
+)");
+
+    auto cursor = doc.before("hblank_req);");
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    normalizeHoverOutput(content, doc);
+    golden.record(content);
+    golden.record("\n");
+}
+
+TEST_CASE("Hover - Modport - AlwaysFF Assignment") {
+    ServerHarness server;
+    GoldenTest golden;
+
+    auto doc = server.openFile("test.sv", R"(
+interface interrupt_if;
+    logic hblank_req;
+    modport PPU_side(output hblank_req);
+endinterface
+
+module PPU(interrupt_if.PPU_side interrupt_bus);
+    logic [8:0] scan_x;
+    logic cycle;
+    always_ff @(posedge cycle) interrupt_bus.hblank_req <= (scan_x == 240 && cycle == 0);
+endmodule
+
+module top;
+    interrupt_if interrupt_bus();
+    PPU ppu(interrupt_bus);
+endmodule
+)");
+
+    auto cursor = doc.before("hblank_req);");
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    normalizeHoverOutput(content, doc);
+    golden.record(content);
+    golden.record("\n");
+}
+
+TEST_CASE("Hover - Plain Port Driver") {
+    ServerHarness server;
+    GoldenTest golden;
+
+    auto doc = server.openFile("test.sv", R"(
+module child(output logic data);
+endmodule
+
+module top;
+    logic value;
+    child u(.data(value));
+endmodule
+)");
+
+    auto cursor = doc.before("value;");
+    auto hover = doc.getHoverAt(cursor.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    normalizeHoverOutput(content, doc);
+    golden.record(content);
+    golden.record("\n");
 }
 
 TEST_CASE("HoverAndGotoExplicitModportPrototypeRetainsDeclaration") {

--- a/tests/cpp/golden/Hover - Modport - AlwaysFF Assignment.out
+++ b/tests/cpp/golden/Hover - Modport - AlwaysFF Assignment.out
@@ -1,0 +1,22 @@
+**ModportPort** `hblank_req` in `interrupt_if.PPU_side`
+Type: `logic`
+
+
+---
+
+````systemverilog
+output hblank_req
+````
+
+---
+
+````systemverilog
+logic hblank_req;
+````
+
+---
+
+Driven through port by always_ff at [test.sv:10:5](<file:///test.sv#L10,5>)
+````systemverilog
+always_ff @(posedge cycle) interrupt_bus.hblank_req <= (scan_x == 240 && cycle == 0);
+````

--- a/tests/cpp/golden/Hover - Modport - Continuous Assignment.out
+++ b/tests/cpp/golden/Hover - Modport - Continuous Assignment.out
@@ -1,0 +1,22 @@
+**ModportPort** `hblank_req` in `interrupt_if.PPU_side`
+Type: `logic`
+
+
+---
+
+````systemverilog
+output hblank_req
+````
+
+---
+
+````systemverilog
+logic hblank_req;
+````
+
+---
+
+Driven through port by continuous assignment at [test.sv:10:5](<file:///test.sv#L10,5>)
+````systemverilog
+assign interrupt_bus.hblank_req = (scan_x == 240 && cycle == 0);
+````

--- a/tests/cpp/golden/Hover - Plain Port Driver.out
+++ b/tests/cpp/golden/Hover - Plain Port Driver.out
@@ -1,0 +1,16 @@
+**Variable** `value` in `top`
+Type: `logic`
+
+
+---
+
+````systemverilog
+logic value;
+````
+
+---
+
+Driven via port from `child u` at [test.sv:7:13](<file:///test.sv#L7,13>)
+````systemverilog
+.data(value)
+````


### PR DESCRIPTION
<img width="1891" height="607" alt="image" src="https://github.com/user-attachments/assets/ef52942e-dde2-478b-abce-3b872bbf97d0" />

This PR shows when ports are driven indirectly:

```
assign MODULE_INSTANCE_NAME.PORT_NAME =  LOGIC
```

stacks onto #489 