### PR TITLE
Fix diagnostics overwritten by stale shallow re-analysis on reopen

### DIFF
--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -199,14 +199,15 @@ std::unique_ptr<ServerDriver> ServerDriver::create(Indexer& indexer, SlangLspCli
 
 void ServerDriver::openDocument(const URI& uri, const std::string_view text) {
     auto docIter = docs.find(uri);
+    bool wasTracked = docIter != docs.end();
     std::shared_ptr<SlangDoc> doc;
     bool alreadyInBuild = false;
-    if (docIter != docs.end() && docIter->second->textMatches(text)) {
+    if (wasTracked && docIter->second->textMatches(text)) {
         doc = docIter->second;
         alreadyInBuild = true;
     }
     else {
-        if (docIter != docs.end())
+        if (wasTracked)
             WARN("Document {} text does not match, updating", uri.getPath());
         doc = SlangDoc::fromText(*this, uri, text);
         docs[uri] = doc;
@@ -216,6 +217,14 @@ void ServerDriver::openDocument(const URI& uri, const std::string_view text) {
         // File is already part of the compilation — compilation diags were
         // already published, so skip shallow diags. Still publish inactive regions.
         publishInactiveRegions(*doc);
+    }
+    else if (comp && wasTracked) {
+        // Already part of the compilation but its text didn't match (e.g. a
+        // stale buffer diffing against a mid-reload full-build snapshot).
+        // Refresh the whole compilation instead of shallow-diagnosing just
+        // this file, so we don't overwrite correct diagnostics for the rest
+        // of the build with a narrower, incomplete pass.
+        updateDoc(*doc, FileUpdateType::SAVE);
     }
     else {
         updateDoc(*doc, FileUpdateType::OPEN);


### PR DESCRIPTION
Fixes #428.

`openDocument()` skips shallow re-diagnosis when a doc is already part of the active compilation, but that check requires an exact `textMatches()` - any mismatch (e.g. a restored buffer diffing against a mid-reload compilation snapshot) falls through to `updateDoc(..., OPEN)`, which unconditionally shallow-diagnoses just that one file, overwriting its correct full-build diagnostics.

Fix: when the doc is tracked and part of the compilation but its text didn't match, refresh the whole compilation instead of shallow-diagnosing the single file.

Built the real library with this change:
```
[100%] Built target slang_server_obj_lib
```
Couldn't run the Catch2 suite here - `tests/cpp/` hits a pre-existing MinGW-only build issue (Windows COM headers colliding with `slang::byte`), confirmed on a clean unmodified checkout too, unrelated to this change.
