### PR TITLE
Show resolved interface type parameters

### DIFF
--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -776,6 +776,10 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         [&](const ast::Symbol* symbol) -> std::optional<DefinitionInfo::SyntaxTarget> {
         auto* symSyntax = symbol->getSyntax();
         if (!symSyntax) {
+            if (auto* typeParam = symbol->as_if<ast::TypeParameterSymbol>())
+                symSyntax = typeParam->getTypeAlias().getSyntax();
+        }
+        if (!symSyntax) {
             ERROR("Failed to get syntax for symbol {} of kind {}", symbol->name,
                   toString(symbol->kind));
             return {};

--- a/src/completions/MemberCompletions.cpp
+++ b/src/completions/MemberCompletions.cpp
@@ -37,6 +37,7 @@
 #include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/AllTypes.h"
+#include "slang/ast/types/TypePrinter.h"
 #include "slang/parsing/TokenKind.h"
 #include "slang/syntax/SyntaxKind.h"
 #include "slang/syntax/SyntaxNode.h"
@@ -61,6 +62,40 @@ std::string getCompletionTypeString(const ast::Symbol& symbol, const ast::Type& 
         }
     }
     return type.toString();
+}
+
+const ast::Type* getResolvedTypeParameter(const ast::Symbol& symbol) {
+    auto* typeSymbol = &symbol;
+    if (auto* modportPort = symbol.as_if<ast::ModportPortSymbol>();
+        modportPort && modportPort->internalSymbol) {
+        typeSymbol = modportPort->internalSymbol;
+    }
+
+    auto* value = typeSymbol->as_if<ast::ValueSymbol>();
+    if (!value)
+        return nullptr;
+
+    auto* alias = value->getType().as_if<ast::TypeAliasType>();
+    if (!alias)
+        return nullptr;
+
+    // Preserve ordinary typedef names and only unwrap aliases introduced by type parameters.
+    auto* aliasSyntax = alias->getSyntax();
+    if (!aliasSyntax || !aliasSyntax->parent ||
+        aliasSyntax->parent->kind != syntax::SyntaxKind::TypeParameterDeclaration) {
+        return nullptr;
+    }
+
+    auto& type = alias->targetType.getType();
+    return type.isError() ? nullptr : &type;
+}
+
+std::string getTypeDetail(const ast::Type& type) {
+    ast::TypePrinter printer;
+    printer.options.elideScopeNames = true;
+    printer.options.skipTypeDefs = true;
+    printer.append(type);
+    return printer.toString();
 }
 
 class CompletionSymbolFinder
@@ -353,6 +388,9 @@ std::string getMemberCompletionDetail(const slang::ast::Symbol& symbol) {
             detailStr = "TypeAlias";
         }
     }
+    else if (slang::ast::TypeParameterSymbol::isKind(symbol.kind)) {
+        detailStr = "type";
+    }
     else if (slang::ast::InterfacePortSymbol::isKind(symbol.kind)) {
         auto& port = symbol.as<slang::ast::InterfacePortSymbol>();
         detailStr = port.interfaceDef ? std::string{port.interfaceDef->name} : "interface";
@@ -383,13 +421,16 @@ std::string getMemberCompletionDetail(const slang::ast::Symbol& symbol) {
         detailStr = getInstanceArrayCompletionDetail(symbol.as<ast::InstanceArraySymbol>());
     }
     else {
+        if (auto* resolvedType = getResolvedTypeParameter(symbol))
+            detailStr = getTypeDetail(*resolvedType);
+
         bool supportsDeclaredTypeDetail = slang::ast::ValueSymbol::isKind(symbol.kind) ||
-                                          slang::ast::ParameterSymbol::isKind(symbol.kind) ||
-                                          slang::ast::TypeParameterSymbol::isKind(symbol.kind);
+                                          slang::ast::ParameterSymbol::isKind(symbol.kind);
         auto declType = symbol.getDeclaredType();
         // For value symbols, unwrap their type to see in the dropdown, and go one layer up for
         // the syntax to include the type
-        if (supportsDeclaredTypeDetail && declType && declType->getTypeSyntax()) {
+        if (detailStr.empty() && supportsDeclaredTypeDetail && declType &&
+            declType->getTypeSyntax()) {
             auto typeSyntax = declType->getTypeSyntax();
             if (typeSyntax) {
                 detailStr = slang::syntax::SyntaxPrinter()
@@ -398,7 +439,7 @@ std::string getMemberCompletionDetail(const slang::ast::Symbol& symbol) {
                                 .str();
             }
         }
-        else if (supportsDeclaredTypeDetail) {
+        else if (detailStr.empty() && supportsDeclaredTypeDetail) {
             detailStr = toString(symbol.kind);
         }
     }
@@ -414,7 +455,9 @@ lsp::CompletionItem MemberCompletionQuery::getHierarchicalCompletion(
 
     if (ast::FieldSymbol::isKind(symbol.kind)) {
         auto& field = symbol.as<ast::FieldSymbol>();
-        auto detailStr = getCompletionTypeString(field, field.getType());
+        auto* resolvedType = getResolvedTypeParameter(symbol);
+        auto detailStr = resolvedType ? getTypeDetail(*resolvedType)
+                                      : getCompletionTypeString(field, field.getType());
         auto valSym = parentSymbol.as_if<ast::ValueSymbol>();
         auto descStr = valSym ? valSym->getType().getLexicalPath() : parentSymbol.getLexicalPath();
         auto item = lsp::CompletionItem{

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -533,9 +533,12 @@ void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol,
                        const SourceManager& sourceManager) {
     auto appendTypeParameterValue = [&](const ast::Type& type) {
         if (!type.isError()) {
-            infoPg.appendText("Value: ")
-                .appendText(getTypeString(type, TypeStringMode::FriendlyMarkdownQuoted))
-                .newLine();
+            infoPg.appendText("Value: ");
+            if (!appendSourceLink(infoPg, type.location, sourceManager,
+                                  getTypeString(type, TypeStringMode::Friendly))) {
+                infoPg.appendText(getTypeString(type, TypeStringMode::FriendlyMarkdownQuoted));
+            }
+            infoPg.newLine();
         }
     };
 

--- a/tests/cpp/CompletionTests.cpp
+++ b/tests/cpp/CompletionTests.cpp
@@ -958,6 +958,83 @@ TEST_CASE("HierarchicalInterfacePortCompletion") {
     CHECK(!hasCompletion(producerCompletions, "hidden"));
 }
 
+TEST_CASE("HierarchicalInterfaceInstanceCompletionUsesResolvedParameterType") {
+    ServerHarness server("repo1");
+
+    auto doc = server.openFile("parameterized_iface_completion.sv", R"(
+    typedef logic [3:0] nibble_t;
+
+    interface stream_if #(
+        parameter type element_t = logic
+    );
+        element_t data;
+    endinterface
+
+    module parameterized_iface_completion;
+        stream_if #(.element_t(logic [7:0])) stream();
+        stream_if #(.element_t(nibble_t)) narrow_stream();
+
+        initial begin
+            stream.data;
+            narrow_stream.data;
+        end
+    endmodule
+    )");
+
+    auto completions = doc.after("stream.").getCompletions(".");
+    auto data = std::ranges::find(completions, "data",
+                                  [](const CompletionHandle& item) { return item.m_item.label; });
+    REQUIRE(data != completions.end());
+    REQUIRE(data->m_item.labelDetails);
+    CHECK(data->m_item.labelDetails->detail == " logic[7:0]");
+    auto typeParameter = std::ranges::find(
+        completions, "element_t", [](const CompletionHandle& item) { return item.m_item.label; });
+    REQUIRE(typeParameter != completions.end());
+    REQUIRE(typeParameter->m_item.labelDetails);
+    CHECK(typeParameter->m_item.labelDetails->detail == " type");
+
+    auto narrowCompletions = doc.after("narrow_stream.").getCompletions(".");
+    auto narrowData = std::ranges::find(
+        narrowCompletions, "data", [](const CompletionHandle& item) { return item.m_item.label; });
+    REQUIRE(narrowData != narrowCompletions.end());
+    REQUIRE(narrowData->m_item.labelDetails);
+    CHECK(narrowData->m_item.labelDetails->detail == " nibble_t");
+}
+
+TEST_CASE("HierarchicalInterfacePortCompletionUsesPinnedParameterType") {
+    ServerHarness server("repo1");
+
+    auto doc = server.openFile("pinned_parameter_iface_completion.sv", R"(
+    package types_pkg;
+        typedef logic [15:0] event_t;
+    endpackage
+
+    interface event_if #(
+        parameter type data_type = logic
+    );
+        data_type data;
+        modport source(output data);
+    endinterface
+
+    module pinned_parameter_iface_completion (
+        event_if.source channel
+    );
+        $static_assert(type(channel.data_type) == type(types_pkg::event_t));
+
+        initial begin
+            channel.; // completion target
+        end
+    endmodule
+    )");
+
+    auto completions = doc.before("; // completion target").getCompletions(".");
+    auto data = std::ranges::find(completions, "data",
+                                  [](const CompletionHandle& item) { return item.m_item.label; });
+    REQUIRE(data != completions.end());
+    REQUIRE(data->m_item.labelDetails);
+    CHECK(data->m_item.labelDetails->detail == " event_t");
+}
+
 TEST_CASE("HierarchicalInterfacePortArrayCompletionWithUnresolvedBounds") {
     ServerHarness server("repo1");
 

--- a/tests/cpp/GotoTests.cpp
+++ b/tests/cpp/GotoTests.cpp
@@ -59,6 +59,35 @@ TEST_CASE("FindMultiSymbolRef") {
     scanner.scanDocument(hdl);
 }
 
+TEST_CASE("HoverAndGotoHierarchicalInterfaceTypeParameter") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+typedef logic [7:0] payload_t;
+
+interface stream_if #(
+    parameter type data_type = logic
+);
+endinterface
+
+module top;
+    stream_if #(.data_type(payload_t)) decoded_event_fifo();
+    localparam type resolved_t = type(decoded_event_fifo.data_type);
+endmodule
+)");
+
+    auto declaration = doc.before("data_type = logic");
+    auto use = doc.after("decoded_event_fifo.");
+    auto definitions = use.getDefinitions();
+    REQUIRE(definitions.size() == 1);
+    CHECK(definitions.front().targetSelectionRange.start == declaration.getPosition());
+
+    auto hover = doc.getHoverAt(use.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("Value: [`payload_t (aka logic[7:0])`](<file:") != std::string::npos);
+}
+
 TEST_CASE("GotoDefinition_UndefDirective") {
     ServerHarness server;
 

--- a/tests/cpp/golden/FindSymbolRef.out
+++ b/tests/cpp/golden/FindSymbolRef.out
@@ -183,7 +183,7 @@ macromodule m3;
     ^^ Ref -> **Module** `m2`  \n\\n\\n\---\n\\n\`module m2 #(\n\    parameter i = 1,\n\    localparam j = i,\n\    parameter type x_t = bit\n\)\n\    (input int a[], (* bar = "asdf" *) output logic b = 1, ref c,\n\    input p::y2 d2,\n\     interface.mod d, .e());`
 
         .x_t(y_t)
-         ^^^ Ref -> **TypeAlias** `x_t` in `m2`  \n\Value: `y_t` (aka `logic[1:0]`)  \n\Resolved Type: [`x_t (aka logic[1:0])`](<file:///tests/data/all.sv#L38,20>)  \n\Resolved Width: `2`  \n\\n\\n\---\n\\n\`parameter type x_t = bit`
+         ^^^ Ref -> **TypeAlias** `x_t` in `m2`  \n\Value: [`y_t (aka logic[1:0])`](<file:///tests/data/all.sv#L58,20>)  \n\Resolved Type: [`x_t (aka logic[1:0])`](<file:///tests/data/all.sv#L38,20>)  \n\Resolved Width: `2`  \n\\n\\n\---\n\\n\`parameter type x_t = bit`
              ^^^ Ref -> **TypeAlias** `y_t` in `m3`  \n\Resolved Type: [`y_t (aka logic[1:0])`](<file:///tests/data/all.sv#L58,20>)  \n\Resolved Width: `2`  \n\\n\\n\---\n\\n\`typedef p::y_t y_t;`
 
     ) m (, b, c, d, );
@@ -210,7 +210,7 @@ macromodule m3;
          ^ Ref -> **Parameter** `i` in `m2`  \n\Type: `logic signed[31:0]`  \n\Value: `1`  \n\\n\\n\---\n\\n\`parameter i = 1`
 
         .x_t(y2)
-         ^^^ Ref -> **TypeAlias** `x_t` in `m2`  \n\Value: `y2` (aka `logic[2:0]`)  \n\Resolved Type: [`x_t (aka logic[2:0])`](<file:///tests/data/all.sv#L38,20>)  \n\Resolved Width: `3`  \n\\n\\n\---\n\\n\`parameter type x_t = bit`
+         ^^^ Ref -> **TypeAlias** `x_t` in `m2`  \n\Value: [`y2 (aka logic[2:0])`](<file:///tests/data/all.sv#L65,19>)  \n\Resolved Type: [`x_t (aka logic[2:0])`](<file:///tests/data/all.sv#L38,20>)  \n\Resolved Width: `3`  \n\\n\\n\---\n\\n\`parameter type x_t = bit`
              ^^ Ref -> **TypeAlias** `y2` in `m3`  \n\Resolved Type: [`y2 (aka logic[2:0])`](<file:///tests/data/all.sv#L65,19>)  \n\Resolved Width: `3`  \n\\n\\n\---\n\\n\`typedef p::y2 y2;`
 
     ) m2_inst (


### PR DESCRIPTION
Completions now show the resolved type parameter type, not just something like `parameter data_type`
Hovers for type params also now show their value with a type link.