### PR TITLE
Shallow Compilation: Limit with maxInstanceDepth to avoid deep nesting

### DIFF
--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -102,6 +102,9 @@ public:
 
     const std::unique_ptr<slang::ast::Compilation>& getCompilation() const { return m_compilation; }
 
+    /// @brief Gets semantic diagnostics after shallowly elaborating edited-file definitions.
+    const Diagnostics& getSemanticDiagnostics();
+
     /// @brief Ensures the shallow compilation has been analyzed and returns the slang
     /// `AnalysisManager`. Returns nullptr if analysis could not be run, for example no top
     /// instances.
@@ -191,6 +194,8 @@ private:
 
     /// Cached diagnostics from the latest analysis run, if available
     std::optional<Diagnostics> m_cachedAnalysisDiags;
+
+    bool m_editedDefinitionsElaborated = false;
 
     /// Analysis options for driver analysis (numThreads=1 to avoid persistent threads)
     slang::analysis::AnalysisOptions m_analysisOptions;

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -22,6 +22,7 @@
 #include "slang/ast/ASTContext.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/symbols/BlockSymbols.h"
+#include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/ast/symbols/ParameterSymbols.h"
@@ -96,6 +97,8 @@ ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID b
     cOptions.flags |= ast::CompilationFlags::AllowTopLevelIfacePorts;
     cOptions.flags |= ast::CompilationFlags::CheckUninstantiated;
     cOptions.flags |= ast::CompilationFlags::AllowInvalidTop;
+    // Check the edited module and two levels of instantiated children.
+    cOptions.maxInstanceDepth = 3;
 
     // Add definitions from this tree (even if they aren't valid tops)
     cOptions.topModules.clear();
@@ -108,6 +111,24 @@ ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID b
     // - token -> symbol defs
     // - syntax -> scopes
     m_compilation->getRoot().visit(m_symbolIndexer);
+}
+
+const Diagnostics& ShallowAnalysis::getSemanticDiagnostics() {
+    if (!m_editedDefinitionsElaborated) {
+        auto& root = m_compilation->getRoot();
+        for (auto* symbol : m_compilation->getDefinitions()) {
+            auto* definition = symbol->as_if<ast::DefinitionSymbol>();
+            if (!definition || definition->syntaxTree != m_tree.get())
+                continue;
+
+            auto& instance = ast::InstanceSymbol::createDefault(*m_compilation, *definition);
+            instance.setParent(root);
+            m_compilation->forceElaborate(instance.body);
+        }
+        m_editedDefinitionsElaborated = true;
+    }
+
+    return m_compilation->getSemanticDiagnostics();
 }
 
 std::vector<lsp::DocumentSymbol> ShallowAnalysis::getDocSymbols() {
@@ -1044,7 +1065,7 @@ const slang::analysis::AnalysisManager* ShallowAnalysis::getAnalysisManager() {
         return m_driverAnalysis.get();
     }
 
-    (void)m_compilation->getSemanticDiagnostics();
+    (void)getSemanticDiagnostics();
 
     if (!m_compilation || m_compilation->getRoot().topInstances.empty()) {
         m_cachedAnalysisDiags = Diagnostics{};

--- a/src/document/SlangDoc.cpp
+++ b/src/document/SlangDoc.cpp
@@ -21,6 +21,7 @@
 #include <string_view>
 
 #include "slang/ast/Compilation.h"
+#include "slang/diagnostics/CompilationDiags.h"
 #include "slang/diagnostics/DeclarationsDiags.h"
 #include "slang/diagnostics/Diagnostics.h"
 #include "slang/diagnostics/ExpressionsDiags.h"
@@ -255,7 +256,6 @@ void SlangDoc::issueParseDiagnostics(DiagnosticEngine& diagEngine) {
 void SlangDoc::issueDiagnosticsTo(DiagnosticEngine& diagEngine) {
     // Issue compilation diagnostics
     auto analysis = getAnalysis(true);
-    auto& shallowComp = *analysis->getCompilation();
 
     // Parse diags (just this tree, others will be handled by their SlangDoc objects
     for (auto& diag : getSyntaxTree()->diagnostics()) {
@@ -264,8 +264,12 @@ void SlangDoc::issueDiagnosticsTo(DiagnosticEngine& diagEngine) {
 
     // Parse and shallow compilation diagnostics
     // There will be many diags outside the buffer, like unknown modules.
-    for (auto& diag : shallowComp.getSemanticDiagnostics()) {
+    const auto& semanticDiagnostics = analysis->getSemanticDiagnostics();
+    for (auto& diag : semanticDiagnostics) {
         if (m_sourceManager.getFullyOriginalLoc(diag.location).buffer() != m_buffer.id) {
+            continue;
+        }
+        if (diag.code == slang::diag::MaxInstanceDepthExceeded) {
             continue;
         }
         diagEngine.issue(diag);

--- a/tests/cpp/DiagTests.cpp
+++ b/tests/cpp/DiagTests.cpp
@@ -5,6 +5,9 @@
 #include "utils/ServerHarness.h"
 #include <cstdlib>
 
+#include "slang/diagnostics/CompilationDiags.h"
+#include "slang/diagnostics/ExpressionsDiags.h"
+
 TEST_CASE("SingleFileDiag") {
     ServerHarness server;
 
@@ -515,4 +518,105 @@ endmodule
                    code == "unused-but-set-variable"));
         }
     }
+}
+
+TEST_CASE("ShallowCompilationSuppressesMaxInstanceDepth") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(
+module leaf;
+endmodule
+
+module level3;
+    leaf child();
+endmodule
+
+module level2;
+    level3 child();
+endmodule
+
+module level1;
+    level2 child();
+endmodule
+
+module top;
+    level1 child();
+endmodule
+)");
+
+    auto& semanticDiags = doc.doc->getCompilation()->getSemanticDiagnostics();
+    CHECK(std::ranges::any_of(semanticDiags, [](const auto& diag) {
+        return diag.code == slang::diag::MaxInstanceDepthExceeded;
+    }));
+    CHECK(doc.getDiagnostics().empty());
+}
+
+TEST_CASE("ShallowCompilationKeepsExpressionDiagWithMatchingNumericCode") {
+    CHECK(slang::diag::BadIntegerCast.getCode() == slang::diag::MaxInstanceDepthExceeded.getCode());
+    CHECK(slang::diag::BadIntegerCast.getSubsystem() !=
+          slang::diag::MaxInstanceDepthExceeded.getSubsystem());
+
+    ServerHarness server;
+    auto doc = server.openFile("test.sv", R"(
+module top;
+    initial 4'(1.0);
+endmodule
+)");
+
+    auto diags = doc.getDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags.front().message ==
+          "cannot change width or signedness of non-integral expression (type is 'real')");
+}
+
+TEST_CASE("ShallowCompilationChecksExpressionsPastDepthLimit") {
+    ServerHarness server;
+
+    auto doc = server.openFile("test.sv", R"(`default_nettype none
+module receiver #(
+    parameter int WIDTH = 1,
+    parameter int DEPTH = 1
+) (input logic value);
+endmodule
+
+module checked_module;
+    logic value;
+    assign value = missing_assign_rhs;
+    receiver #(
+        .WIDTH(missing_param_rhs),
+        .DEPTH(missing_second_param_rhs)
+    ) receiver_i(.value(missing_port_rhs));
+endmodule
+
+module level_two;
+    checked_module checked_module_i();
+endmodule
+
+module level_one;
+    level_two level_two_i();
+endmodule
+
+module top;
+    level_one level_one_i();
+endmodule
+)");
+
+    auto diags = doc.getDiagnostics();
+    bool sawAssignRhs = false;
+    bool sawParamRhs = false;
+    bool sawSecondParamRhs = false;
+    bool sawPortRhs = false;
+    for (const auto& diag : diags) {
+        sawAssignRhs |= diag.message == "use of undeclared identifier 'missing_assign_rhs'";
+        sawParamRhs |= diag.message == "use of undeclared identifier 'missing_param_rhs'";
+        sawSecondParamRhs |= diag.message ==
+                             "use of undeclared identifier 'missing_second_param_rhs'";
+        sawPortRhs |= diag.message == "use of undeclared identifier 'missing_port_rhs'";
+    }
+
+    REQUIRE(diags.size() == 4);
+    CHECK(sawAssignRhs);
+    CHECK(sawParamRhs);
+    CHECK(sawSecondParamRhs);
+    CHECK(sawPortRhs);
 }


### PR DESCRIPTION
Only directly referenced modules are loaded, but elaboration can still run deep if modules are referenced again by children modules, leading to lag