### PR TITLE
Vscode: Advertise client version and send warning from server

### DIFF
--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -4,10 +4,16 @@ import { Config } from './config.gen'
 
 export type { Config }
 
+export interface SlangClientInfo {
+  name: string
+  version: string
+}
+
 export type ExperimentalCapabilities = {
   inactiveRegions?: {
     inactiveRegions: boolean
   }
+  slangClient?: SlangClientInfo
 }
 
 export enum SlangKind {

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -31,6 +31,7 @@ import {
   toPosix,
 } from './utils'
 import { glob } from 'glob'
+import { SlangClientInfoFeature } from './lib/clientInfo'
 import { InactiveRegionsFeature } from './lib/inactiveRegions'
 
 export var ext: SlangExtension
@@ -182,7 +183,12 @@ File input is sent to stdin, and formatted output is read from stdout.',
     }
 
     this.client = new LanguageClient('slang-server', serverOptions, clientOptions)
+    const clientInfo = {
+      name: this.context.extension.packageJSON.name as string,
+      version: this.context.extension.packageJSON.version as string,
+    }
 
+    this.client.registerFeature(new SlangClientInfoFeature(clientInfo))
     this.client.registerFeature(this.inactiveRegions)
     this.inactiveRegions.register(this.client)
 
@@ -220,9 +226,8 @@ File input is sent to stdin, and formatted output is read from stdout.',
     await this.project.onStart()
 
     // Log and check version compatibility
-    const clientVersion = vscode.extensions.getExtension('Hudson-River-Trading.vscode-slang')
-      ?.packageJSON.version
-    this.logger.info(`Using slang-vscode v${clientVersion ?? 'unknown'}`)
+    const clientVersion = clientInfo.version
+    this.logger.info(`Using ${clientInfo.name} v${clientVersion}`)
 
     const serverInfo = this.client.initializeResult?.serverInfo
     const serverFullVersion = serverInfo?.version?.trim()

--- a/clients/vscode/src/lib/clientInfo.ts
+++ b/clients/vscode/src/lib/clientInfo.ts
@@ -1,0 +1,26 @@
+import type * as vscodelc from 'vscode-languageclient/node'
+import type { ExperimentalCapabilities, SlangClientInfo } from '../SlangInterface'
+
+export class SlangClientInfoFeature implements vscodelc.StaticFeature {
+  constructor(private readonly clientInfo: SlangClientInfo) {}
+
+  fillClientCapabilities(capabilities: vscodelc.ClientCapabilities): void {
+    if (!capabilities.experimental) {
+      capabilities.experimental = {}
+    }
+
+    const exp = capabilities.experimental as ExperimentalCapabilities
+    exp.slangClient = this.clientInfo
+  }
+
+  initialize(
+    _capabilities: vscodelc.ServerCapabilities,
+    _documentSelector: vscodelc.DocumentSelector | undefined
+  ) {}
+
+  getState(): vscodelc.FeatureState {
+    return { kind: 'static' }
+  }
+
+  clear() {}
+}

--- a/clients/vscode/test/unit/clientInfo.test.ts
+++ b/clients/vscode/test/unit/clientInfo.test.ts
@@ -1,0 +1,15 @@
+import tape from 'tape'
+import type * as vscodelc from 'vscode-languageclient/node'
+import { SlangClientInfoFeature } from '../../src/lib/clientInfo'
+
+tape('SlangClientInfoFeature advertises the extension identity', (assert) => {
+  const capabilities: vscodelc.ClientCapabilities = {}
+  const feature = new SlangClientInfoFeature({ name: 'vscode-slang', version: '1.2.3' })
+
+  feature.fillClientCapabilities(capabilities)
+
+  assert.deepEqual(capabilities.experimental, {
+    slangClient: { name: 'vscode-slang', version: '1.2.3' },
+  })
+  assert.end()
+})

--- a/docs/development/versioning.md
+++ b/docs/development/versioning.md
@@ -1,0 +1,35 @@
+# Versioning and releases
+
+The `slang-server` binary and VS Code extension use independent semantic
+versions. Patch versions can advance independently, but the major and minor
+versions describe the shared feature set. Each side warns when the other has an
+older major or minor version.
+
+## Version sources
+
+| Component | Version source | Release workflow |
+| --- | --- | --- |
+| Server | [`VERSION`](https://github.com/hudson-trading/slang-server/blob/main/VERSION) | `release.yml` |
+| VS Code extension | [`clients/vscode/package.json`](https://github.com/hudson-trading/slang-server/blob/main/clients/vscode/package.json) | `vscode-publish.yml` |
+
+## Compatibility
+
+The VS Code extension requires a server with at least its major and minor
+version. The server also warns when the extension has an older major or minor
+version. Patch differences do not generate compatibility warnings.
+
+The extension advertises its name and version through the
+`experimental.slangClient` initialization capability. The server uses this
+information to detect an older extension during initialization.
+
+## Server release assets
+
+The server release workflow publishes one archive per supported platform. The
+VS Code installer uses the canonical names, such as
+`slang-server-linux-x64.tar.gz`, `slang-server-macos.tar.gz`, and
+`slang-server-windows-x64.zip`.
+
+Releases also include `slang-server-old-linux-x64-gcc.tar.gz` and
+`slang-server-linux-arm64-clang.tar.gz` compatibility aliases for clients that
+predate the canonical Linux names. Keep these aliases until those client
+versions no longer need to install current server releases.

--- a/include/lsp/LspTypeExtensions.h
+++ b/include/lsp/LspTypeExtensions.h
@@ -21,8 +21,14 @@ struct InactiveRegionsClientCapabilities {
     std::optional<bool> inactiveRegions;
 };
 
+struct SlangClientInfo {
+    std::optional<std::string> name;
+    std::optional<std::string> version;
+};
+
 struct ExperimentalClientCapabilities {
     std::optional<InactiveRegionsClientCapabilities> inactiveRegions;
+    std::optional<SlangClientInfo> slangClient;
 };
 
 struct InactiveRegionsParams {

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -83,6 +83,8 @@ nav:
       - start/building.md
       - start/installing.md
       - start/config.md
+  - Development:
+      - Versioning and releases: development/versioning.md
   - Features:
       - features/features.md
       - features/formatting.md

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -13,12 +13,14 @@
 #include "ast/WcpClient.h"
 #include "completions/CompletionContext.h"
 #include "completions/CompletionDispatch.h"
+#include "lsp/LspTypeExtensions.h"
 #include "lsp/LspTypes.h"
 #include "lsp/URI.h"
 #include "util/Converters.h"
 #include "util/Logging.h"
 #include <algorithm>
 #include <cctype>
+#include <charconv>
 #include <filesystem>
 #include <fmt/base.h>
 #include <fmt/ranges.h>
@@ -26,8 +28,10 @@
 #include <optional>
 #include <ranges>
 #include <rfl/Variant.hpp>
+#include <rfl/from_generic.hpp>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -165,6 +169,54 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
 
     loadConfig();
     m_driver->completions.resolveEdits = m_client.capabilities.completionEditResolveSupported;
+
+    if (params.capabilities.experimental) {
+        auto exp = rfl::from_generic<lsp::ExperimentalClientCapabilities>(
+            *params.capabilities.experimental);
+
+        if (exp) {
+            if (exp->slangClient) {
+                const auto& client = *exp->slangClient;
+                const auto clientName = client.name.value_or("slang client");
+                INFO("Using {} v{}", clientName, client.version.value_or("unknown"));
+                auto parseVersion = [](std::string_view version) {
+                    std::optional<std::pair<int, int>> result;
+                    if (version.starts_with('v'))
+                        version.remove_prefix(1);
+
+                    int major = 0;
+                    auto [majorEnd, majorError] =
+                        std::from_chars(version.data(), version.data() + version.size(), major);
+                    if (majorError != std::errc() || majorEnd == version.data() + version.size() ||
+                        *majorEnd != '.') {
+                        return result;
+                    }
+
+                    int minor = 0;
+                    auto [minorEnd, minorError] =
+                        std::from_chars(majorEnd + 1, version.data() + version.size(), minor);
+                    if (minorError != std::errc() ||
+                        (minorEnd != version.data() + version.size() && *minorEnd != '.')) {
+                        return result;
+                    }
+                    return std::optional(std::pair(major, minor));
+                };
+
+                const auto parsed = client.version ? parseVersion(*client.version) : std::nullopt;
+                const auto required = std::pair(VersionInfo::getMajor(), VersionInfo::getMinor());
+                if (!parsed) {
+                    m_client.showWarning(
+                        fmt::format("Could not determine the {} version. Please update {}.",
+                                    clientName, clientName));
+                }
+                else if (*parsed < required) {
+                    m_client.showWarning(fmt::format(
+                        "{} v{} is older than the server requirement {}.{}.x. Please update {}.",
+                        clientName, *client.version, required.first, required.second, clientName));
+                }
+            }
+        }
+    }
 
     auto result = lsp::InitializeResult{
         .capabilities =

--- a/tests/cpp/InitializeTests.cpp
+++ b/tests/cpp/InitializeTests.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "utils/ServerHarness.h"
+
+TEST_CASE("Initialize accepts a compatible editor extension") {
+    auto params = rfl::json::read<lsp::InitializeParams>(R"(
+{
+  "capabilities": {
+    "experimental": {
+      "otherClientFeature": true,
+      "slangClient": {
+        "name": "vscode-slang",
+        "version": "0.2.17"
+      }
+    }
+  }
+}
+)");
+    REQUIRE(params);
+    ServerHarness server(std::move(*params));
+}
+
+TEST_CASE("Initialize warns about an old editor extension") {
+    auto params = rfl::json::read<lsp::InitializeParams>(R"(
+{
+  "capabilities": {
+    "experimental": {
+      "slangClient": {
+        "name": "vscode-slang",
+        "version": "0.0.0"
+      }
+    }
+  }
+}
+)");
+    REQUIRE(params);
+    ServerHarness server(std::move(*params));
+    server.client.expectWarning("vscode-slang v0.0.0 is older than the server requirement");
+}


### PR DESCRIPTION
Advertise VS Code client versions during initialization and warn when client and server versions are incompatible