### PR TITLE
Implement Active Instances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ add_library(
   slang_server_obj_lib OBJECT
   ${CMAKE_CURRENT_BINARY_DIR}/VersionInfo.cpp
   src/SystemTaskDocs.cpp
+  src/ast/ActiveDesignContext.cpp
   src/ast/ServerCompilation.cpp
   src/ast/ServerCompilationAnalysis.cpp
   src/ast/WcpClient.cpp

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Intuitive completions for module instances and macros, as well as scope members 
 
 ![](docs/assets/images/completions.gif)
 
-HDL-specific features that allow you to easily set a filelist or top level for a design, browse the elaborated hierarchy, and go back and forth with a waveform viewer.
+HDL-specific features that allow you to set a filelist or top level, browse the elaborated hierarchy, select the active instance of each module, inspect instance-specific values, and go back and forth with a waveform viewer.
 
 ![](docs/assets/images/hdl.gif)
 

--- a/clients/neovim/README.md
+++ b/clients/neovim/README.md
@@ -7,7 +7,19 @@ A Neovim plugin to support non-LSP features of [Slang Server](https://github.com
 Note that it is not necessary to install this plugin in order to use Slang Server.
 Neovim supports all standard [LSP](https://microsoft.github.io/language-server-protocol/) commands.
 This plugin is for the following features which extend the standard LSP interface.
-More information on plugin features can be [found here](https://hudson-trading.github.io/slang-server/hdl/neovim/).
+More information on plugin features can be [found here](https://hudson-trading.github.io/slang-server/features/hdl/neovim/).
+
+The hierarchy and Cells views can select an active elaborated instance for each module or interface. That selection drives instance-specific hovers and inlay hints, and stays synchronized with CodeLens and Go to Definition navigation.
+
+Hierarchy search is also available to Neovim integrations without transferring the full design:
+
+```lua
+require("slang-server").search_hierarchy("fifo.data", function(result)
+  vim.print(result.totalResults, result.matches)
+end)
+```
+
+The server performs the fuzzy match and returns at most 100 entries per query.
 
 ## Requirements
 

--- a/clients/neovim/ftplugin/systemverilog.lua
+++ b/clients/neovim/ftplugin/systemverilog.lua
@@ -13,6 +13,8 @@ if vim.lsp.config then
    })
 end
 
+require("slang-server._lsp.clientCommands").register()
+
 local subcommands = {}
 subcommands = vim.tbl_deep_extend("error", subcommands, require("slang-server._commands.setTopLevel"))
 subcommands = vim.tbl_deep_extend("error", subcommands, require("slang-server._commands.setBuildFile"))

--- a/clients/neovim/lua/slang-server/_lsp/client.lua
+++ b/clients/neovim/lua/slang-server/_lsp/client.lua
@@ -73,6 +73,16 @@ end
 
 ---@param bufnr integer
 ---@param handlers RespHandlers
+---@param params { query: string }
+M.searchHierarchy = function(bufnr, handlers, params)
+   lsp_execute(bufnr, {
+      command = "slang.searchHierarchy",
+      arguments = { params.query },
+   }, handlers)
+end
+
+---@param bufnr integer
+---@param handlers RespHandlers
 M.getScopesByModule = function(bufnr, handlers)
    lsp_execute(bufnr, {
       command = "slang.getScopesByModule",
@@ -87,6 +97,16 @@ M.getInstancesOfModule = function(bufnr, handlers, params)
    lsp_execute(bufnr, {
       command = "slang.getInstancesOfModule",
       arguments = { params.moduleName },
+   }, handlers)
+end
+
+---@param bufnr integer
+---@param handlers RespHandlers
+---@param params { hierPath: string }
+M.setActiveInstance = function(bufnr, handlers, params)
+   lsp_execute(bufnr, {
+      command = "slang.setActiveInstance",
+      arguments = { params.hierPath },
    }, handlers)
 end
 

--- a/clients/neovim/lua/slang-server/_lsp/clientCommands.lua
+++ b/clients/neovim/lua/slang-server/_lsp/clientCommands.lua
@@ -1,0 +1,94 @@
+local M = {}
+
+---@param command string
+---@param value any
+---@param ctx table
+M.executeServerCommand = function(command, value, ctx)
+   local client = vim.lsp.get_client_by_id(ctx.client_id)
+   if not client then
+      vim.notify(
+         "slang-server: quick pick LSP client is no longer available",
+         vim.log.levels.ERROR
+      )
+      return
+   end
+   client:request(
+      "workspace/executeCommand",
+      { command = command, arguments = { value } },
+      function(err)
+         if err then
+            vim.notify(err.message, vim.log.levels.ERROR)
+         end
+      end,
+      ctx.bufnr
+   )
+end
+
+---@param command lsp.Command
+---@param ctx table
+M.quickPick = function(command, ctx)
+   local params = command.arguments and command.arguments[1]
+   if
+      type(params) ~= "table"
+      or type(params.items) ~= "table"
+      or type(params.onSelectCommand) ~= "string"
+   then
+      vim.notify("slang-server: invalid quick pick command", vim.log.levels.ERROR)
+      return
+   end
+
+   vim.ui.select(params.items, {
+      prompt = params.placeholder,
+      format_item = function(item)
+         if item.description then
+            return item.label .. " " .. item.description
+         end
+         return item.label
+      end,
+   }, function(item)
+      if not item then
+         return
+      end
+
+      M.executeServerCommand(params.onSelectCommand, item.value, ctx)
+   end)
+end
+
+---@param params { hierPath: string }
+M.revealInHierarchy = function(params)
+   local navigation = require("slang-server.navigation")
+   if not navigation.state.open then
+      return
+   end
+   require("slang-server.navigation/hierarchy").open_remainder(
+      nil,
+      true,
+      params.hierPath,
+      false
+   )
+end
+
+---@param _err lsp.ResponseError?
+---@param params { hierPath: string }
+M.activeInstanceChanged = function(_err, params)
+   M.revealInHierarchy(params)
+end
+
+---@param command lsp.Command
+M.showInHierarchy = function(command)
+   local params = command.arguments and command.arguments[1]
+   if type(params) ~= "table" or type(params.hierPath) ~= "string" then
+      vim.notify("slang-server: invalid show in hierarchy command", vim.log.levels.ERROR)
+      return
+   end
+   M.revealInHierarchy(params)
+end
+
+M.register = function()
+   vim.lsp.commands = vim.lsp.commands or {}
+   vim.lsp.commands["slang.quickPick"] = M.quickPick
+   vim.lsp.commands["slang.showInHierarchy"] = M.showInHierarchy
+   vim.lsp.handlers["slang/activeInstanceChanged"] = M.activeInstanceChanged
+end
+
+return M

--- a/clients/neovim/lua/slang-server/_lsp/types.lua
+++ b/clients/neovim/lua/slang-server/_lsp/types.lua
@@ -51,4 +51,15 @@
 ---@field instCount integer
 ---@field inst slang-server.lsp.QualifiedInstance?
 
+---@class slang-server.lsp.HierarchySearchItem
+---@field name string
+---@field path string
+---@field kind slang-server.SlangKind
+---@field description string?
+---@field containerName string?
+
+---@class slang-server.lsp.HierarchySearchResult
+---@field totalResults integer
+---@field matches slang-server.lsp.HierarchySearchItem[]
+
 ---@alias RespHandlers {on_success: fun(resp: any), on_failure?: fun(message: string)}

--- a/clients/neovim/lua/slang-server/init.lua
+++ b/clients/neovim/lua/slang-server/init.lua
@@ -10,4 +10,18 @@ M.setup = function(opts)
    config.update(opts)
 end
 
+---@param query string
+---@param callback fun(result: slang-server.lsp.HierarchySearchResult)
+---@param opts slang-server.SearchHierarchyOptions?
+M.search_hierarchy = function(query, callback, opts)
+   opts = opts or {}
+   local capabilities = require("slang-server._lsp.capabilities")
+   local client = require("slang-server._lsp.client")
+   local handlers = require("slang-server.handlers")
+   client.searchHierarchy(opts.bufnr or capabilities.get_source_context(), {
+      on_success = callback,
+      on_failure = opts.on_error or handlers.defaultOnFailure,
+   }, { query = query })
+end
+
 return M

--- a/clients/neovim/lua/slang-server/navigation/cells.lua
+++ b/clients/neovim/lua/slang-server/navigation/cells.lua
@@ -66,7 +66,9 @@ local function scope_jump(node)
       return
    end
 
-   hier.open_remainder(nil, true, instPath, true)
+   navigation.set_active_instance(instPath, function()
+      hier.open_remainder(nil, true, instPath, true)
+   end)
 end
 
 ---@param insts slang-server.lsp.QualifiedInstance[]

--- a/clients/neovim/lua/slang-server/navigation/hierarchy.lua
+++ b/clients/neovim/lua/slang-server/navigation/hierarchy.lua
@@ -54,6 +54,7 @@ local function map_keys(split, tree)
          impl = function(node)
             if node and node.instLoc then
                util.jump_loc(node.instLoc, navigation.state.sv_win.winnr)
+               navigation.set_active_instance(node.path)
             end
          end,
          opts = { noremap = true },

--- a/clients/neovim/lua/slang-server/navigation/init.lua
+++ b/clients/neovim/lua/slang-server/navigation/init.lua
@@ -1,6 +1,8 @@
 local hl = require("slang-server._core.highlights")
 local ui = require("slang-server._core.ui")
 local util = require("slang-server.util")
+local client = require("slang-server._lsp.client")
+local handlers = require("slang-server.handlers")
 local hier = require("slang-server.navigation/hierarchy")
 local cells = require("slang-server.navigation/cells")
 
@@ -87,6 +89,21 @@ end
 ---@return string
 function M.get_node_id(node)
    return node._uid
+end
+
+---@param hier_path string
+---@param on_success fun()?
+function M.set_active_instance(hier_path, on_success)
+   local source = M.state.sv_buf
+   if not source then
+      vim.notify("No SV buffer", vim.log.levels.ERROR)
+      return
+   end
+
+   client.setActiveInstance(source.bufnr, {
+      on_success = on_success or function() end,
+      on_failure = handlers.defaultOnFailure,
+   }, { hierPath = hier_path })
 end
 
 ---@param top slang-server.navigation.Path The top level at which to initialise the hierarchy

--- a/clients/neovim/lua/slang-server/types.lua
+++ b/clients/neovim/lua/slang-server/types.lua
@@ -34,6 +34,10 @@
 
 ---@alias slang-server.config.Highlights table<string, vim.api.keyset.highlight>
 
+---@class (exact) slang-server.SearchHierarchyOptions
+---@field bufnr integer?
+---@field on_error fun(message: string)?
+
 --- Navigation types
 
 ---@alias slang-server.navigation.Path string

--- a/clients/neovim/spec/plugin_spec.lua
+++ b/clients/neovim/spec/plugin_spec.lua
@@ -4,12 +4,14 @@ local function wait_on(buf_name)
    local lines
 
    local buf = nil
-   for _, win in ipairs(vim.api.nvim_list_wins()) do
-      local this_buf = vim.api.nvim_win_get_buf(win)
+   local win = nil
+   for _, candidate_win in ipairs(vim.api.nvim_list_wins()) do
+      local this_buf = vim.api.nvim_win_get_buf(candidate_win)
       local this_name = vim.api.nvim_buf_get_name(this_buf)
 
       if string.find(this_name, buf_name, 1, true) then
          buf = this_buf
+         win = candidate_win
          break
       end
    end
@@ -29,7 +31,24 @@ local function wait_on(buf_name)
    end)
    assert(success, lines)
 
-   return lines
+   return lines, win
+end
+
+local function find_line(lines, text)
+   for index, line in ipairs(lines) do
+      if string.find(line, text, 1, true) then
+         return index
+      end
+   end
+   error("Could not find line containing " .. text)
+end
+
+local function press_key(win, line, key)
+   vim.api.nvim_set_current_win(win)
+   vim.api.nvim_win_set_cursor(win, { line, 0 })
+   local mapping = vim.fn.maparg(key, "n", false, true)
+   assert.is_function(mapping.callback)
+   mapping.callback()
 end
 
 ---@param fn fun()
@@ -81,6 +100,8 @@ describe("SlangServer", function()
    -- load test SV
    vim.cmd("edit tests/foo.sv")
    vim.cmd("set filetype=systemverilog")
+   local source_buf = vim.api.nvim_get_current_buf()
+   local source_win = vim.api.nvim_get_current_win()
    -- start slang-server
    local server_bin = os.getenv("SLANG_SERVER_BIN") or "../../build/bin/slang-server"
    local client = vim.lsp.start({
@@ -91,6 +112,60 @@ describe("SlangServer", function()
       capabilities = require("slang-server._lsp.capabilities").make_client_capabilities(),
    })
    assert(client)
+   local function execute_server_command(command, arguments)
+      local done = false
+      local response
+      local request_error
+      vim.lsp.get_client_by_id(client):request(
+         "workspace/executeCommand",
+         { command = command, arguments = arguments },
+         function(err, result)
+            request_error = err
+            response = result
+            done = true
+         end,
+         source_buf
+      )
+      assert(vim.wait(5000, function()
+         return done
+      end))
+      assert.is_nil(request_error)
+      return response
+   end
+
+   local function press_key_and_wait_for_activation(win, line)
+      local navigation = require("slang-server.navigation")
+      local original_set_active_instance = navigation.set_active_instance
+      local activated_path
+      navigation.set_active_instance = function(hier_path, on_success)
+         original_set_active_instance(hier_path, function()
+            activated_path = hier_path
+            if on_success then
+               on_success()
+            end
+         end)
+      end
+
+      local ok, err = pcall(function()
+         press_key(win, line, "<CR>")
+         assert(vim.wait(5000, function()
+            return activated_path ~= nil
+         end))
+      end)
+      navigation.set_active_instance = original_set_active_instance
+      assert(ok, err)
+      return activated_path
+   end
+
+   local function focus_source()
+      if vim.api.nvim_win_is_valid(source_win) then
+         vim.api.nvim_set_current_win(source_win)
+      end
+      if vim.api.nvim_buf_is_valid(source_buf) then
+         vim.api.nvim_set_current_buf(source_buf)
+      end
+   end
+
    -- wait for client to attach to this buffer
    local success, _ = vim.wait(5000, function()
       return #vim.lsp.get_clients() > 0
@@ -100,7 +175,121 @@ describe("SlangServer", function()
    vim.cmd("luafile ftplugin/systemverilog.lua")
    vim.cmd("luafile lua/slang-server/init.lua")
    -- compile design
-   vim.cmd("SlangServer setTopLevel")
+   execute_server_command("slang.setTopLevel", { vim.api.nvim_buf_get_name(source_buf) })
+
+   before_each(focus_source)
+
+   after_each(function()
+      local navigation = require("slang-server.navigation")
+      local ok, err = pcall(function()
+         if navigation.state.open then
+            navigation.on_close()
+         end
+      end)
+      focus_source()
+      assert(ok, err)
+   end)
+
+   it("Generic quick pick dispatches its selected value", function()
+      local client_commands = require("slang-server._lsp.clientCommands")
+      local original_select = vim.ui.select
+      local original_execute = client_commands.executeServerCommand
+      local command
+      local selected
+
+      local ok, err = pcall(function()
+         client_commands.executeServerCommand = function(selected_command, value)
+            command = selected_command
+            selected = value
+         end
+         vim.ui.select = function(items, options, on_choice)
+            assert.are.same("Pick one", options.prompt)
+            assert.are.same("second (current)", options.format_item(items[2]))
+            on_choice(items[2])
+         end
+         vim.lsp.commands["slang.quickPick"]({
+            arguments = {
+               {
+                  placeholder = "Pick one",
+                  items = {
+                     { label = "first", value = 1 },
+                     { label = "second", description = "(current)", value = 2 },
+                  },
+                  onSelectCommand = "test.callback",
+               },
+            },
+         }, { bufnr = 0 })
+      end)
+      vim.ui.select = original_select
+      client_commands.executeServerCommand = original_execute
+
+      assert(ok, err)
+      assert.are.same("test.callback", command)
+      assert.are.same(2, selected)
+   end)
+
+   it("Active instance notifications reveal an open hierarchy", function()
+      local client_commands = require("slang-server._lsp.clientCommands")
+      local navigation = require("slang-server.navigation")
+      local hierarchy = require("slang-server.navigation/hierarchy")
+      local original_open = hierarchy.open_remainder
+      local original_state = navigation.state.open
+      local revealed
+
+      local ok, err = pcall(function()
+         hierarchy.open_remainder = function(parent, root, path, from_cell)
+            revealed = { parent, root, path, from_cell }
+         end
+
+         navigation.state.open = false
+         client_commands.activeInstanceChanged(nil, { hierPath = "top.hidden" })
+         assert.is_nil(revealed)
+
+         navigation.state.open = true
+         client_commands.activeInstanceChanged(nil, { hierPath = "top.visible" })
+         assert.are.same({ nil, true, "top.visible", false }, revealed)
+      end)
+      hierarchy.open_remainder = original_open
+      navigation.state.open = original_state
+
+      assert(ok, err)
+   end)
+
+   it("Single-instance code lenses reveal an open hierarchy", function()
+      local client_commands = require("slang-server._lsp.clientCommands")
+      local original_reveal = client_commands.revealInHierarchy
+      local shown
+
+      local ok, err = pcall(function()
+         client_commands.revealInHierarchy = function(params)
+            shown = params
+         end
+         vim.lsp.commands["slang.showInHierarchy"]({
+            arguments = { { hierPath = "top.only" } },
+         })
+      end)
+      client_commands.revealInHierarchy = original_reveal
+
+      assert(ok, err)
+      assert.are.same({ hierPath = "top.only" }, shown)
+   end)
+
+   it("Searches hierarchy members through the server API", function()
+      local result
+      require("slang-server").search_hierarchy("the_sub", function(resp)
+         result = resp
+      end)
+
+      assert(vim.wait(5000, function()
+         return result ~= nil
+      end))
+      -- Fuzzy path matches include the four instances and their parameter children.
+      assert.are.same(8, result.totalResults)
+      assert.is_true(#result.matches <= 100)
+      assert.is_true(vim.iter(result.matches):any(function(item)
+         return item.path == "foo.gen_loop[2].the_sub"
+      end))
+   end)
 
    -- Catches anything the server complained about, including messages emitted
    -- during startup, which land before the first test runs.
@@ -198,9 +387,8 @@ describe("SlangServer", function()
       set_top_level("tests/interface_ports.sv")
       vim.cmd("SlangServer hierarchy interface_top.u")
       local lines = wait_on("Slang-server: Hierarchy")
-      local rendered = table.concat(lines, "\n")
-      assert.is_truthy(string.find(rendered, "single_bus", 1, true))
-      assert.is_truthy(string.find(rendered, "bus_array", 1, true))
+      find_line(lines, "single_bus")
+      find_line(lines, "bus_array")
       vim.api.nvim_buf_delete(0, { force = true })
 
       local config = require("slang-server._core.config").CONFIG
@@ -209,12 +397,49 @@ describe("SlangServer", function()
       local ok, err = pcall(function()
          vim.cmd("SlangServer hierarchy interface_top.u")
          lines = wait_on("Slang-server: Hierarchy")
-         assert.is_truthy(string.find(table.concat(lines, "\n"), "? single_bus", 1, true))
+         find_line(lines, "? single_bus")
          vim.api.nvim_buf_delete(0, { force = true })
       end)
       config.kinds.interfaceport = interfaceport
       set_top_level("tests/foo.sv")
       assert(ok, err)
+   end)
+
+   it("Cell selections activate instances", function()
+      execute_server_command("slang.setTopLevel", { vim.api.nvim_buf_get_name(source_buf) })
+      vim.cmd("SlangServer hierarchy")
+
+      local lines, cells_win = wait_on("Slang-server: Cells")
+      press_key(cells_win, find_line(lines, "sub (4)"), "<Space>")
+      lines, cells_win = wait_on("Slang-server: Cells")
+      local target = "foo.gen_loop[2].the_sub"
+      local activated = press_key_and_wait_for_activation(cells_win, find_line(lines, target))
+      assert.are.same(target, activated)
+
+      local active = execute_server_command("slang.getActiveInstance", { "sub" })
+      assert.are.same(target, active.instPath)
+
+      local _, hierarchy_win = wait_on("Slang-server: Hierarchy")
+      vim.api.nvim_set_current_win(hierarchy_win)
+      vim.api.nvim_buf_delete(0, { force = true })
+   end)
+
+   it("Hierarchy selections activate instances", function()
+      execute_server_command("slang.setTopLevel", { vim.api.nvim_buf_get_name(source_buf) })
+      local target = "foo.gen_loop[3].the_sub"
+      vim.cmd("SlangServer hierarchy " .. target)
+
+      local lines, hierarchy_win = wait_on("Slang-server: Hierarchy")
+      local activated = press_key_and_wait_for_activation(
+         hierarchy_win,
+         find_line(lines, "the_sub sub")
+      )
+      assert.are.same(target, activated)
+
+      local active = execute_server_command("slang.getActiveInstance", { "sub" })
+      assert.are.same(target, active.instPath)
+      vim.api.nvim_set_current_win(hierarchy_win)
+      vim.api.nvim_buf_delete(0, { force = true })
    end)
 end)
 

--- a/clients/vscode/README.md
+++ b/clients/vscode/README.md
@@ -31,7 +31,7 @@ Intuitive completions for module instances and macros, as well as scope members 
 
 ![Completions](https://github.com/hudson-trading/slang-server/blob/main/docs/assets/images/completions.gif?raw=true)
 
-HDL-specific features that allow you to easily set a filelist or top level for a design, browse the elaborated hierarchy, and interact with waveform viewers.
+HDL-specific features that allow you to set a filelist or top level, browse the elaborated hierarchy, select the active instance of each module, inspect instance-specific values, and interact with waveform viewers.
 
 ![HDL Features](https://github.com/hudson-trading/slang-server/blob/main/docs/assets/images/hdl.gif?raw=true)
 

--- a/clients/vscode/eslint.config.ts
+++ b/clients/vscode/eslint.config.ts
@@ -50,6 +50,8 @@ export default [
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/await-thenable': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
+      'no-redeclare': 'off',
+      '@typescript-eslint/no-redeclare': ['error', { ignoreDeclarationMerge: true }],
       curly: 'warn',
       eqeqeq: 'error',
       'no-throw-literal': 'warn',

--- a/clients/vscode/integration/suite/index.ts
+++ b/clients/vscode/integration/suite/index.ts
@@ -4,6 +4,28 @@ import * as vscode from 'vscode'
 const extensionId = 'Hudson-River-Trading.vscode-slang'
 const timeoutMs = 15_000
 
+interface HierarchyItem {
+  inst: { instName: string }
+}
+
+interface ModuleViewItem {
+  data: { declName?: string; instPath?: string }
+}
+
+interface InstancesView {
+  getChildren(item?: ModuleViewItem): Promise<ModuleViewItem[]>
+  revealPath(moduleName: string, instancePath: string): Promise<void>
+}
+
+interface ProjectComponent {
+  includeData: boolean
+  includeParams: boolean
+  instancesView: InstancesView
+  top: HierarchyItem | undefined
+  getChildren(item?: HierarchyItem): Promise<HierarchyItem[]>
+  getTreeItem(item: HierarchyItem): Promise<vscode.TreeItem>
+}
+
 async function waitFor(description: string, predicate: () => boolean): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (!predicate()) {
@@ -35,7 +57,7 @@ export async function run(): Promise<void> {
 
   const extension = vscode.extensions.getExtension(extensionId)
   assert.ok(extension, `${extensionId} was not loaded`)
-  await extension.activate()
+  const extensionApi = (await extension.activate()) as { project: ProjectComponent }
 
   const uri = vscode.Uri.joinPath(workspace.uri, 'hierarchy.sv')
   const document = await vscode.workspace.openTextDocument(uri)
@@ -51,14 +73,92 @@ export async function run(): Promise<void> {
   assert.notEqual(generatedInstanceLine, -1)
 
   try {
-    await vscode.commands.executeCommand('slang.setTopLevel', uri.fsPath)
+    await vscode.commands.executeCommand('slang.project.setTopLevel', uri)
 
-    editor.selection = new vscode.Selection(instanceLine, 0, instanceLine, 0)
+    const project = extensionApi.project
+    assert.equal(project.includeData, true, 'data signals should be visible by default')
+    assert.ok(project.top, 'top-level instance was not populated')
+    const topChildren = await project.getChildren(project.top)
+    assert.ok(
+      topChildren.some((item) => item.inst.instName === 'data_signal'),
+      'default hierarchy should include data signals'
+    )
+
+    for (const name of ['u_child', 'params_only']) {
+      const item = topChildren.find((child) => child.inst.instName === name)
+      assert.ok(item, `missing hierarchy item ${name}`)
+      assert.equal(
+        (await project.getTreeItem(item)).collapsibleState,
+        vscode.TreeItemCollapsibleState.None,
+        `${name} should not be expandable without visible children`
+      )
+    }
+
+    const emptyPackage = (await project.getChildren()).find(
+      (item) => item.inst.instName === 'empty_pkg'
+    )
+    assert.ok(emptyPackage, 'missing empty package')
+    assert.equal(
+      (await project.getTreeItem(emptyPackage)).collapsibleState,
+      vscode.TreeItemCollapsibleState.None,
+      'empty package should not be expandable'
+    )
+
+    assert.equal(project.includeParams, false, 'module parameters should be hidden by default')
+    const paramsPackage = (await project.getChildren()).find(
+      (item) => item.inst.instName === 'params_pkg'
+    )
+    assert.ok(paramsPackage, 'missing parameter package')
+    assert.ok(
+      (await project.getChildren(paramsPackage)).some(
+        (item) => item.inst.instName === 'PACKAGE_PARAM'
+      ),
+      'package parameters should remain visible'
+    )
+
+    const modules = await project.instancesView.getChildren()
+    const childModule = modules.find((item) => item.data.declName === 'child')
+    assert.ok(childModule, 'missing child module in Modules view')
+    const childInstance = (await project.instancesView.getChildren(childModule)).find(
+      (item) => item.data.instPath === 'top.u_child'
+    )
+    assert.ok(childInstance, 'missing top.u_child in Modules view')
+
+    const revealCalls: [string, string][] = []
+    const revealPath = project.instancesView.revealPath.bind(project.instancesView)
+    project.instancesView.revealPath = async (moduleName, instancePath) => {
+      revealCalls.push([moduleName, instancePath])
+      await revealPath(moduleName, instancePath)
+    }
+    try {
+      await vscode.commands.executeCommand(
+        'slang.project.instancesView.gotoInstantiation',
+        childInstance
+      )
+    } finally {
+      project.instancesView.revealPath = revealPath
+    }
+    assert.deepEqual(
+      revealCalls[revealCalls.length - 1],
+      ['top', 'top'],
+      'Go to Instantiation should reveal the parent module instance'
+    )
+
+    const lenses = await vscode.commands.executeCommand<vscode.CodeLens[]>(
+      'vscode.executeCodeLensProvider',
+      uri
+    )
+    const gotoInstantiation = lenses.find((lens) => {
+      const params = lens.command?.arguments?.[0] as { hierPath?: string } | undefined
+      return lens.command?.title === 'Go to Instantiation' && params?.hierPath === 'top.u_child'
+    })
+    assert.ok(gotoInstantiation?.command, 'missing child module CodeLens')
+    editor.selection = new vscode.Selection(moduleLine, 0, moduleLine, 0)
     await executeAndExpectLocation(
-      'slang.showModuleDefinition',
-      { moduleName: 'child', takeFocus: true },
+      gotoInstantiation.command.command,
+      gotoInstantiation.command.arguments?.[0],
       uri,
-      moduleLine
+      instanceLine
     )
 
     editor.selection = new vscode.Selection(moduleLine, 0, moduleLine, 0)

--- a/clients/vscode/integration/workspace/hierarchy.sv
+++ b/clients/vscode/integration/workspace/hierarchy.sv
@@ -1,3 +1,10 @@
+package empty_pkg;
+endpackage
+
+package params_pkg;
+    localparam int PACKAGE_PARAM = 1;
+endpackage
+
 module child;
 endmodule
 
@@ -9,8 +16,13 @@ module branch;
 endmodule
 
 module top;
+    logic data_signal;
     child u_child();
     branch branch_array[1:0]();
+
+    if (1) begin : params_only
+        localparam int HIDDEN = 1;
+    end
 
     for (genvar i = 0; i < 2; i++) begin : generated
         leaf generated_leaf();

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -387,25 +387,6 @@
     },
     "commands": [
       {
-        "command": "slang.project.instancesView.copyHierarchyPath",
-        "title": "Copy Path",
-        "viewItems": [
-          "Instance"
-        ],
-        "icon": "$(files)",
-        "isSubmenu": true,
-        "keybind": "cmd+c"
-      },
-      {
-        "command": "slang.project.instancesView.showInWaveform",
-        "title": "Show in Waveform",
-        "viewItems": [
-          "Instance"
-        ],
-        "icon": "$(graph-line)",
-        "keybind": "w"
-      },
-      {
         "command": "slang.project.setTopLevel",
         "title": "Set Top Level",
         "shortTitle": "Set Top",
@@ -427,14 +408,31 @@
       },
       {
         "command": "slang.project.fuzzyFindInstance",
-        "title": "Fuzzy Find Instances",
+        "title": "Find in Hierarchy",
         "icon": "$(search-view-icon)",
         "keybind": "cmd+f",
         "keybindContainer": true
       },
       {
+        "command": "slang.quickPick",
+        "title": "slang: Quick Pick"
+      },
+      {
+        "command": "slang.showInHierarchy",
+        "title": "slang: Show in Hierarchy"
+      },
+      {
         "command": "slang.project.setInstance",
         "title": "slang: Select Instance"
+      },
+      {
+        "command": "slang.project.selectModuleInstance",
+        "title": "slang: Select Module Instance"
+      },
+      {
+        "command": "slang.project.instancesView.gotoInstantiation",
+        "title": "Go to Instantiation",
+        "icon": "$(go-to-file)"
       },
       {
         "command": "slang.project.showBuildFile",
@@ -468,17 +466,6 @@
         "title": "slang: Refresh Compilation",
         "icon": "$(refresh)",
         "shown": true
-      },
-      {
-        "command": "slang.project.showSourceFile",
-        "title": "Show Module",
-        "viewItems": [
-          "Module"
-        ],
-        "icon": {
-          "light": "./resources/light/go-to-file.svg",
-          "dark": "./resources/dark/go-to-file.svg"
-        }
       },
       {
         "command": "slang.project.showInWaveform",
@@ -609,9 +596,9 @@
       ],
       "view/item/context": [
         {
-          "command": "slang.project.showSourceFile",
+          "command": "slang.project.instancesView.gotoInstantiation",
           "group": "inline",
-          "when": "view == slang.project && viewItem == Module"
+          "when": "view == slang.project.instancesView && viewItem == Instance"
         },
         {
           "command": "slang.project.showInWaveform",
@@ -625,18 +612,8 @@
         },
         {
           "command": "slang.project.copyHierarchyPath",
-          "group": "submenu@4",
+          "group": "submenu@3",
           "when": "view == slang.project"
-        },
-        {
-          "command": "slang.project.instancesView.copyHierarchyPath",
-          "group": "submenu@5",
-          "when": "view == slang.project.instancesView && viewItem == Instance"
-        },
-        {
-          "command": "slang.project.instancesView.showInWaveform",
-          "group": "inline",
-          "when": "view == slang.project.instancesView && viewItem == Instance"
         }
       ],
       "editor/title": [
@@ -686,17 +663,6 @@
         "command": "slang.project.copyHierarchyPath",
         "when": "focusedView == slang.project && !inputFocus",
         "mac": "cmd+c"
-      },
-      {
-        "key": "ctrl+c",
-        "command": "slang.project.instancesView.copyHierarchyPath",
-        "when": "focusedView == slang.project.instancesView && !inputFocus",
-        "mac": "cmd+c"
-      },
-      {
-        "key": "w",
-        "command": "slang.project.instancesView.showInWaveform",
-        "when": "focusedView == slang.project.instancesView && !inputFocus"
       }
     ]
   },

--- a/clients/vscode/resources/config.schema.json
+++ b/clients/vscode/resources/config.schema.json
@@ -190,6 +190,10 @@
           "description": "Hints for inferred assignment pattern types",
           "type": "boolean"
         },
+        "activeParameterValues": {
+          "description": "Hints for active instance parameter and localparam values",
+          "type": "boolean"
+        },
         "orderedInstanceNames": {
           "description": "Hints for names of ordered ports and params",
           "type": "boolean"

--- a/clients/vscode/src/SlangInterface.ts
+++ b/clients/vscode/src/SlangInterface.ts
@@ -57,29 +57,80 @@ export interface Scope extends Item {
 export interface Instance extends Item {
   declName: string
   declKind: SlangInstKind
+  // True when the instance body has at least one hierarchy member.
   hasChildren: boolean
   // May or may not be filled
   children: Item[]
 }
 
-////////////////////////////////////////////////////////////
-// Instances View
-////////////////////////////////////////////////////////////
+export interface QualifiedInstance {
+  instPath: string
+}
 
 export interface Module {
   declName: string
-  inst?: QualifiedInstance
   instCount: number
+  inst?: QualifiedInstance
 }
 
-// When buttons are pressed on these, we call getScopes() to get relevant data
-export interface QualifiedInstance {
-  instPath: string
+export enum InteractionSource {
+  // Selection came from the editor or another command that should keep the editor in place.
+  Editor = 'editor',
+  // Selection came from a codelens action that should keep the editor in place.
+  CodeLensSelect = 'codeLensSelect',
+  // Selection came from a codelens action that should navigate to the instantiation.
+  CodeLensGotoInstantiation = 'codeLensGotoInstantiation',
+  // Selection came from the hierarchy tree.
+  Hierarchy = 'hierarchy',
+  // Selection came from the modules tree.
+  Modules = 'modules',
+  // Selection came from a terminal link.
+  Terminal = 'terminal',
+  // Selection came from waveform navigation.
+  Waveform = 'waveform',
+  // Selection came from the waveform netlist, which should not reveal the hierarchy view.
+  WaveformNetlist = 'waveformNetlist',
+}
+
+export namespace InteractionSource {
+  export function isFromEditor(source: InteractionSource | undefined): boolean {
+    return (
+      source === InteractionSource.Editor ||
+      source === InteractionSource.CodeLensSelect ||
+      source === InteractionSource.CodeLensGotoInstantiation
+    )
+  }
+
+  export function isFromSidebar(source: InteractionSource | undefined): boolean {
+    return source === InteractionSource.Hierarchy || source === InteractionSource.Modules
+  }
+
+  export function isFromWaveform(source: InteractionSource | undefined): boolean {
+    return source === InteractionSource.Waveform || source === InteractionSource.WaveformNetlist
+  }
+}
+
+export interface ActivateInstanceParams {
+  hierPath: string
+  interactionSource: InteractionSource
 }
 
 export interface ScopeStep {
   path: string
   children: Item[]
+}
+
+export interface HierarchySearchItem {
+  name: string
+  path: string
+  kind: SlangKind
+  description?: string
+  containerName?: string
+}
+
+export interface HierarchySearchResult {
+  totalResults: number
+  matches: HierarchySearchItem[]
 }
 
 ////////////////////////////////////////////////////////////
@@ -113,14 +164,12 @@ export async function getUnit(): Promise<Instance[]> {
   return children
 }
 
-/// Module -> scopes for instances view
 export async function getScopesByModule(): Promise<Module[]> {
-  const children: Module[] = await vscode.commands.executeCommand('slang.getScopesByModule')
-  if (children === undefined) {
-    vscode.window.showErrorMessage('Failed to get modules')
-    return []
-  }
-  return children
+  return (await vscode.commands.executeCommand('slang.getScopesByModule')) ?? []
+}
+
+export async function getInstancesOfModule(declName: string): Promise<QualifiedInstance[]> {
+  return (await vscode.commands.executeCommand('slang.getInstancesOfModule', declName)) ?? []
 }
 
 /// Query root-to-focus scope steps, with child lists for each hierarchy segment.
@@ -133,8 +182,36 @@ export async function getScopes(hierPath: string): Promise<ScopeStep[]> {
   return scopes
 }
 
-export async function getInstancesOfModule(declName: string): Promise<QualifiedInstance[]> {
-  return await vscode.commands.executeCommand('slang.getInstancesOfModule', declName)
+export async function searchHierarchy(query: string): Promise<HierarchySearchResult | undefined> {
+  return await vscode.commands.executeCommand('slang.searchHierarchy', query)
+}
+
+// Get the instances for the module in this file (by editor position)
+export async function getInstances(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): Promise<string[]> {
+  const instances: string[] = await vscode.commands.executeCommand('slang.getInstances', {
+    textDocument: { uri: document.uri.toString() },
+    position,
+  })
+  return instances ?? []
+}
+
+// Server resolves the path (canonical or port-side alias) and walks up to set active
+// instances and generate scopes for every module in the chain.
+export async function setActiveInstance(hierPath: string): Promise<boolean> {
+  return await vscode.commands.executeCommand('slang.setActiveInstance', hierPath)
+}
+
+export async function getActiveInstance(
+  moduleName: string
+): Promise<QualifiedInstance | undefined> {
+  const instance: QualifiedInstance | undefined = await vscode.commands.executeCommand(
+    'slang.getActiveInstance',
+    moduleName
+  )
+  return instance
 }
 
 export async function getFilesContainingModule(moduleName: string): Promise<string[]> {
@@ -176,9 +253,10 @@ export async function showHierLocation(hierPath: string, takeFocus: boolean): Pr
   await vscode.commands.executeCommand('slang.showHierLocation', { hierPath, takeFocus })
 }
 
-export async function showModuleDefinition(moduleName: string, takeFocus: boolean): Promise<void> {
-  await vscode.commands.executeCommand('slang.showModuleDefinition', { moduleName, takeFocus })
+export async function openModuleDefinition(moduleName: string): Promise<void> {
+  await vscode.commands.executeCommand('slang.openModuleDefinition', moduleName)
 }
+
 ////////////////////////////////////////////////////////////
 /// server -> client is in commands in the project component
 ////////////////////////////////////////////////////////////

--- a/clients/vscode/src/config.gen.ts
+++ b/clients/vscode/src/config.gen.ts
@@ -66,6 +66,8 @@ export interface Config__InlayHints {
   portTypes?: boolean
   /** Hints for inferred assignment pattern types */
   assignmentPatternTypes?: boolean
+  /** Hints for active instance parameter and localparam values */
+  activeParameterValues?: boolean
   /** Hints for names of ordered ports and params */
   orderedInstanceNames?: boolean
   /** Hints for port names in wildcard (.*) ports */

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -36,6 +36,20 @@ import { InactiveRegionsFeature } from './lib/inactiveRegions'
 
 export var ext: SlangExtension
 
+interface QuickPickItem extends vscode.QuickPickItem {
+  value: unknown
+}
+
+interface QuickPickAction {
+  onSelectCommand: string
+  interactionSource?: slang.InteractionSource
+}
+
+interface QuickPickParams extends QuickPickAction {
+  placeholder: string
+  items: QuickPickItem[]
+}
+
 export class SlangExtension extends ActivityBarComponent {
   ////////////////////////////////////////////////
   /// top level configs
@@ -97,6 +111,40 @@ File input is sent to stdin, and formatted output is read from stdout.',
   /// top level commands and configs
   ////////////////////////////////////////////////
   expandDir: vscode.Uri | undefined = undefined
+
+  private async executeQuickPickAction(params: QuickPickAction, value: unknown): Promise<void> {
+    if (params.interactionSource !== undefined && typeof value === 'string') {
+      await this.project.setInstance.func(value, params.interactionSource)
+      return
+    }
+
+    await vscode.commands.executeCommand(params.onSelectCommand, value)
+  }
+
+  quickPick: CommandNode = new CommandNode(
+    {
+      title: 'Quick Pick',
+    },
+    async (params: QuickPickParams) => {
+      const picked = await vscode.window.showQuickPick(params.items, {
+        placeHolder: params.placeholder,
+      })
+      if (!picked) {
+        return
+      }
+
+      await this.executeQuickPickAction(params, picked.value)
+    }
+  )
+
+  showInHierarchy: CommandNode = new CommandNode(
+    {
+      title: 'Show in Hierarchy',
+    },
+    async (params: slang.ActivateInstanceParams) => {
+      await this.project.showInHierarchy(params)
+    }
+  )
 
   rewrite: EditorButton = new EditorButton(
     {
@@ -189,6 +237,15 @@ File input is sent to stdin, and formatted output is read from stdout.',
     }
 
     this.client.registerFeature(new SlangClientInfoFeature(clientInfo))
+    this.context.subscriptions.push(
+      this.client.onNotification(
+        'slang/activeInstanceChanged',
+        (params: slang.ActivateInstanceParams) => {
+          void this.project.onActiveInstanceChanged(params)
+        }
+      )
+    )
+
     this.client.registerFeature(this.inactiveRegions)
     this.inactiveRegions.register(this.client)
 
@@ -468,4 +525,5 @@ export async function activate(context: vscode.ExtensionContext) {
     'eirikpre.systemverilog',
     'IMCTradingBV.svlangserver',
   ])
+  return ext
 }

--- a/clients/vscode/src/lib/InstancePathUtils.ts
+++ b/clients/vscode/src/lib/InstancePathUtils.ts
@@ -1,3 +1,18 @@
+// Matches dotted instance paths like "top.sub.module" or "top.sub[0].module[1]"
+// but not file paths (containing /) or SystemVerilog file extensions (.sv, .v, etc.)
+
+// Lookbehind rejects word chars, '.', '/', '\' — ensuring we match from the
+// start of an identifier, not mid-word or mid-file-path.
+// Lookahead also rejects continuations like `.foo` or `/child`, so we don't
+// backtrack to a shorter dotted prefix of a longer file or path string.
+const RE_INSTANCE_PATHS = /(?<![/\\\w$.])[\w$]+(\[\d+\])?(\.[\w$]+(\[\d+\])?)+(?![\w$./\\[])/g
+const RE_SV_EXTENSION = /\.(sv|svh|v|vh)$/i
+
+export interface InstancePathMatch {
+  path: string
+  index: number
+}
+
 export interface HierarchyLookupChild {
   instName: string
   path: string
@@ -6,6 +21,23 @@ export interface HierarchyLookupChild {
 export interface ResolvedHierarchyChild<T extends HierarchyLookupChild> {
   child: T | undefined
   nextIndex: number
+}
+
+// Extract hierarchy-like instance paths from free-form text such as log lines.
+export function findInstancePaths(line: string): InstancePathMatch[] {
+  RE_INSTANCE_PATHS.lastIndex = 0
+  const results: InstancePathMatch[] = []
+  for (const match of line.matchAll(RE_INSTANCE_PATHS)) {
+    const startIndex = match.index
+    if (startIndex === undefined) {
+      continue
+    }
+    if (RE_SV_EXTENSION.test(match[0])) {
+      continue
+    }
+    results.push({ path: match[0], index: startIndex })
+  }
+  return results
 }
 
 // Split a scope path into parts, handling array indices and package-qualified

--- a/clients/vscode/src/lib/inactiveRegions.ts
+++ b/clients/vscode/src/lib/inactiveRegions.ts
@@ -97,10 +97,16 @@ export class InactiveRegionsFeature extends ExtensionComponent implements vscode
 
   private applyHighlights(fileUri: string) {
     const ranges = this.files.get(fileUri)
-    if (!ranges) return
+    if (!ranges) {
+      return
+    }
     vscode.window.visibleTextEditors.forEach((e) => {
-      if (!this.decorationType) return
-      if (e.document.uri.toString() !== fileUri) return
+      if (!this.decorationType) {
+        return
+      }
+      if (e.document.uri.toString() !== fileUri) {
+        return
+      }
       e.setDecorations(this.decorationType, ranges)
     })
   }

--- a/clients/vscode/src/sidebar/InstancesView.ts
+++ b/clients/vscode/src/sidebar/InstancesView.ts
@@ -1,88 +1,53 @@
+// SPDX-License-Identifier: MIT
+
 import * as vscode from 'vscode'
 
 import { TreeItemButton, ViewComponent } from '../lib/libconfig'
 import * as slang from '../SlangInterface'
-import { ext } from '../extension'
-import { HierItem } from './ProjectComponent'
 
 export class InstanceViewItem {
-  data: slang.QualifiedInstance
-  parent: ModuleItem
-
-  constructor(parent: ModuleItem, inst: slang.QualifiedInstance) {
-    this.parent = parent
-    this.data = inst
-  }
-  getParent(): ModuleItem {
-    return this.parent
-  }
+  constructor(
+    readonly parent: ModuleItem,
+    readonly data: slang.QualifiedInstance
+  ) {}
 
   getTreeItem(): vscode.TreeItem {
     const item = new vscode.TreeItem(this.data.instPath, vscode.TreeItemCollapsibleState.None)
     item.iconPath = new vscode.ThemeIcon('chip')
     item.contextValue = 'Instance'
-    return item
-  }
-
-  resolveTreeItem(item: vscode.TreeItem, _token: vscode.CancellationToken): vscode.TreeItem {
     item.tooltip = this.data.instPath
     item.command = {
-      title: 'Open Instance',
-      command: 'slang.project.setInstance',
-      arguments: [
-        this.data.instPath,
-        { revealInstance: false, revealFile: true, revealHierarchy: true },
-      ],
+      title: 'Select Instance',
+      command: 'slang.project.selectModuleInstance',
+      arguments: [this.data.instPath, this.parent.data.declName],
     }
     return item
-  }
-
-  getChildren(): [] {
-    return []
   }
 }
 
-export class ModuleItem {
-  data: slang.Module
-  instances: Map<string, InstanceViewItem> = new Map()
+class ModuleItem {
+  private instances: Map<string, InstanceViewItem> | undefined
 
-  constructor(data: slang.Module) {
-    this.data = data
-  }
+  constructor(readonly data: slang.Module) {}
 
-  getTreeItem(): vscode.TreeItem {
+  getTreeItem(expanded: boolean): vscode.TreeItem {
     const item = new vscode.TreeItem(
-      this.data.declName + ` (${this.data.instCount})`,
-      vscode.TreeItemCollapsibleState.Collapsed
+      `${this.data.declName} (${this.data.instCount})`,
+      expanded
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed
     )
     item.iconPath = new vscode.ThemeIcon('file')
-    if (this.data.inst) {
-      item.collapsibleState = vscode.TreeItemCollapsibleState.Expanded
-    }
-    return item
-  }
-
-  resolveTreeItem(item: vscode.TreeItem, _token: vscode.CancellationToken): vscode.TreeItem {
+    item.contextValue = 'Module'
     item.tooltip = this.data.declName
-    item.command = {
-      title: 'Open Module',
-      command: 'slang.showModuleDefinition',
-      arguments: [{ moduleName: this.data.declName, takeFocus: false }],
-    }
     return item
-  }
-
-  async getChildren(): Promise<InstanceViewItem[]> {
-    return Array.from((await this.getInstances()).values())
   }
 
   async getInstances(): Promise<Map<string, InstanceViewItem>> {
-    if (this.instances.size === 0) {
-      const insts = await slang.getInstancesOfModule(this.data.declName)
+    if (this.instances === undefined) {
       this.instances = new Map()
-      for (const inst of insts) {
-        const item = new InstanceViewItem(this, inst)
-        this.instances.set(inst.instPath, item)
+      for (const instance of await slang.getInstancesOfModule(this.data.declName)) {
+        this.instances.set(instance.instPath, new InstanceViewItem(this, instance))
       }
     }
     return this.instances
@@ -90,162 +55,125 @@ export class ModuleItem {
 }
 
 type InstanceTreeItem = InstanceViewItem | ModuleItem
+
 export class InstancesView
   extends ViewComponent
   implements vscode.TreeDataProvider<InstanceTreeItem>
 {
-  copyHierarchyPath: TreeItemButton = new TreeItemButton(
-    {
-      title: 'Copy Path',
-      viewItems: ['Instance'],
-      icon: '$(files)',
-      isSubmenu: true,
-      keybind: 'cmd+c',
-    },
-    async (item: InstanceViewItem | undefined) => {
-      if (item === undefined) {
-        // undefined if we're coming from keybind
-        if (this.treeView?.selection.length === 0) {
-          return
-        }
-        const genericItem = this.treeView?.selection[0]
-        if (genericItem instanceof ModuleItem) {
-          vscode.env.clipboard.writeText(genericItem.data.declName)
-          return
-        } else {
-          item = genericItem as InstanceViewItem
-        }
-      }
-      vscode.env.clipboard.writeText(item.data.instPath)
-    }
-  )
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<
+    InstanceTreeItem | undefined | null
+  >()
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event
 
-  showInWaveform: TreeItemButton = new TreeItemButton(
-    {
-      title: 'Show in Waveform',
-      viewItems: ['Instance'],
-      icon: '$(graph-line)',
-      keybind: 'w',
-    },
-    async (instItem: InstanceViewItem | undefined) => {
-      if (instItem === undefined) {
-        // undefined if we're coming from keybind
-        if (
-          !this.treeView ||
-          this.treeView.selection.length === 0 ||
-          !(this.treeView.selection[0] instanceof InstanceViewItem)
-        ) {
-          this.logger.warn('No instance selected to show in waveform')
-          return
-        }
-        instItem = this.treeView.selection[0]
-      }
-      const item: HierItem = await ext.project.setInstance.func(instItem.data.instPath, {
-        revealInstance: false,
-        revealFile: false,
-        revealHierarchy: true,
-      })
-      const ok = await ext.project.maybeOpenWaveform()
-      if (!ok) {
-        return
-      }
-      await item.showChildrenInWaveform(this.logger)
-    }
-  )
+  private modules = new Map<string, ModuleItem>()
+  private expandedModule: ModuleItem | undefined
+  private treeView: vscode.TreeView<InstanceTreeItem> | undefined
+  private changingExpansion = false
+  gotoInstantiation: TreeItemButton
 
-  modules: Map<string, ModuleItem> = new Map()
-  async updateModules() {
-    const modules = await slang.getScopesByModule()
-    this.modules = new Map()
-    for (const mod of modules) {
-      const item = new ModuleItem(mod)
-      this.modules.set(mod.declName, item)
-    }
-
-    this._onDidChangeTreeData.fire()
+  constructor(onGotoInstantiation: (item: InstanceViewItem) => Promise<void>) {
+    super({ name: 'Modules' })
+    this.gotoInstantiation = new TreeItemButton(
+      {
+        title: 'Go to Instantiation',
+        icon: '$(go-to-file)',
+        viewItems: ['Instance'],
+      },
+      onGotoInstantiation
+    )
   }
 
-  async clearModules() {
-    this.modules = new Map()
-    this._onDidChangeTreeData.fire()
-  }
-
-  revealPath(module: string, path: string | undefined = undefined, focus: boolean = false) {
-    if (!this.treeView?.visible) {
-      return
-    }
-
-    const moduleItem = this.modules.get(module)
-    if (moduleItem === undefined) {
-      return
-    }
-    if (path === undefined) {
-      this.treeView?.reveal(moduleItem, { select: true, focus: focus, expand: true })
-      return
-    }
-    const inst = moduleItem.instances.get(path)
-    if (inst) {
-      this.treeView?.reveal(inst, { select: true, focus: focus, expand: true })
-    }
-  }
-  private _onDidChangeTreeData: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
-  readonly onDidChangeTreeData: vscode.Event<void> = this._onDidChangeTreeData.event
-  treeView: vscode.TreeView<InstanceTreeItem> | undefined
-
-  constructor() {
-    super({
-      name: 'Modules',
-    })
-  }
-
-  async activate(_context: vscode.ExtensionContext) {
+  async activate(context: vscode.ExtensionContext): Promise<void> {
     this.treeView = vscode.window.createTreeView(this.configPath!, {
       treeDataProvider: this,
       showCollapseAll: true,
       canSelectMany: false,
-      dragAndDropController: undefined,
-      manageCheckboxStateManually: false,
     })
-    // If you actually register it, you don't get the collapsible state button :/
-    // context.subscriptions.push(vscode.window.registerTreeDataProvider(this.configPath!, this))
+    context.subscriptions.push(
+      this.treeView,
+      this.treeView.onDidExpandElement(({ element }) => {
+        if (this.changingExpansion || !(element instanceof ModuleItem)) {
+          return
+        }
+        void this.expandOnly(element, false)
+      }),
+      this.treeView.onDidCollapseElement(({ element }) => {
+        if (!this.changingExpansion && element === this.expandedModule) {
+          this.expandedModule = undefined
+        }
+      })
+    )
+  }
+
+  private async expandOnly(module: ModuleItem, reveal: boolean): Promise<void> {
+    const previous = this.expandedModule
+    this.expandedModule = module
+    if (previous && previous !== module) {
+      this.changingExpansion = true
+      try {
+        await vscode.commands.executeCommand(
+          `workbench.actions.treeView.${this.configPath}.collapseAll`
+        )
+        await this.treeView?.reveal(module, { expand: true })
+      } finally {
+        this.changingExpansion = false
+      }
+    } else if (reveal) {
+      await this.treeView?.reveal(module, { expand: true })
+    }
+  }
+
+  async updateModules(): Promise<void> {
+    const expandedName = this.expandedModule?.data.declName
+    this.modules = new Map(
+      (await slang.getScopesByModule()).map((module) => [module.declName, new ModuleItem(module)])
+    )
+    this.expandedModule = expandedName ? this.modules.get(expandedName) : undefined
+    this._onDidChangeTreeData.fire(undefined)
+  }
+
+  clearModules(): void {
+    this.modules.clear()
+    this.expandedModule = undefined
+    this._onDidChangeTreeData.fire(undefined)
+  }
+
+  async revealPath(moduleName: string, instancePath: string): Promise<void> {
+    if (!this.treeView?.visible) {
+      return
+    }
+
+    const module = this.modules.get(moduleName)
+    if (!module) {
+      return
+    }
+
+    await this.expandOnly(module, true)
+    const instance = (await module.getInstances()).get(instancePath)
+    if (instance) {
+      await this.treeView.reveal(instance, { select: true })
+    }
   }
 
   getTreeItem(element: InstanceTreeItem): vscode.TreeItem {
-    // check if element has gettreeitem
+    return element instanceof ModuleItem
+      ? element.getTreeItem(element === this.expandedModule)
+      : element.getTreeItem()
+  }
+
+  async getChildren(element?: InstanceTreeItem): Promise<InstanceTreeItem[]> {
     if (element instanceof ModuleItem) {
-      return element.getTreeItem()
+      return Array.from((await element.getInstances()).values())
     }
     if (element instanceof InstanceViewItem) {
-      return element.getTreeItem()
+      return []
     }
-
-    return new vscode.TreeItem('undefined')
+    return Array.from(this.modules.values()).sort((a, b) =>
+      a.data.declName.localeCompare(b.data.declName)
+    )
   }
 
-  async getChildren(element?: undefined | InstanceTreeItem): Promise<InstanceTreeItem[]> {
-    if (element === undefined) {
-      return Array.from(this.modules.values()).sort((a, b) => {
-        if (a.data.instCount === b.data.instCount && a.data.inst && b.data.inst) {
-          return a.data.inst.instPath < b.data.inst.instPath ? -1 : 1
-        }
-        return a.data.instCount > b.data.instCount ? 1 : -1
-      })
-    }
-    return await element.getChildren()
-  }
-
-  getParent(element: InstanceTreeItem): InstanceTreeItem | undefined {
-    if (element instanceof ModuleItem) {
-      return undefined
-    }
-    return element.parent
-  }
-
-  async resolveTreeItem(
-    item: vscode.TreeItem,
-    element: InstanceTreeItem,
-    _token: vscode.CancellationToken
-  ): Promise<vscode.TreeItem> {
-    return element.resolveTreeItem(item, _token)
+  getParent(element: InstanceTreeItem): ModuleItem | undefined {
+    return element instanceof InstanceViewItem ? element.parent : undefined
   }
 }

--- a/clients/vscode/src/sidebar/ProjectComponent.ts
+++ b/clients/vscode/src/sidebar/ProjectComponent.ts
@@ -13,7 +13,7 @@ import {
   WebviewButton,
 } from '../lib/libconfig'
 import * as slang from '../SlangInterface'
-import { InstancesView } from './InstancesView'
+import { InteractionSource } from '../SlangInterface'
 import * as vv from '../vaporview-api'
 import { getBasename, getIcons, getWorkspaceFolder, isAnyVerilog } from '../utils'
 import { Logger } from '../lib/logger'
@@ -33,10 +33,11 @@ import {
   resolveCommandToken,
 } from './BuildConfigUtils'
 import {
-  ResolvedHierarchyChild,
+  findInstancePaths,
   resolveHierarchyChild,
   splitHierarchyPath,
 } from '../lib/InstancePathUtils'
+import { InstancesView } from './InstancesView'
 
 const STRUCTURE_SYMS = [
   slang.SlangKind.Instance,
@@ -58,12 +59,13 @@ interface HasChildren {
   getPath(): string
 }
 
-interface RevealOptions {
-  revealHierarchy?: boolean
-  revealFile?: boolean
-  revealInstance?: boolean
-  focus?: 'editor' | 'hierarchy' | 'modules'
-  showBeside?: boolean
+interface HierarchyQuickPickItem extends vscode.QuickPickItem {
+  path: string
+}
+
+interface RefreshOptions {
+  revealSelection?: boolean
+  preserveFocusedPath?: boolean
 }
 
 type CompilationSource =
@@ -172,10 +174,6 @@ export abstract class HierItem implements HasChildren {
     }
     return undefined
   }
-
-  async hasChildren(): Promise<boolean> {
-    return false
-  }
 }
 
 function mapChildren(parent: HierItem, items: slang.Item[]): HierItem[] {
@@ -226,10 +224,6 @@ class ScopeItem extends HierItem {
     return mapChildren(this, this.inst.children)
   }
 
-  async hasChildren(): Promise<boolean> {
-    return this.inst.children.length > 0
-  }
-
   async getTreeItem(): Promise<TreeItem> {
     let item = new TreeItem(this.inst.instName)
     item.iconPath =
@@ -270,15 +264,6 @@ export class InstanceItem extends HierItem {
   async _fetchChildren(): Promise<HierItem[]> {
     return await getSlangChildren(this, this.getPath())
   }
-
-  async hasChildren(): Promise<boolean> {
-    // Use the server-provided flag to avoid a getScope round-trip; only fetch if we
-    // already happen to have the children cached.
-    if (this.children !== undefined) {
-      return this.children.length > 0
-    }
-    return this.inst.hasChildren
-  }
 }
 
 class InstanceArrayItem extends InstanceItem {
@@ -286,10 +271,6 @@ class InstanceArrayItem extends InstanceItem {
 
   async _fetchChildren(): Promise<HierItem[]> {
     return mapChildren(this, this.inst.children)
-  }
-
-  async hasChildren(): Promise<boolean> {
-    return true
   }
 
   getChildPath(name: string): string {
@@ -354,7 +335,6 @@ export class UnitItem implements HasChildren {
 class VarItem extends HierItem {
   inst: slang.Var
   static PARAM_TYPES: slang.SlangKind[] = [slang.SlangKind.Param]
-  static DATA_TYPES: slang.SlangKind[] = DATA_SYMS
 
   constructor(parent: HierItem | undefined, instance: slang.Var) {
     super(parent, instance)
@@ -454,20 +434,29 @@ export class ProjectComponent
     }
   }
 
-  // Show the selected instance for the open file
-  focusedBar: vscode.StatusBarItem
-
-  // Map from module name to instance for following along in the hierarchy view
-  moduleToInstance: Map<string, InstanceItem> = new Map()
-
   // Hierarchy Tree
   private _onDidChangeTreeData: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
   readonly onDidChangeTreeData: vscode.Event<void> = this._onDidChangeTreeData.event
   treeView: vscode.TreeView<HierItem> | undefined
   focused: HierItem | undefined = undefined
+  instancesView = new InstancesView(async (item) => {
+    const selected = await this.setInstance.func(item.data.instPath, InteractionSource.Modules)
+    if (selected) {
+      await slang.showHierLocation(selected.getPath(), true)
 
-  // Instances Index
-  instancesView: InstancesView = new InstancesView()
+      let parentModule = selected.parent
+      while (
+        parentModule &&
+        (!(parentModule instanceof InstanceItem) ||
+          parentModule.inst.kind !== slang.SlangKind.Instance)
+      ) {
+        parentModule = parentModule.parent
+      }
+      if (parentModule instanceof InstanceItem) {
+        await this.instancesView.revealPath(parentModule.inst.declName, parentModule.getPath())
+      }
+    }
+  })
 
   //////////////////////////////////////////////////////////////////
   // Editor Buttons
@@ -489,7 +478,7 @@ export class ProjectComponent
       this.clearBuildCommandTracking()
       this.topFile = uri
       await slang.setTopLevel(uri.fsPath)
-      await this.refreshSlangCompilation()
+      await this.refreshSlangCompilation({ preserveFocusedPath: false })
     }
   )
 
@@ -522,14 +511,55 @@ export class ProjectComponent
       await this.setTopLevel.func(vscode.Uri.file(file.fsPath))
     }
   )
-  isRevalingFile: boolean = false
+  private interactionSource: InteractionSource | undefined
+
+  // If the saved interaction source is undefined, push/pop to this source
+  private async withInteractionSource<T>(
+    interactionSource: InteractionSource | undefined,
+    action: () => Promise<T>
+  ): Promise<T> {
+    if (!interactionSource || this.interactionSource !== undefined) {
+      return await action()
+    }
+
+    this.interactionSource = interactionSource
+    try {
+      return await action()
+    } finally {
+      this.interactionSource = undefined
+    }
+  }
+
+  private getInteractionSource(): InteractionSource | undefined {
+    return this.interactionSource
+  }
+
+  private isInterfaceInstance(item: HierItem): item is InstanceItem {
+    return item instanceof InstanceItem && item.inst.declKind === slang.SlangInstKind.Interface
+  }
+
+  private isDataItem(item: HierItem): boolean {
+    return this.isInterfaceInstance(item) || DATA_SYMS.includes(item.inst.kind)
+  }
+
+  private isCategoryVisible(item: HierItem): boolean {
+    if (this.isInterfaceInstance(item)) {
+      return this.includeData
+    }
+    return this.symFilter.has(item.inst.kind)
+  }
+
+  // The server emits LSP window/showDocument so the language client handles URI translation
+  // (file:// vs vscode-remote://). viewColumn is dropped — showDocument has no equivalent.
+  private async revealHierLocation(
+    hierPath: string,
+    { preserveFocus = false }: { preserveFocus?: boolean; viewColumn?: vscode.ViewColumn } = {}
+  ): Promise<void> {
+    await slang.showHierLocation(hierPath, !preserveFocus)
+  }
 
   async onStart(): Promise<void> {
-    await this.refreshSlangCompilation({
-      revealHierarchy: false,
-      revealFile: false,
-      revealInstance: false,
-    })
+    await this.refreshSlangCompilation({ revealSelection: false })
   }
 
   //////////////////////////////////////////////////////////////////
@@ -547,15 +577,19 @@ export class ProjectComponent
 
       this.unit = undefined
       this.top = undefined
+      this.focused = undefined
+      this.instancesView.clearModules()
 
-      await this.instancesView.clearModules()
       this._onDidChangeTreeData.fire()
       await slang.setBuildFile('')
-      this.focusedBar.hide()
     }
   )
 
-  async reveal(item: HierItem | undefined = undefined, focus: boolean = false) {
+  async reveal(
+    item: HierItem | undefined = undefined,
+    focus: boolean = false,
+    openViewWhenNotVisible: boolean = false
+  ) {
     if (item === undefined) {
       if (this.focused === undefined) {
         this._onDidChangeTreeData.fire()
@@ -569,23 +603,113 @@ export class ProjectComponent
       this.focused = item
     }
     this._onDidChangeTreeData.fire()
-    if (item !== undefined) {
+    if (item !== undefined && this.treeView && (openViewWhenNotVisible || this.treeView.visible)) {
       this.logger.info('Revealing in hierarchy: ' + item.getPath())
-      await this.treeView?.reveal(item, { select: true, focus: focus, expand: true })
+      await this.treeView.reveal(item, { select: true, focus: focus, expand: true })
+    }
+  }
+
+  private async showHierarchySearch(): Promise<void> {
+    const quickPick = vscode.window.createQuickPick<HierarchyQuickPickItem>()
+    quickPick.placeholder = 'Search hierarchy by path'
+    quickPick.matchOnDescription = true
+    quickPick.matchOnDetail = true
+
+    let closed = false
+    let searchInProgress = false
+    let pendingQuery: string | undefined
+    const applyFilter = async (query: string): Promise<void> => {
+      pendingQuery = query
+      if (searchInProgress) {
+        return
+      }
+
+      searchInProgress = true
+      quickPick.busy = true
+      try {
+        while (!closed && pendingQuery !== undefined) {
+          const currentQuery = pendingQuery
+          pendingQuery = undefined
+
+          let result: slang.HierarchySearchResult | undefined
+          try {
+            result = await slang.searchHierarchy(currentQuery)
+          } catch (error) {
+            if (quickPick.value === currentQuery) {
+              quickPick.items = []
+              quickPick.title = `Search failed: ${String(error)}`
+            }
+            continue
+          }
+          if (closed || quickPick.value !== currentQuery) {
+            continue
+          }
+
+          const matches = result?.matches ?? []
+          const totalResults = result?.totalResults ?? 0
+          quickPick.items = matches.map((match) => {
+            const isSignal =
+              match.kind === slang.SlangKind.Logic || match.kind === slang.SlangKind.Port
+            return {
+              label: match.name,
+              description:
+                isSignal && match.containerName ? match.containerName : match.description,
+              detail:
+                isSignal && match.description ? `${match.description} — ${match.path}` : match.path,
+              path: match.path,
+            }
+          })
+          if (totalResults === 0) {
+            quickPick.title = 'No results found'
+          } else if (matches.length !== totalResults) {
+            quickPick.title = `Showing ${matches.length} of ${totalResults} results`
+          } else {
+            quickPick.title = `${totalResults} ${totalResults === 1 ? 'result' : 'results'}`
+          }
+        }
+      } finally {
+        searchInProgress = false
+        if (!closed) {
+          quickPick.busy = false
+        }
+      }
+    }
+
+    let selected: HierarchyQuickPickItem | undefined
+    const disposables = [
+      quickPick.onDidChangeValue((query) => void applyFilter(query)),
+      quickPick.onDidAccept(() => {
+        selected = quickPick.selectedItems[0]
+        quickPick.hide()
+      }),
+    ]
+    await new Promise<void>((resolve) => {
+      disposables.push(
+        quickPick.onDidHide(() => {
+          closed = true
+          resolve()
+        })
+      )
+      quickPick.show()
+      void applyFilter(quickPick.value)
+    })
+    disposables.forEach((disposable) => disposable.dispose())
+    quickPick.dispose()
+
+    if (selected) {
+      await this.setInstance.func(selected.path)
     }
   }
 
   fuzzyFindInstance: ViewButton = new ViewButton(
     {
-      title: 'Fuzzy Find Instances',
+      title: 'Find in Hierarchy',
       icon: '$(search-view-icon)',
       keybind: 'cmd+f',
       keybindContainer: true,
     },
     async (_instance: HierItem | undefined) => {
-      // Calling with undefined will pull up the instance quick pick
-      // We can't bind setInstance directly since it'll pass the focused tree item
-      await this.setInstance.func(undefined)
+      await this.showHierarchySearch()
     }
   )
 
@@ -598,10 +722,7 @@ export class ProjectComponent
       return null
     }
 
-    const scopes = await slang.getScopes(path)
     const parts = splitHierarchyPath(path)
-    let current: HasChildren = this.unit
-    let lastResolved: HierItem | undefined = undefined
 
     // Replace `current`'s children with server-fresh items, but reuse existing HierItem
     // objects (by name) so vscode's TreeView selection identity survives. Replacing
@@ -626,168 +747,235 @@ export class ProjectComponent
       parent.setChildren(fresh)
     }
 
-    for (let i = 0; i < parts.length; i++) {
-      if (i > 0 && current instanceof HierItem) {
-        const step = scopes[i]
-        if (step) {
-          refreshChildren(current, step.children)
-        }
-      }
+    const walkHierarchy = async (scopes?: slang.ScopeStep[]) => {
+      let current: HasChildren = this.unit!
+      let lastResolved: HierItem | undefined
 
-      type ChildCandidate = { instName: string; path: string; item: HierItem }
-      const childCandidates: ChildCandidate[] = (await current.getChildren()).map((item) => ({
-        instName: item.inst.instName,
-        path: item.getPath(),
-        item,
-      }))
-      const resolvedChild: ResolvedHierarchyChild<ChildCandidate> = resolveHierarchyChild(
-        childCandidates,
-        parts,
-        i,
-        lastResolved?.getPath()
-      )
-      const child: HierItem | undefined = resolvedChild.child?.item
-      i = resolvedChild.nextIndex
-      if (!child) {
-        if (lastResolved) {
-          return {
-            item: lastResolved,
-            exact: false,
-            missingPart: parts[i],
+      for (let i = 0; i < parts.length; i++) {
+        if (i > 0 && current instanceof HierItem && scopes) {
+          const step = scopes[i]
+          if (step) {
+            refreshChildren(current, step.children)
           }
         }
-        return null
+
+        // Normal instances lazily fetch their children from the server. Stop the cache-only
+        // pass here; scope and array children are embedded in their parent payloads.
+        if (
+          !scopes &&
+          current instanceof InstanceItem &&
+          !(current instanceof InstanceArrayItem) &&
+          current.children === undefined
+        ) {
+          return null
+        }
+
+        const childCandidates: Array<{ instName: string; path: string; item: HierItem }> = (
+          await current.getChildren()
+        ).map((item) => ({
+          instName: item.inst.instName,
+          path: item.getPath(),
+          item,
+        }))
+        const resolvedChild = resolveHierarchyChild(
+          childCandidates,
+          parts,
+          i,
+          lastResolved?.getPath()
+        )
+        const child = resolvedChild.child?.item
+        i = resolvedChild.nextIndex
+        if (!child) {
+          if (lastResolved) {
+            return {
+              item: lastResolved,
+              exact: false,
+              missingPart: parts[i],
+            }
+          }
+          return null
+        }
+
+        lastResolved = child
+        current = child
       }
 
-      lastResolved = child
-      current = child
+      if (lastResolved) {
+        const finalStep = scopes?.[parts.length]
+        if (finalStep) {
+          refreshChildren(lastResolved, finalStep.children)
+        }
+        return {
+          item: lastResolved,
+          exact: true,
+        }
+      }
+
+      return null
     }
 
-    if (lastResolved) {
-      const finalStep = scopes[parts.length]
-      if (finalStep) {
-        refreshChildren(lastResolved, finalStep.children)
-      }
-      return {
-        item: lastResolved,
-        exact: true,
-      }
+    const cached = await walkHierarchy()
+    if (cached?.exact) {
+      return cached
     }
+    return await walkHierarchy(await slang.getScopes(path))
+  }
 
-    return null
+  public async showInHierarchy(params: slang.ActivateInstanceParams): Promise<void> {
+    await this.setInstance.func(params.hierPath, params.interactionSource, true)
+  }
+
+  public async onActiveInstanceChanged(params: slang.ActivateInstanceParams): Promise<void> {
+    await this.showInHierarchy(params)
   }
 
   // Set instance given one of:
   // - a path (from internal calls)
-  // - a hierarchy item (from hierarchy or modules view)
-  // - undefined (let user select from compilation)
+  // - a hierarchy item
+  // - undefined (let user search the hierarchy)
   setInstance: CommandNode = new CommandNode(
     {
       title: 'Select Instance',
     },
     async (
       instance: HierItem | string | undefined,
-      { revealHierarchy, revealFile, revealInstance, focus }: RevealOptions = {
-        revealHierarchy: true,
-        revealFile: true,
-        revealInstance: true,
-      }
-    ) => {
-      if (instance === undefined) {
-        if (this.unit === undefined) {
-          // TODO: have one flow that this leads to- setting top, then specfiying build spec / params
-          await vscode.window.showInformationMessage('Please set top level or build file first')
+      interactionSource?: InteractionSource,
+      alreadyActivated = false
+    ) =>
+      this.withInteractionSource(interactionSource, async () => {
+        if (instance === undefined) {
+          if (this.unit === undefined) {
+            // TODO: have one flow that this leads to- setting top, then specfiying build spec / params
+            await vscode.window.showInformationMessage('Please set top level or build file first')
+            return
+          }
+
+          await this.showHierarchySearch()
+          return
         }
 
-        let options: vscode.QuickPickItem[] = []
-        await Promise.all(
-          Array.from(this.instancesView.modules.values()).map(async (mod) => {
-            const children = await mod.getChildren()
-            for (const child of children) {
-              options.push({
-                label: child.data.instPath,
-                description: mod.data.declName,
-              })
+        const currentInteractionSource = this.getInteractionSource()
+        const fromEditor = InteractionSource.isFromEditor(currentInteractionSource)
+        const fromSidebar = InteractionSource.isFromSidebar(currentInteractionSource)
+        const fromWaveform = InteractionSource.isFromWaveform(currentInteractionSource)
+        const preserveEditorFocus =
+          currentInteractionSource === undefined ||
+          fromSidebar ||
+          (fromEditor && currentInteractionSource !== InteractionSource.CodeLensGotoInstantiation)
+        const viewColumn = fromWaveform ? vscode.ViewColumn.Beside : undefined
+        const shouldOpenEditorLocation =
+          !alreadyActivated &&
+          currentInteractionSource !== InteractionSource.Modules &&
+          (!fromEditor || currentInteractionSource === InteractionSource.CodeLensGotoInstantiation)
+        let openedEditorPath: string | undefined
+
+        // resolve instances if hierarchy path
+        if (typeof instance === 'string') {
+          if (this.unit === undefined) {
+            // TODO: set the top level based on top name?
+            await vscode.window.showErrorMessage(
+              'Please set top level or build file first (no $unit)'
+            )
+            return
+          }
+
+          if (shouldOpenEditorLocation) {
+            await this.revealHierLocation(instance, {
+              preserveFocus: preserveEditorFocus,
+              viewColumn,
+            })
+            openedEditorPath = instance
+          }
+
+          const resolved = await this.resolveHierarchyPath(instance)
+          this._onDidChangeTreeData.fire()
+          if (!resolved) {
+            const error = `Could not find instance ${instance}`
+            this.logger.warn(error)
+            await vscode.window.showErrorMessage(error)
+            return
+          }
+          if (!resolved.exact && resolved.missingPart) {
+            const error = `Could not find instance ${resolved.missingPart} in ${resolved.item.getPath()}`
+            this.logger.warn(error)
+            await vscode.window.showErrorMessage(error)
+          }
+          instance = resolved.item
+        }
+
+        this.focused = instance
+        // The tree's getChildren filter hides fromExpansion items, so reveal can't walk
+        // the parent chain if any ancestor is macro-expanded. Toggle if any node on the
+        // path needs the macro-defined visibility on.
+        if (!this.includeMacroDefined) {
+          for (let node: HierItem | undefined = instance; node; node = node.parent) {
+            if (node.fromExpansion) {
+              await this.toggleHiddenFunc()
+              break
             }
-          })
-        )
-        const selectedInst = await vscode.window.showQuickPick(options, {
-          placeHolder: 'Enter instance path',
-        })
-
-        if (selectedInst === undefined) {
-          return
+          }
         }
-        instance = selectedInst.label
-        this.logger.info('Selected instance: ' + instance)
-      }
-
-      // resolve instances if hierarchy path
-      if (typeof instance === 'string') {
-        if (this.unit === undefined) {
-          // TODO: set the top level based on top name?
-          await vscode.window.showErrorMessage(
-            'Please set top level or build file first (no $unit)'
-          )
-          return
-        }
-
-        const resolved = await this.resolveHierarchyPath(instance)
-        this._onDidChangeTreeData.fire()
-        if (!resolved) {
-          const error = `Could not find instance ${instance}`
-          this.logger.warn(error)
-          await vscode.window.showErrorMessage(error)
-          return
-        }
-        if (!resolved.exact && resolved.missingPart) {
-          const error = `Could not find instance ${resolved.missingPart} in ${resolved.item.getPath()}`
-          this.logger.warn(error)
-          await vscode.window.showErrorMessage(error)
-        }
-        instance = resolved.item
-      }
-
-      this.focused = instance
-      if (revealHierarchy) {
-        if (instance.fromExpansion && !this.includeMacroDefined) {
-          await this.toggleHiddenFunc()
-        }
-        if (!this.symFilter.has(instance.inst.kind)) {
+        if (!this.isCategoryVisible(instance)) {
           if (instance.inst.kind === slang.SlangKind.Param) {
             await this.toggleParamsFunc()
-          } else if (DATA_SYMS.includes(instance.inst.kind)) {
+          } else if (this.isDataItem(instance)) {
             await this.toggleDataFunc()
           }
         }
-        await this.reveal(instance, focus === 'hierarchy')
-      }
 
-      if (revealFile) {
-        this.isRevalingFile = true
-        await slang.showHierLocation(instance.getPath(), focus === 'editor')
-        this.isRevalingFile = false
-      }
-
-      if (revealInstance) {
-        // select the most recent module
-        while (!(instance instanceof InstanceItem)) {
-          instance = instance.parent
-          if (instance === undefined) {
-            return
-          }
+        // Reveal in Hierarchy
+        if (
+          currentInteractionSource !== InteractionSource.Hierarchy &&
+          currentInteractionSource !== InteractionSource.WaveformNetlist
+        ) {
+          const openHierarchyWhenNotVisible =
+            currentInteractionSource === undefined ||
+            currentInteractionSource === InteractionSource.Terminal ||
+            currentInteractionSource === InteractionSource.Waveform
+          await this.reveal(instance, false, openHierarchyWhenNotVisible)
+        } else {
+          this._onDidChangeTreeData.fire()
         }
-        this.instancesView.revealPath(instance.inst.declName, instance.getPath())
-      }
 
-      const parentModule = instance.getModule()
-      if (parentModule) {
-        this.moduleToInstance.set(parentModule.inst.declName, parentModule!)
-        this.focusedBar.text = `$(chip) ${parentModule.getPath()}`
-        this.focusedBar.show()
-      }
+        // Set as active
+        const selectedModule = instance.getModule()
+        const selectedActiveModule =
+          selectedModule && selectedModule.inst.declKind !== slang.SlangInstKind.Package
+            ? selectedModule
+            : undefined
 
-      return instance
+        if (selectedActiveModule && !alreadyActivated) {
+          await slang.setActiveInstance(instance.getPath())
+        }
+
+        if (selectedActiveModule) {
+          await this.instancesView.revealPath(
+            selectedActiveModule.inst.declName,
+            selectedActiveModule.getPath()
+          )
+        }
+
+        if (shouldOpenEditorLocation && openedEditorPath !== instance.getPath()) {
+          await this.revealHierLocation(instance.getPath(), {
+            preserveFocus: preserveEditorFocus,
+            viewColumn,
+          })
+        }
+
+        return instance
+      })
+  )
+
+  selectModuleInstance: CommandNode = new CommandNode(
+    {
+      title: 'Select Module Instance',
+    },
+    async (instancePath: string, moduleName: string) => {
+      const selected = await this.setInstance.func(instancePath, InteractionSource.Modules)
+      if (!selected) {
+        return
+      }
+      await slang.openModuleDefinition(moduleName)
     }
   )
 
@@ -940,7 +1128,7 @@ export class ProjectComponent
         await this.setDirectBuildFile(selection.filePath)
       }
 
-      await this.refreshSlangCompilation()
+      await this.refreshSlangCompilation({ preserveFocusedPath: false })
     }
   )
 
@@ -948,11 +1136,11 @@ export class ProjectComponent
   // Symbol Filtering
   //////////////////////////////////////////////////////////////////
 
-  symFilter: Set<string> = new Set<string>(STRUCTURE_SYMS)
+  symFilter: Set<string> = new Set<string>([...STRUCTURE_SYMS, ...DATA_SYMS])
   // params / localparams (constants)
   includeParams: boolean = false
-  // ports / nets / registers (variables)
-  includeData: boolean = false
+  // ports / nets / registers / interfaces / interface ports
+  includeData: boolean = true
 
   // symbols hidden behind macros
   includeMacroDefined: boolean = false
@@ -994,11 +1182,11 @@ export class ProjectComponent
   async toggleDataFunc() {
     this.includeData = !this.includeData
     if (this.includeData) {
-      for (let type of VarItem.DATA_TYPES) {
+      for (let type of DATA_SYMS) {
         this.symFilter.add(type)
       }
     } else {
-      for (let type of VarItem.DATA_TYPES) {
+      for (let type of DATA_SYMS) {
         this.symFilter.delete(type)
       }
     }
@@ -1038,21 +1226,6 @@ export class ProjectComponent
   //////////////////////////////////////////////////////////////////
   // Inline Item Buttons
   //////////////////////////////////////////////////////////////////
-
-  showSourceFile: TreeItemButton = new TreeItemButton(
-    {
-      title: 'Show Module',
-      viewItems: ['Module'],
-      icon: getIcons('go-to-file'),
-    },
-    async (item: HierItem) => {
-      if (item instanceof InstanceItem && item) {
-        this.isRevalingFile = true
-        await slang.showModuleDefinition(item.inst.declName, true)
-        this.isRevalingFile = false
-      }
-    }
-  )
 
   showInWaveform: TreeItemButton = new TreeItemButton(
     {
@@ -1138,9 +1311,8 @@ export class ProjectComponent
       }
       await this.setDirectBuildFile(this.buildfile)
       await this.refreshSlangCompilation({
-        revealFile: false,
-        revealHierarchy: false,
-        revealInstance: false,
+        revealSelection: false,
+        preserveFocusedPath: false,
       })
     } else {
       this.logger.warn('No build files found for pattern: ' + buildPattern)
@@ -1176,13 +1348,7 @@ export class ProjectComponent
         const top = decoded.scopeId?.split('.')[0] || ''
         await this.openBuildFile({ name: basename, top: top })
       }
-      await this.setInstance.func(fullpath, {
-        revealHierarchy: false,
-        revealFile: true,
-        revealInstance: true,
-        focus: 'editor',
-        showBeside: true,
-      })
+      await this.setInstance.func(fullpath, InteractionSource.WaveformNetlist)
     }
   )
 
@@ -1236,13 +1402,7 @@ export class ProjectComponent
           "'e' keybind from netlist view not yet supported; please add to waveform first or use button."
         )
       }
-      await this.setInstance.func(signalPath, {
-        revealHierarchy: true,
-        revealFile: true,
-        revealInstance: true,
-        focus: 'editor',
-        showBeside: true,
-      })
+      await this.setInstance.func(signalPath, InteractionSource.Waveform)
     }
   )
 
@@ -1274,72 +1434,17 @@ export class ProjectComponent
           '[Select Build File](command:slang.project.selectBuildFile)\n[Select Top Level](command:slang.project.selectTopLevel)',
       },
     })
-    this.focusedBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100)
-    this.focusedBar.name = 'Slang Instance'
-    vscode.window.onDidChangeActiveTextEditor(async (e: vscode.TextEditor | undefined) => {
-      if (e === undefined) {
-        return
-      }
-      if (this.unit === undefined) {
-        return
-      }
-      if (!isAnyVerilog(e.document.languageId)) {
-        return
-      }
-      if (this.isRevalingFile) {
-        return
-      }
-
-      // Only show when slang view is visible.
-      // Users may put the instances view in another tab, so check that too.
-      if (!(this.treeView?.visible === true || this.instancesView.treeView?.visible === true)) {
-        return
-      }
-
-      this.logger.info(
-        'Active editor changed: ' + e.document.uri.toString(),
-        'updating instances view'
-      )
-
-      // always open the modules view so we can select an instance
-
-      // try this first to avoid querying slang-server
-      const basename = getBasename(e.document.uri.fsPath)!
-      if (this.instancesView.modules.has(basename)) {
-        this.instancesView.revealPath(basename)
-        return
-      }
-
-      const modules = await slang.getModulesInFile(e.document.uri.fsPath)
-      if (modules.length === 0) {
-        this.logger.info('No modules found in file')
-        return
-      }
-      const instance = this.moduleToInstance.get(modules[0])
-      if (instance !== undefined) {
-        await this.setInstance.func(instance, {
-          revealHierarchy: true,
-          revealFile: false,
-          revealInstance: false,
-          focus: 'hierarchy',
-        })
-      }
-      this.instancesView.revealPath(modules[0])
-    })
   }
-
-  static RE_INSTANCE_PATHS = /(?<![/\\])[\w$]+(\[\d+\])?(\.[\w$]+(\[\d+\])?)+(?![/\\])/g
 
   async provideTerminalLinks(
     context: vscode.TerminalLinkContext,
     _token: vscode.CancellationToken
   ): Promise<InstanceLink[]> {
     let links = []
-    for (let match of context.line.matchAll(ProjectComponent.RE_INSTANCE_PATHS)) {
-      this.logger.info('Potential instance path in terminal: ' + match[0])
-      const line = context.line
-      const startIndex = line.indexOf(match[0])
-      const path = match[0]
+    for (let match of findInstancePaths(context.line)) {
+      this.logger.info('Potential instance path in terminal: ' + match.path)
+      const startIndex = match.index
+      const path = match.path
       const topModule = path.split('.')[0]
 
       if (this.unit?.childMap.has(topModule)) {
@@ -1373,12 +1478,7 @@ export class ProjectComponent
       }
       await this.setTopLevel.func(vscode.Uri.file(file))
     }
-    await this.setInstance.func(link.path, {
-      revealHierarchy: true,
-      revealFile: true,
-      revealInstance: true,
-      focus: 'editor',
-    })
+    await this.setInstance.func(link.path, InteractionSource.Terminal)
   }
 
   // Stop watching the currently active command-backed build source, if any.
@@ -1397,7 +1497,7 @@ export class ProjectComponent
       return true
     }
     if (this.topFile) {
-      await this.setTopLevel.func(this.topFile)
+      await slang.setTopLevel(this.topFile.fsPath)
       return true
     }
     return false
@@ -1454,11 +1554,7 @@ export class ProjectComponent
 
       this.compilationSource = { type: 'commandBuild', buildfile, args }
       await slang.setBuildFile(buildfile)
-      await this.refreshSlangCompilation({
-        revealFile: false,
-        revealHierarchy: false,
-        revealInstance: false,
-      })
+      await this.refreshSlangCompilation({ revealSelection: false })
     }
 
     watcher.onDidChange((uri) => void rerun(uri))
@@ -1571,34 +1667,41 @@ export class ProjectComponent
 
     context.subscriptions.push(vscode.window.registerTerminalLinkProvider(this))
     context.subscriptions.push({ dispose: () => this.clearBuildCommandTracking() })
-
     // user updates to buildfile
-    vscode.workspace.onDidSaveTextDocument(async (document) => {
-      if (document.uri.fsPath === this.buildfile) {
-        this.logger.info(
-          'Build file updated, reloading: ' + vscode.workspace.asRelativePath(this.buildfile)
-        )
-        vscode.commands.executeCommand('slang.setBuildFile', this.buildfile)
-        await this.refreshSlangCompilation()
-      }
-    })
+    context.subscriptions.push(
+      vscode.workspace.onDidSaveTextDocument(async (document) => {
+        if (document.uri.fsPath === this.buildfile) {
+          this.logger.info(
+            'Build file updated, reloading: ' + vscode.workspace.asRelativePath(this.buildfile)
+          )
+          vscode.commands.executeCommand('slang.setBuildFile', this.buildfile)
+          await this.refreshSlangCompilation()
+          return
+        }
+
+        if (this.unit && isAnyVerilog(document.languageId)) {
+          this.logger.info(
+            'HDL file updated, refreshing hierarchy: ' +
+              vscode.workspace.asRelativePath(document.uri)
+          )
+          await this.refreshSlangCompilation({ revealSelection: false })
+        }
+      })
+    )
   }
 
-  async refreshSlangCompilation(
-    revealOptions: RevealOptions = {
-      revealHierarchy: true,
-      revealFile: true,
-      revealInstance: false,
-    }
-  ) {
+  async refreshSlangCompilation({
+    revealSelection = true,
+    preserveFocusedPath = true,
+  }: RefreshOptions = {}) {
+    const previousFocusedPath = preserveFocusedPath ? this.focused?.getPath() : undefined
     const unit = await slang.getUnit()
     if (unit.length === 0) {
       this.unit = undefined
       this.top = undefined
       this.focused = undefined
-      this.focusedBar.hide()
+      this.instancesView.clearModules()
       this._onDidChangeTreeData.fire()
-      await this.instancesView.clearModules()
       return
     }
     this.unit = new UnitItem(
@@ -1608,25 +1711,43 @@ export class ProjectComponent
     )
 
     const tops = this.unit.children.filter((item) => item.inst.kind === slang.SlangKind.Instance)
-
-    if (tops.length === 1 && this.treeView !== undefined) {
-      this.top = tops[0]
-      this.setInstance.func(tops[0], revealOptions)
+    this.top = tops.length === 1 ? tops[0] : undefined
+    if (!preserveFocusedPath) {
+      this.focused = undefined
     }
     this._onDidChangeTreeData.fire()
-    // TODO: maybe setInstance() regardless of how many tops there are
     await this.instancesView.updateModules()
+    if (previousFocusedPath) {
+      const restored = await this.resolveHierarchyPath(previousFocusedPath)
+      if (restored) {
+        this.focused = restored.item
+        if (revealSelection) {
+          await this.setInstance.func(restored.item)
+        } else {
+          this._onDidChangeTreeData.fire()
+        }
+        return
+      }
+    }
+
+    if (tops.length === 1 && this.treeView !== undefined && revealSelection) {
+      await this.setInstance.func(tops[0])
+    }
+  }
+
+  private decorateHierarchyTreeItem(item: TreeItem, element: HierItem): TreeItem {
+    item.tooltip = element.getPath()
+    item.command = {
+      title: 'Go to definition',
+      command: 'slang.project.setInstance',
+      arguments: [element, InteractionSource.Hierarchy],
+    }
+    return item
   }
 
   async getTreeItem(element: HierItem): Promise<TreeItem> {
-    if (element.inst.kind === slang.SlangKind.Package) {
-      const treeItem = await element.getTreeItem()
-      treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed
-      return treeItem
-    }
-
     const treeItem = await element.getTreeItem()
-    const expandable = await element.hasChildren()
+    const expandable = (await this.getChildren(element)).length > 0
     if (!expandable) {
       treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None
     } else if (element instanceof RootItem && element.inst.kind === slang.SlangKind.Instance) {
@@ -1634,7 +1755,7 @@ export class ProjectComponent
     } else {
       treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed
     }
-    return treeItem
+    return this.decorateHierarchyTreeItem(treeItem, element)
   }
 
   async getChildren(element?: HierItem | undefined): Promise<HierItem[]> {
@@ -1645,16 +1766,18 @@ export class ProjectComponent
       return this.unit.getChildren()
     }
     const children = await element.getChildren()
-    if (element.inst.kind === slang.SlangKind.Package) {
-      // Packages don't have children loaded, but should always have something
-      return children
+    if (element instanceof PkgItem) {
+      return children.filter(
+        (child) =>
+          (child.inst.kind === slang.SlangKind.Param || this.isCategoryVisible(child)) &&
+          (this.includeMacroDefined || !child.fromExpansion)
+      )
     }
     return children.filter((child) => this.shouldBeVisible(child))
   }
 
-  // doesn't include filtering for package children
   shouldBeVisible(element: HierItem): boolean {
-    if (!this.symFilter.has(element.inst.kind)) {
+    if (!this.isCategoryVisible(element)) {
       return false
     }
     if (!this.includeMacroDefined && element.fromExpansion) {
@@ -1672,14 +1795,6 @@ export class ProjectComponent
     element: HierItem,
     _token: vscode.CancellationToken
   ): Promise<TreeItem> {
-    /// Triggered on hover
-    item.tooltip = element.getPath()
-    item.command = {
-      title: 'Go to definition',
-      command: 'slang.project.setInstance',
-      arguments: [element, { revealHierarchy: false, revealFile: true, revealInstance: true }],
-    }
-
-    return item
+    return this.decorateHierarchyTreeItem(item, element)
   }
 }

--- a/clients/vscode/test/unit/instancePath.test.ts
+++ b/clients/vscode/test/unit/instancePath.test.ts
@@ -1,0 +1,128 @@
+import tape from 'tape'
+import { findInstancePaths } from '../../src/lib/InstancePathUtils'
+
+tape('matches simple dotted instance path', (t) => {
+  const results = findInstancePaths('top.sub.module')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.sub.module')
+  t.equal(results[0].index, 0)
+  t.end()
+})
+
+tape('matches instance path with array indices', (t) => {
+  const results = findInstancePaths('top.sub[0].module[1]')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.sub[0].module[1]')
+  t.end()
+})
+
+tape('matches instance path in a log line', (t) => {
+  const results = findInstancePaths('Error at top.sub.module during simulation')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.sub.module')
+  t.equal(results[0].index, 9)
+  t.end()
+})
+
+tape('matches multiple instance paths on one line', (t) => {
+  const results = findInstancePaths('comparing top.a.b and top.c.d')
+  t.equal(results.length, 2)
+  t.equal(results[0].path, 'top.a.b')
+  t.equal(results[1].path, 'top.c.d')
+  t.end()
+})
+
+tape('ignores .sv file extensions', (t) => {
+  const results = findInstancePaths('error in mymodule.sv')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('ignores .v file extensions', (t) => {
+  const results = findInstancePaths('error in mymodule.v')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('ignores .svh file extensions', (t) => {
+  const results = findInstancePaths('included header.svh')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('ignores .vh file extensions', (t) => {
+  const results = findInstancePaths('included header.vh')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('matches instance path that happens to contain sv-like segment in the middle', (t) => {
+  const results = findInstancePaths('top.sv_wrapper.module')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.sv_wrapper.module')
+  t.end()
+})
+
+tape('ignores file paths with slashes', (t) => {
+  const results = findInstancePaths('/path/to/thing.with.dots')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('ignores relative file paths', (t) => {
+  const results = findInstancePaths('src/design/top.sub.module')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('ignores file paths with backslashes', (t) => {
+  const results = findInstancePaths('C:\\path\\to\\thing.with.dots')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('matches instance path after colon', (t) => {
+  const results = findInstancePaths('signal: top.sub.module')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.sub.module')
+  t.end()
+})
+
+tape('matches instance path after parenthesis', (t) => {
+  const results = findInstancePaths('(top.sub.module)')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.sub.module')
+  t.end()
+})
+
+tape('ignores .sv file but matches real instance path on same line', (t) => {
+  const results = findInstancePaths('In file top.sv, see top.dut.core')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.dut.core')
+  t.end()
+})
+
+tape('ignores single word with no dots', (t) => {
+  const results = findInstancePaths('just a plain word')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('handles dollar sign identifiers', (t) => {
+  const results = findInstancePaths('top.$unit.module')
+  t.equal(results.length, 1)
+  t.equal(results[0].path, 'top.$unit.module')
+  t.end()
+})
+
+tape('does not match path followed by slash', (t) => {
+  const results = findInstancePaths('top.sub.module/child')
+  t.equal(results.length, 0)
+  t.end()
+})
+
+tape('ignores sv extension at end of longer path', (t) => {
+  const results = findInstancePaths('path.to.file.sv')
+  t.equal(results.length, 0)
+  t.end()
+})

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -20,6 +20,8 @@ Hovers are provided on each symbol with the following info if applicable:
 - The syntax that the symbol is derived from
 - Macro usage, if symbol was defined from one.
 
+With an elaborated design, hovers use the [active instance](hdl/hdl.md#active-instances) of the enclosing module or interface. Parameter values, dependent types and widths, interface connections, and driver information therefore reflect the selected instance rather than the default elaboration.
+
 ![goto-refs](/assets/images/hovers.gif)
 
 Planned features:
@@ -63,13 +65,13 @@ Inlay hints are text that show up inline in the code to provide useful info. The
 **Wildcard Ports** - Show which signals are passed through
 ![goto-refs](/assets/images/port_wildcard_inlays.png)
 
-**Positional args in Macros, Functions, Paramter/Port lists** - Show the argument names
+**Positional args in Macros, Functions, Parameter/Port lists** - Show the argument names
 ![goto-refs](/assets/images/macro_inlays.png)
 
+**Active parameter values** - Show resolved parameter and localparam values for the [active instance](hdl/hdl.md#active-instances). These hints are enabled by default and can be controlled with `inlayHints.activeParameterValues`.
 
 Planned Inlays:
 
-- **Constant Values** - Show parameter values and resolved types
 - **Signals** - Show the value when a waveform is connected and an instance is selected.
 - **Wildcard Imports** - Show which symbols are used from the import
 

--- a/docs/features/hdl/hdl.md
+++ b/docs/features/hdl/hdl.md
@@ -16,6 +16,21 @@ When a design is set, a full hierarchy will be elaborated in conjunction with th
 
 The compilation is refreshed on save, updating the diagnostics and related info.
 
+## Active Instances
+
+A module or interface definition can be elaborated many times with different parameters, types, generate branches, and interface connections. Slang Server keeps one **active instance** for each definition so source-level features have a concrete elaborated context.
+
+The active instance controls:
+
+- Resolved parameter and localparam values in hovers and inlay hints.
+- Dependent signal types and widths.
+- Interface parameter values, connections, and forwarded interface paths.
+- The selected iteration of generate loops.
+
+Selecting an instance also updates the active instances along its enclosing hierarchy. Go to Definition from an instantiation, port, or parameter reference selects the referenced instance before opening its declaration. Selections that still exist are preserved when the design is recompiled; if one disappears, the server chooses a valid default.
+
+The editor integrations provide controls for inspecting and changing these selections. See the editor-specific pages below.
+
 See the [Vscode Docs](./vscode.md)
 
 See the [Neovim Docs](./neovim.md)

--- a/docs/features/hdl/neovim.md
+++ b/docs/features/hdl/neovim.md
@@ -38,6 +38,12 @@ This will open the hierarchy view and, if `SCOPE` is provided, expand the view t
 
 ![Hierarchy View](neovim/hierarchy.png)
 
+The hierarchy opens with a Cells view that groups elaborated instances by module. Press `<Space>` on a module to list its instances, then `<CR>` on an instance to make it active, jump to its source, and reveal it in the hierarchy. Pressing `<CR>` on an instance in the hierarchy also makes it active; `gd` opens its declaration without changing the selection. Press `?` in either view for the complete key map.
+
+If Neovim CodeLens display is enabled, module and interface declarations show the active path and instance count. Activating that CodeLens opens `vim.ui.select` when multiple instances are available. Generate-loop CodeLenses similarly select an active elaborated iteration.
+
+The active instance supplies the context for resolved parameter values, dependent types and widths, interface connections, hovers, and parameter-value inlay hints. An open hierarchy follows active-instance changes initiated by CodeLens or Go to Definition.
+
 ## Cone Tracing (experimental)
 
 ```

--- a/docs/features/hdl/vscode.md
+++ b/docs/features/hdl/vscode.md
@@ -31,7 +31,9 @@ The 'chip' icon at the top right of a file will scan the current file for valid 
 ## Hierarchy View
 
 The Hierarchy View shows the elaborated tree, with declared types and resolved values to the right of the identifier.
-Clicking a symbol in the hierarchy view or modules view will open the instance in the file, as well as in the other view.
+Interface ports and their elaborated members are included alongside modules, generate scopes, parameters, ports, and data signals. Data signals are visible by default. Parameters can be toggled for modules, while package parameters remain visible whenever their package is shown.
+
+Clicking a symbol opens its source location and makes its enclosing module or interface the [active instance](hdl.md#active-instances). The Hierarchy and Modules views follow the new selection. Scopes with no visible children are shown as leaves rather than expandable nodes.
 
 <div class="grid" markdown>
 <div class="grid-item" markdown>
@@ -76,9 +78,11 @@ Clicking a symbol in the hierarchy view or modules view will open the instance i
 <div class="grid" markdown>
 <div class="grid-item" markdown>
 
-The modules view shows the instances indexed by module, sorted by the number of instances with higher level objects closer to the top.
+The Modules view groups elaborated instances by their module or interface definition.
 
-While a compilation is active, the modules view will open when switching text documents, allowing the user to select which instance of that module they'd like to focus on. In the future, inlay hints will show values for parameters and signals in the source code.
+Click an instance path to make it active and open its definition. Use the **Go to Instantiation** button on an instance path to open the instantiation site instead; the view also reveals the corresponding parent instance.
+
+The selected instance determines the resolved parameter values, dependent types and widths, interface connections, and other elaboration-specific information shown while editing that definition.
 
 </div>
 <div class="grid-item" markdown>
@@ -87,6 +91,14 @@ While a compilation is active, the modules view will open when switching text do
 
 </div>
 </div>
+
+## Active Instance CodeLens
+
+With a compilation active, a CodeLens above each instantiated module or interface declaration displays its active hierarchical path and total instance count. Click it to choose another instance when more than one exists. A neighboring **Go to Instantiation** CodeLens opens the selected instance's instantiation site.
+
+Generate loops also receive a CodeLens when the active module instance contains multiple elaborated iterations. Selecting an iteration updates the context used by source features.
+
+Instance selections stay synchronized across CodeLens actions, Go to Definition, the Hierarchy view, and the Modules view. Hovers and the `inlayHints.activeParameterValues` hints update to show values from the selected instance.
 
 ## Inactive Preprocessor Regions
 

--- a/docs/start/config.md
+++ b/docs/start/config.md
@@ -173,6 +173,8 @@ All configuration options are optional and have sensible defaults. In VSCode, th
       portTypes?: boolean           // default: false
       /** Hints for inferred assignment pattern types */
       assignmentPatternTypes?: boolean // default: true
+      /** Hints for active instance parameter and localparam values */
+      activeParameterValues?: boolean  // default: true
       /** Hints for names of ordered ports and params */
       orderedInstanceNames?: boolean // default: true
       /** Hints for port names in wildcard (.*) ports */
@@ -188,6 +190,7 @@ All configuration options are optional and have sensible defaults. In VSCode, th
 
     - **`portTypes`**: Show type hints on ports. Off by default.
     - **`assignmentPatternTypes`**: Show the inferred struct or union type before untyped assignment patterns.
+    - **`activeParameterValues`**: Show parameter and localparam values from the active instance.
     - **`orderedInstanceNames`**: Show parameter/port name hints on ordered (positional) instance connections.
     - **`wildcardNames`**: Show port name hints on wildcard (`.*`) connections.
     - **`funcArgNames`**: Show argument name hints on function calls. Set to `0` to disable, or `N` to only show hints for calls with N or more arguments.

--- a/include/Config.h
+++ b/include/Config.h
@@ -104,6 +104,8 @@ struct Config {
         rfl::Description<"Hints for port types", bool> portTypes = false;
         rfl::Description<"Hints for inferred assignment pattern types", bool>
             assignmentPatternTypes = true;
+        rfl::Description<"Hints for active instance parameter and localparam values", bool>
+            activeParameterValues = true;
         rfl::Description<"Hints for names of ordered ports and params", bool> orderedInstanceNames =
             true;
         rfl::Description<"Hints for port names in wildcard (.*) ports", bool> wildcardNames = true;

--- a/include/ServerDriver.h
+++ b/include/ServerDriver.h
@@ -96,6 +96,11 @@ public:
 
     std::shared_ptr<SlangDoc> getDocument(const URI& uri);
 
+    /// Record the active instance for the module reached by `instPath`, then invalidate
+    /// every open document's cached analysis so subsequent hovers/gotos see the new
+    /// selection. Refreshes client-side code lenses and inlay hints.
+    bool setActiveInstance(std::string_view hierPath);
+
     std::vector<std::shared_ptr<syntax::SyntaxTree>> getDependentTrees(
         std::shared_ptr<syntax::SyntaxTree> tree);
 
@@ -108,6 +113,10 @@ public:
     /// @return Optional definition information
     std::optional<DefinitionInfo> getDefinitionInfoAt(const URI& uri,
                                                       const lsp::Position& position);
+
+    /// Return the concrete full-design instance referenced by an instantiation token.
+    std::optional<std::string> getDesignInstancePathAt(const URI& uri,
+                                                       const lsp::Position& position);
 
     /// @brief Gets hover information for a symbol at an LSP position
     /// @param uri The URI of the document
@@ -177,6 +186,9 @@ private:
 
     /// Parse config flags and build files, load sources, create documents
     void parseAndLoadSources(const std::vector<std::string>& buildfiles);
+
+    /// Drop analysis state derived from the active design and refresh client-side annotations.
+    void invalidateAnalysesAndRefreshClient();
 
     std::optional<DefinitionInfo> getMacroDefinitionInfo(const ShallowAnalysis& analysis,
                                                          const parsing::Token& token,

--- a/include/SlangLspClient.h
+++ b/include/SlangLspClient.h
@@ -11,13 +11,47 @@
 #include "lsp/LspClient.h"
 #include "lsp/LspTypeExtensions.h"
 #include <algorithm>
+#include <optional>
 #include <rfl/from_generic.hpp>
+#include <rfl/to_generic.hpp>
+#include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 class SlangLspClient : public lsp::LspClient {
-    /// Helper functions to send things to the client
-
 public:
+    enum class InteractionSource {
+        editor,
+        codeLensSelect,
+        codeLensGotoInstantiation,
+        hierarchy,
+        modules,
+        terminal,
+        waveform,
+        waveformNetlist,
+    };
+
+    struct ActivateInstanceParams {
+        std::string hierPath;
+        InteractionSource interactionSource;
+    };
+
+    struct QuickPickItem {
+        std::string label;
+        std::optional<std::string> description;
+        lsp::LSPAny value;
+    };
+
+    struct QuickPickParams {
+        std::string placeholder;
+        std::vector<QuickPickItem> items;
+        /// The selected item's value is passed as this command's sole argument.
+        std::string onSelectCommand;
+        /// Clients with a hierarchy UI route the selection through that UI using this source.
+        std::optional<InteractionSource> interactionSource;
+    };
+
     struct Capabilities {
         /// Experimental slang-server inactive-regions extension.
         bool inactiveRegionsSupported = false;
@@ -59,6 +93,14 @@ public:
         }
     } capabilities;
 
+private:
+    /// Pack arbitrary values into the LSP `arguments` array via rfl serialization.
+    template<typename... Args>
+    static std::vector<lsp::LSPAny> passArgs(Args&&... args) {
+        return {rfl::to_generic(std::forward<Args>(args))...};
+    }
+
+public:
     virtual void setConfig(const Config& params) {
         lsp::sendNotification("slang/setConfig", rfl::to_generic(params));
     }
@@ -67,5 +109,55 @@ public:
         lsp::sendRequest("client/registerCapability",
                          rfl::to_generic<rfl::UnderlyingEnums>(params));
         return std::monostate{};
+    }
+
+    virtual void onActiveInstanceChanged(const ActivateInstanceParams& params) {
+        lsp::sendNotification("slang/activeInstanceChanged", rfl::to_generic(params));
+    }
+
+    lsp::Command makeActivateInstanceCommand(std::string title, std::string tooltip,
+                                             std::string_view instance,
+                                             InteractionSource source) const {
+        return lsp::Command{
+            .title = std::move(title),
+            .tooltip = std::move(tooltip),
+            .command = "slang.activateInstance",
+            .arguments = std::vector<lsp::LSPAny>{rfl::to_generic<rfl::UnderlyingEnums>(
+                ActivateInstanceParams{.hierPath = std::string(instance),
+                                       .interactionSource = source})},
+        };
+    }
+
+    lsp::Command makeQuickPickCommand(std::string title, std::string tooltip,
+                                      std::string placeholder, std::string_view activeValue,
+                                      const std::vector<std::string>& values,
+                                      std::string onSelectCommand,
+                                      std::optional<InteractionSource> interactionSource) const {
+        std::vector<QuickPickItem> items;
+        items.reserve(values.size());
+        for (const auto& value : values) {
+            items.push_back(QuickPickItem{
+                .label = value,
+                .description = value == activeValue ? std::optional<std::string>("(current)")
+                                                    : std::nullopt,
+                .value = interactionSource
+                             ? rfl::to_generic<rfl::UnderlyingEnums>(ActivateInstanceParams{
+                                   .hierPath = value,
+                                   .interactionSource = *interactionSource,
+                               })
+                             : rfl::to_generic(value),
+            });
+        }
+        return lsp::Command{
+            .title = std::move(title),
+            .tooltip = std::move(tooltip),
+            .command = "slang.quickPick",
+            .arguments = passArgs(QuickPickParams{
+                .placeholder = std::move(placeholder),
+                .items = std::move(items),
+                .onSelectCommand = std::move(onSelectCommand),
+                .interactionSource = interactionSource,
+            }),
+        };
     }
 };

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -128,7 +128,8 @@ public:
     std::vector<hier::HierItem_t> getScope(const std::string& hierPath);
 
     // Return root-to-focus scope steps with child lists for each hierarchy segment.
-    std::vector<hier::ScopeStep> getScopes(const std::string& hierPath);
+    std::vector<hier::ScopeStep> getScopes(const std::string& hierPath,
+                                           const lsp::RequestContext& ctx = {});
 
     std::optional<lsp::Location> getHierLocation(const std::string& hierPath);
 

--- a/include/SlangServer.h
+++ b/include/SlangServer.h
@@ -115,10 +115,15 @@ public:
     // it will require another query
     std::vector<hier::InstanceSet> getScopesByModule(const std::monostate&);
 
-    // Returns the instances of a module
+    // Returns the instances of a module plus its declaration location
     std::vector<hier::QualifiedInstance> getInstancesOfModule(const std::string moduleName);
 
-    // Returns the modules defined in a file, used for the modules view
+    bool setActiveInstance(const std::string& hierPath);
+    bool activateInstance(const SlangLspClient::ActivateInstanceParams& params,
+                          const lsp::RequestContext& ctx = {});
+    std::optional<hier::QualifiedInstance> getActiveInstance(const std::string& moduleName);
+
+    // Returns the modules defined in a file.
     std::vector<std::string> getModulesInFile(const std::string path);
 
     // Returns the files that contain a specific module, used for terminal links
@@ -131,6 +136,9 @@ public:
     std::vector<hier::ScopeStep> getScopes(const std::string& hierPath,
                                            const lsp::RequestContext& ctx = {});
 
+    // Resolve the document location for a hierarchical path. Used by tests; the LSP command
+    // is `slang.showHierLocation`, which sends the location to the client via window/showDocument
+    // so the language client handles file://-vs-vscode-remote:// URI translation for us.
     std::optional<lsp::Location> getHierLocation(const std::string& hierPath);
 
     struct ShowHierLocationArgs {
@@ -139,11 +147,7 @@ public:
     };
     std::monostate showHierLocation(const ShowHierLocationArgs& args);
 
-    struct ShowModuleDefinitionArgs {
-        std::string moduleName;
-        bool takeFocus = false;
-    };
-    std::monostate showModuleDefinition(const ShowModuleDefinitionArgs& args);
+    std::monostate openModuleDefinition(const std::string& moduleName);
 
     struct ExpandMacroArgs {
         std::string src;
@@ -218,6 +222,9 @@ public:
     /// Completion (get list of ids and kinds)
     rfl::Variant<std::vector<lsp::CompletionItem>, lsp::CompletionList, std::monostate>
     getDocCompletion(const lsp::CompletionParams&) override;
+
+    // Used to show the selected instance and associated buttons when a design is set
+    std::optional<std::vector<lsp::CodeLens>> getDocCodeLens(const lsp::CodeLensParams&) override;
 
     std::optional<std::vector<lsp::InlayHint>> getDocInlayHint(
         const lsp::InlayHintParams&) override;

--- a/include/ast/ActiveDesignContext.h
+++ b/include/ast/ActiveDesignContext.h
@@ -1,0 +1,68 @@
+//------------------------------------------------------------------------------
+// ActiveDesignContext.h
+// Projects selected full-design instances onto a shallow compilation
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace slang::ast {
+class Compilation;
+class InstanceSymbol;
+class InterfacePortSymbol;
+class Symbol;
+} // namespace slang::ast
+
+namespace server {
+
+class ServerCompilation;
+class ServerCompilationAnalysis;
+
+struct InterfaceConnection {
+    // Forwarded ports followed by the source-backed endpoint, excluding the queried port.
+    std::vector<const slang::ast::Symbol*> sourcePath;
+
+    // Slang can synthesize this symbol for elaboration, while sourcePath remains navigable.
+    const slang::ast::Symbol* resolvedEndpoint = nullptr;
+};
+
+InterfaceConnection resolveInterfaceConnection(const slang::ast::InterfacePortSymbol& port);
+
+class ActiveDesignContext {
+public:
+    /// Install the selected design's parameter values into a shallow compilation.
+    void applyOverrides(slang::ast::Compilation& shallowCompilation) const;
+
+    /// Return the corresponding symbol from the selected full-design instance, if any.
+    const slang::ast::Symbol* getDesignSymbol(const slang::ast::Symbol& shallowSymbol) const;
+
+    /// Return the selected full-design connection for an interface port, if any.
+    const InterfaceConnection* getInterfaceConnection(
+        const slang::ast::InterfacePortSymbol& port) const;
+
+    ServerCompilationAnalysis& getAnalysis() const { return *m_analysis; }
+
+private:
+    struct DefinitionBinding {
+        const slang::ast::InstanceSymbol* instance;
+        std::unordered_map<std::string, InterfaceConnection> interfaceConnections;
+    };
+
+    explicit ActiveDesignContext(std::shared_ptr<ServerCompilationAnalysis> analysis) :
+        m_analysis(std::move(analysis)) {}
+
+    void bindInstance(const slang::ast::InstanceSymbol& instance);
+
+    std::shared_ptr<ServerCompilationAnalysis> m_analysis;
+    std::unordered_map<std::string, DefinitionBinding> m_definitions;
+
+    friend class ServerCompilation;
+};
+
+} // namespace server

--- a/include/ast/HierarchicalView.h
+++ b/include/ast/HierarchicalView.h
@@ -79,8 +79,8 @@ struct Instance;
 
 using HierItem_t = rfl::Variant<Var, Scope, Instance>;
 
-// TODO: Migrate the Neovim hierarchy and cells views to slang.showHierLocation and
-// slang.showModuleDefinition before removing the deprecated location fields below.
+// TODO: Migrate the Neovim hierarchy and cells views to slang.showHierLocation before removing
+// the deprecated instance location fields below.
 struct Item {
     SlangKind kind;
     std::string instName;
@@ -116,7 +116,6 @@ struct Instance {
     lsp::Location instLoc;
     std::optional<bool> fromExpansion;
     std::string declName;
-    /// @deprecated Use slang.showModuleDefinition with declName.
     lsp::Location declLoc;
     DeclKind declKind = DeclKind::Module;
     // True when the instance body has at least one member that the hierarchy view would
@@ -126,7 +125,7 @@ struct Instance {
     std::vector<HierItem_t> children;
 };
 
-// Instances View
+// Module index
 struct QualifiedInstance {
     std::string instPath;
     /// @deprecated Use slang.showHierLocation with instPath.
@@ -153,7 +152,6 @@ struct HierarchySearchResult {
 
 struct InstanceSet {
     std::string declName;
-    /// @deprecated Use slang.showModuleDefinition with declName.
     lsp::Location declLoc;
     size_t instCount;
     // Will be filled if there's only one
@@ -348,7 +346,7 @@ static void handleParameter(std::vector<HierItem_t>& result,
         .instLoc = toLocation(param.getSyntax()->sourceRange(), sm),
         .fromExpansion = getFromExpansion(param, sm),
         .type = getTypeString(param),
-        .value = param.getValue().toString(),
+        .value = formatConstantValue(param.getValue()),
     }));
 }
 

--- a/include/ast/HierarchicalView.h
+++ b/include/ast/HierarchicalView.h
@@ -138,6 +138,19 @@ struct ScopeStep {
     std::vector<HierItem_t> children;
 };
 
+struct HierarchySearchItem {
+    std::string name;
+    std::string path;
+    SlangKind kind;
+    std::optional<std::string> description;
+    std::optional<std::string> containerName;
+};
+
+struct HierarchySearchResult {
+    size_t totalResults;
+    std::vector<HierarchySearchItem> matches;
+};
+
 struct InstanceSet {
     std::string declName;
     /// @deprecated Use slang.showModuleDefinition with declName.

--- a/include/ast/ServerCompilation.h
+++ b/include/ast/ServerCompilation.h
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include "ActiveDesignContext.h"
 #include "HierarchicalView.h"
 #include "ServerCompilationAnalysis.h"
 #include "document/SlangDoc.h"
@@ -16,6 +17,9 @@
 #include <filesystem>
 #include <memory>
 #include <set>
+#include <span>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -24,6 +28,11 @@
 
 namespace server {
 using namespace slang;
+
+struct ActiveGenerateLoop {
+    std::string activePath;
+    std::vector<std::string> iterationPaths;
+};
 
 /// @brief A single endpoint of a driver/load cone.
 struct ConeEntry {
@@ -34,11 +43,8 @@ struct ConeEntry {
 };
 
 /// @brief A server compilation that is set via top level or a .f file.
-/// Manages the specification of the compilation, as well as the analysis state that gets refreshed
-/// on file saves.
-///
-/// More state here is planned, like the currently focused instance, and a mapping
-/// of modules to instance for enriched data like inlayed parameter or signal values.
+/// Manages the specification of the compilation, as well as the analysis state that gets
+/// refreshed on file saves.
 class ServerCompilation {
 public:
     /// @brief Constructs a new ServerCompilation instance
@@ -57,13 +63,35 @@ public:
 
     InstanceIndexer& getInstances() { return m_analysis->instances; }
 
-    /// Get instances by module; Used for the 'instances' view. Only contains the module name and
-    /// count
+    /// Get instances by module; Used for the 'instances' view. Includes declaration metadata.
     std::vector<hier::InstanceSet> getScopesByModule();
 
     /// Get instances of a specific module
     const std::vector<const slang::ast::InstanceSymbol*>& getInstancesOfModule(
         const std::string& moduleName) const;
+
+    /// Return the file path that the active compilation resolved for a symbol name, if any.
+    std::optional<std::string> getPreferredSymbolPath(std::string_view name) const;
+
+    /// Set the active instance and generate scope reached by `hierPath`. The path may be
+    /// canonical (`top.bus8`) or an alias that resolves through an interface port
+    /// (`top.tap.data_bus`); slang's lookup resolves both. Returns false if the path isn't
+    /// contained by an instance.
+    bool setActiveInstance(const std::string& hierPath);
+
+    /// Return the active instance for a module, falling back to a deterministic default.
+    std::optional<hier::QualifiedInstance> getActiveInstance(const std::string& moduleName);
+
+    /// Return the elaborated active instance symbol for a module, if any.
+    const slang::ast::InstanceSymbol* getActiveInstanceSymbol(std::string_view moduleName) const;
+
+    /// Capture the selected full-design instances needed by a shallow compilation.
+    ActiveDesignContext createActiveDesignContext(
+        std::span<const std::string_view> definitionNames) const;
+
+    /// Return the active iteration and available choices for a generate loop in a module.
+    std::optional<ActiveGenerateLoop> getActiveGenerateLoop(
+        std::string_view moduleName, const slang::syntax::LoopGenerateSyntax& loop) const;
 
     /// Retrun the children of the scope at the given hierarchical path
     std::vector<hier::HierItem_t> getScope(const std::string& hierPath);
@@ -75,7 +103,7 @@ public:
     /// Search the elaborated hierarchy for instances, scopes, ports, parameters, and signals.
     hier::HierarchySearchResult searchHierarchy(const std::string& query);
 
-    /// Resolve the source location for a hierarchical instance path.
+    /// Resolve the document location for a hierarchical path on-demand.
     std::optional<lsp::Location> getHierLocation(const std::string& hierPath);
 
     /// Return instances for given doc position
@@ -132,19 +160,25 @@ public:
     }
 
 private:
-    // Used when going from hierPath -> compilation symbol -> shallow compilation symbol so
-    // server-side opens use locations from the up-to-date open document when possible.
+    /// Return the stored active selection for a module, if any.
+    std::optional<hier::QualifiedInstance> getActiveInstanceSelection(
+        std::string_view moduleName) const;
+
+    // Used when going from hierPath -> compilation symbol -> shallow compilation symbol
+    // Therefore we get more up to date source locations
     const slang::ast::Symbol* toShallowSymbol(const slang::ast::Symbol& symbol) const;
 
     /// Build m_moduleToDoc from the declared symbols of each document's syntax tree.
     void indexModuleDocs();
 
-    /// The Slang documents this compilation is based on
-    std::vector<std::shared_ptr<SlangDoc>> m_documents;
+    /// The Slang documents this compilation is based on, keyed by their absolute source path so
+    /// path-driven lookups (LSP URIs, symbol source locations) avoid scanning every doc.
+    std::unordered_map<std::string, std::shared_ptr<SlangDoc>> m_documents;
 
     /// Maps a declared module (/interface/program/class) name to the document that declares it.
-    /// Lets toShallowSymbol() find the owning shallow compilation without scanning all documents.
-    /// Rebuilt in the constructor since m_documents is fixed for this compilation's lifetime.
+    /// Lets toShallowSymbol() find the owning shallow compilation without scanning all
+    /// documents. Rebuilt in the constructor since m_documents is fixed for this compilation's
+    /// lifetime.
     std::unordered_map<std::string, std::shared_ptr<SlangDoc>> m_moduleToDoc;
 
     /// Copy of compilation options
@@ -161,11 +195,22 @@ private:
     /// LSP client owned by the server
     lsp::LspClient& m_client;
 
-    /// The analysis state, rebuilt on refresh()
-    std::unique_ptr<ServerCompilationAnalysis> m_analysis;
+    /// The analysis state, rebuilt on refresh(). Shared by shallow compilations that are using it
+    /// for params while we may be rebuilding a new one.
+    std::shared_ptr<ServerCompilationAnalysis> m_analysis;
+
+    /// Active instance and generate scope selection by module name for this compilation.
+    std::unordered_map<std::string, hier::QualifiedInstance> m_activeInstancesByModule;
+
+    /// Active iteration by fully qualified generate array path.
+    std::unordered_map<std::string, std::string> m_activeGenerateScopesByArray;
+
     /// Flattened hierarchy entries, populated on the first search after each refresh.
     std::vector<hier::HierarchySearchItem> m_hierarchySearchItems;
     bool m_hierarchySearchIndexed = false;
+
+    /// Retain only still-valid active instances after a refresh and seed unique modules.
+    void syncActiveInstances();
 };
 
 } // namespace server

--- a/include/ast/ServerCompilation.h
+++ b/include/ast/ServerCompilation.h
@@ -11,6 +11,7 @@
 #include "ServerCompilationAnalysis.h"
 #include "document/SlangDoc.h"
 #include "lsp/LspClient.h"
+#include "lsp/RequestContext.h"
 #include "util/Converters.h"
 #include <filesystem>
 #include <memory>
@@ -68,7 +69,11 @@ public:
     std::vector<hier::HierItem_t> getScope(const std::string& hierPath);
 
     /// Return root-to-focus scope steps with populated child lists for each path segment.
-    std::vector<hier::ScopeStep> getScopes(const std::string& hierPath);
+    std::vector<hier::ScopeStep> getScopes(const std::string& hierPath,
+                                           const lsp::RequestContext& ctx = {});
+
+    /// Search the elaborated hierarchy for instances, scopes, ports, parameters, and signals.
+    hier::HierarchySearchResult searchHierarchy(const std::string& query);
 
     /// Resolve the source location for a hierarchical instance path.
     std::optional<lsp::Location> getHierLocation(const std::string& hierPath);
@@ -158,6 +163,9 @@ private:
 
     /// The analysis state, rebuilt on refresh()
     std::unique_ptr<ServerCompilationAnalysis> m_analysis;
+    /// Flattened hierarchy entries, populated on the first search after each refresh.
+    std::vector<hier::HierarchySearchItem> m_hierarchySearchItems;
+    bool m_hierarchySearchIndexed = false;
 };
 
 } // namespace server

--- a/include/ast/ServerCompilationAnalysis.h
+++ b/include/ast/ServerCompilationAnalysis.h
@@ -12,8 +12,11 @@
 #include "ReferenceIndexer.h"
 #include "document/SlangDoc.h"
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
+#include "slang/analysis/AnalysisManager.h"
 #include "slang/analysis/AnalysisOptions.h"
 #include "slang/util/Bag.h"
 
@@ -25,8 +28,9 @@ using namespace slang;
 /// instance indexer, etc.
 class ServerCompilationAnalysis {
 public:
-    ServerCompilationAnalysis(std::vector<std::shared_ptr<SlangDoc>>& documents, Bag& options,
-                              SourceManager& sourceManager);
+    ServerCompilationAnalysis(
+        const std::unordered_map<std::string, std::shared_ptr<SlangDoc>>& documents, Bag& options,
+        SourceManager& sourceManager);
 
     slang::ast::Compilation compilation;
 
@@ -36,6 +40,10 @@ public:
 
     /// Issue all semantic diagnostics from the compilation to the diagnostic engine
     void issueDiagnosticsTo(slang::DiagnosticEngine& diagEngine);
+
+    /// Get the full-design drivers for a value symbol.
+    std::vector<const slang::analysis::ValueDriver*> getDrivers(
+        const slang::ast::ValueSymbol& symbol);
 
     template<bool isDrivers>
     struct ConeSelector;
@@ -73,11 +81,15 @@ public:
     }
 
 private:
+    slang::analysis::AnalysisManager& getAnalysisManager();
+
     /// Retained buffer data to prevent deallocation while this compilation exists
     std::vector<std::shared_ptr<void>> m_retainedBuffers;
 
     /// Analysis options from the bag, used for driver analysis
     slang::analysis::AnalysisOptions m_analysisOptions;
+
+    std::unique_ptr<slang::analysis::AnalysisManager> m_driverAnalysis;
 
     /// Index of value symbol -> uses (e.g. processes or continuous assignments)
     std::optional<ReferenceIndexer> m_references = std::nullopt;

--- a/include/document/DefinitionInfo.h
+++ b/include/document/DefinitionInfo.h
@@ -74,6 +74,7 @@ struct DefinitionInfo {
         std::vector<SyntaxTarget> syntaxes;
         const slang::ast::Symbol* symbol;
         std::shared_ptr<ShallowAnalysis> analysis;
+        bool renderInterfaceConnection = true;
         bool renderInputPortDriver = false;
         size_t generatedSignalCount = 1;
 
@@ -81,6 +82,7 @@ struct DefinitionInfo {
 
         bool operator==(const SymbolTarget& other) const {
             return syntaxes == other.syntaxes && symbol == other.symbol &&
+                   renderInterfaceConnection == other.renderInterfaceConnection &&
                    renderInputPortDriver == other.renderInputPortDriver &&
                    generatedSignalCount == other.generatedSignalCount;
         }

--- a/include/document/InlayHintCollector.h
+++ b/include/document/InlayHintCollector.h
@@ -44,6 +44,7 @@ private:
     // Cached config values
     bool m_portTypes;
     bool m_assignmentPatternTypes;
+    bool m_activeParameterValues;
     bool m_orderedInstanceNames;
     bool m_wildcardNames;
     int m_funcArgNames;
@@ -52,6 +53,7 @@ private:
     /// Handle instances- will show port/param names if ordered, names for wildcards, and types for
     /// named ports
     void handle(const slang::syntax::HierarchyInstantiationSyntax& syntax);
+    void handle(const slang::syntax::ParameterDeclarationSyntax& syntax);
 
     /// Handle function calls- will show argument names for calls with more than one arg
     void handle(const slang::syntax::InvocationExpressionSyntax& syntax);

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "Config.h"
+#include "ast/ActiveDesignContext.h"
 #include "document/SymbolIndexer.h"
 #include "document/SymbolTreeVisitor.h"
 #include "document/SyntaxIndexer.h"
@@ -16,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -37,6 +39,8 @@ namespace server {
 using namespace slang;
 
 class DocumentHandle;
+class ServerCompilation;
+
 class ShallowAnalysis {
 public:
     /// @brief Constructs a DocumentAnalysis instance with syntax and symbol indexing
@@ -51,7 +55,8 @@ public:
     /// @param trees Additional syntax trees that this document depends on
     ShallowAnalysis(SourceManager& sourceManager, slang::BufferID buffer,
                     std::shared_ptr<slang::syntax::SyntaxTree> tree, slang::Bag options,
-                    const std::vector<std::shared_ptr<slang::syntax::SyntaxTree>>& allTrees = {});
+                    const std::vector<std::shared_ptr<slang::syntax::SyntaxTree>>& allTrees = {},
+                    const ServerCompilation* design = nullptr);
 
     /// @brief Retrieves document symbols for LSP outline view, called right after open
     /// @return Tree of LSP document symbols representing the document CST structure
@@ -115,6 +120,17 @@ public:
     /// @brief Gets a list of drivers for a given value symbol
     std::vector<const slang::analysis::ValueDriver*> getDrivers(
         const slang::ast::ValueSymbol& symbol);
+
+    /// @brief Return the corresponding symbol from the selected full-design instance, if any.
+    const slang::ast::Symbol* getDesignSymbol(const slang::ast::Symbol& shallowSymbol) const;
+
+    /// Return the full-design instance referenced by a module, named parameter, or named port
+    /// token at an instantiation site.
+    std::optional<std::string> getDesignInstancePathAtToken(
+        const slang::parsing::Token* token) const;
+
+    const InterfaceConnection* getActiveInterfaceConnection(
+        const slang::ast::InterfacePortSymbol& port) const;
 
     /// @brief Gets the source manager for this analysis
     SourceManager& getSourceManager() const { return m_sourceManager; }
@@ -190,6 +206,9 @@ private:
 
     /// Compilation context for symbol resolution
     std::unique_ptr<slang::ast::Compilation> m_compilation;
+
+    /// Information from the active design when a top level or filelist is set
+    std::optional<ActiveDesignContext> m_activeDesign;
 
     /// Analysis manager for running driver analysis (multi-driven, unused, etc)
     std::unique_ptr<slang::analysis::AnalysisManager> m_driverAnalysis = nullptr;

--- a/include/document/SlangDoc.h
+++ b/include/document/SlangDoc.h
@@ -99,6 +99,11 @@ public:
     /// Returns a shared_ptr so callers can hold the analysis alive independently of this document.
     std::shared_ptr<ShallowAnalysis> getAnalysis(const lsp::RequestContext& ctx = {});
 
+    /// @brief Drop the cached analysis so the next getAnalysis() rebuilds it.
+    /// Used when an external change (e.g. active-instance selection) means cached
+    /// goto/hover results must be recomputed.
+    void invalidateAnalysis() { m_analysis.reset(); }
+
     ////////////////////////////////////////////////
     /// Indexed Syntax Tree Methods
     ////////////////////////////////////////////////

--- a/include/lsp/LspClient.h
+++ b/include/lsp/LspClient.h
@@ -197,5 +197,15 @@ public:
     virtual void onShowDocument(const ShowDocumentParams& params) {
         sendRequest("window/showDocument", rfl::to_generic<rfl::UnderlyingEnums>(params));
     };
+
+    /// Ask the client to refresh all inlay hints.
+    virtual void onWorkspaceInlayHintRefresh(std::monostate params = {}) {
+        sendRequest("workspace/inlayHint/refresh", rfl::to_generic(params));
+    }
+
+    /// Ask the client to refresh all code lenses.
+    virtual void onWorkspaceCodeLensRefresh(std::monostate params = {}) {
+        sendRequest("workspace/codeLens/refresh", rfl::to_generic(params));
+    }
 };
 } // namespace lsp

--- a/include/lsp/LspServer.h
+++ b/include/lsp/LspServer.h
@@ -25,7 +25,9 @@ namespace lsp {
 template<typename Impl>
 class LspServer : public JsonRpcServer<Impl> {
 protected:
-    std::unordered_map<std::string, std::function<rfl::Generic(rfl::Generic)>> m_commands;
+    std::unordered_map<std::string,
+                       std::function<rfl::Generic(rfl::Generic, const lsp::RequestContext&)>>
+        m_commands;
 
     // LspClient& m_lspClient;
 
@@ -34,8 +36,9 @@ protected:
     /// Register an rpc command with the given Params, Return, and handler
     template<typename P, typename R, typename Func>
     void registerCommand(const std::string& name, Func&& func) {
-        m_commands[name] = [func = std::forward<Func>(func)](
-                               std::optional<rfl::Generic> paramsJson) -> rfl::Generic {
+        m_commands[name] =
+            [func = std::forward<Func>(func)](std::optional<rfl::Generic> paramsJson,
+                                              const RequestContext& ctx) mutable -> rfl::Generic {
             // Deserialize params
             R result;
             if constexpr (!std::is_same_v<P, std::nullopt_t>) {
@@ -44,10 +47,18 @@ protected:
                 if (!params) {
                     throw std::runtime_error(params.error().what());
                 }
-                result = func(params.value());
+                if constexpr (std::is_invocable_v<Func&, P&, const RequestContext&>)
+                    result = func(params.value(), ctx);
+                else
+                    result = func(params.value());
             }
             else {
-                result = func(std::monostate{});
+                if constexpr (std::is_invocable_v<Func&, std::monostate, const RequestContext&>) {
+                    result = func(std::monostate{}, ctx);
+                }
+                else {
+                    result = func(std::monostate{});
+                }
             }
 
             if constexpr (std::is_same_v<R, std::monostate>) {
@@ -63,14 +74,21 @@ protected:
     /// Register an rpc method with the given Params, Return, and Method (name)
     template<typename P, typename R, auto Method>
     void registerCommand(const std::string& name) {
-        registerCommand<P, R>(name, [this](const auto& params) {
-            return (static_cast<Impl*>(this)->*Method)(params);
+        registerCommand<P, R>(name, [this](const P& params, const RequestContext& ctx) {
+            if constexpr (std::is_invocable_v<decltype(Method), Impl*, const P&,
+                                              const RequestContext&>) {
+                return (static_cast<Impl*>(this)->*Method)(params, ctx);
+            }
+            else {
+                return (static_cast<Impl*>(this)->*Method)(params);
+            }
         });
     }
 
     /// A request send from the client to the server to execute a command. The request might return
     /// a workspace edit which the client will apply to the workspace.
-    std::optional<lsp::LSPAny> getWorkspaceExecuteCommand(const lsp::ExecuteCommandParams& params) {
+    std::optional<lsp::LSPAny> getWorkspaceExecuteCommand(const lsp::ExecuteCommandParams& params,
+                                                          const RequestContext& ctx = {}) {
         std::cerr << " <---" << params.command << "(" << rfl::json::write(params.arguments)
                   << ")\n";
         auto command = m_commands.find(params.command);
@@ -94,7 +112,7 @@ protected:
                 throw std::runtime_error("Expected 0 or 1 argument for command");
             }
         }
-        auto x = command->second(args);
+        auto x = command->second(args, ctx);
 
         std::cerr << " ---> " << params.command << "\n";
 

--- a/include/util/Formatting.h
+++ b/include/util/Formatting.h
@@ -83,8 +83,8 @@ std::string toCamelCase(std::string_view str);
 /// Convert a string to lower case
 std::string toLowerCase(std::string_view str);
 
-/// @brief Format a ConstantValue for display in hovers
-/// For string values, shows escaped invalid UTF-8 characters
+/// @brief Format a ConstantValue for display to users
+/// Uses compact notation for scalar bits and escapes invalid UTF-8 strings.
 std::string formatConstantValue(const slang::ConstantValue& value);
 
 enum class TypeStringMode {

--- a/src/ServerDriver.cpp
+++ b/src/ServerDriver.cpp
@@ -184,6 +184,7 @@ void ServerDriver::onDocDidSave(SlangDoc& doc) {
     else {
         diagClient->clear();
         comp->refresh();
+        invalidateAnalysesAndRefreshClient();
         publishCompilationDiagnostics(&doc.getURI());
         publishInactiveRegions(doc);
     }
@@ -399,6 +400,27 @@ void ServerDriver::onWorkspaceDidChangeWatchedFiles(
     for (auto& doc : updatedDocs) {
         analyzeDocument(*doc);
     }
+}
+
+void ServerDriver::invalidateAnalysesAndRefreshClient() {
+    for (auto& [_, doc] : docs) {
+        doc->invalidateAnalysis();
+    }
+    client.onWorkspaceCodeLensRefresh(std::monostate{});
+    client.onWorkspaceInlayHintRefresh(std::monostate{});
+}
+
+bool ServerDriver::setActiveInstance(std::string_view hierPath) {
+    if (!comp) {
+        return false;
+    }
+
+    if (!comp->setActiveInstance(std::string(hierPath))) {
+        return false;
+    }
+
+    invalidateAnalysesAndRefreshClient();
+    return true;
 }
 
 std::vector<std::shared_ptr<syntax::SyntaxTree>> ServerDriver::getDependentTrees(
@@ -715,24 +737,41 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         return false;
     };
 
-    std::vector<std::pair<const ast::Symbol*, std::shared_ptr<ShallowAnalysis>>> symbols;
+    struct SymbolCandidate {
+        const ast::Symbol* symbol;
+        std::shared_ptr<ShallowAnalysis> analysis;
+        bool renderInterfaceConnection;
+    };
+    std::vector<SymbolCandidate> symbols;
     auto addSymbol = [&](const ast::Symbol* symbol,
-                         const std::shared_ptr<ShallowAnalysis>& symbolAnalysis) {
+                         const std::shared_ptr<ShallowAnalysis>& symbolAnalysis,
+                         bool renderInterfaceConnection = true) {
         if (!symbol)
             return;
-        auto duplicate = std::ranges::any_of(symbols, [&](const auto& existing) {
-            return (existing.first == symbol && existing.second == symbolAnalysis) ||
-                   (existing.second != symbolAnalysis && existing.first->kind == symbol->kind &&
-                    existing.first->location == symbol->location) ||
-                   symbolsEquivalent(existing.first, symbol);
+        auto duplicate = std::ranges::find_if(symbols, [&](const auto& existing) {
+            return (existing.symbol == symbol && existing.analysis == symbolAnalysis) ||
+                   (existing.analysis != symbolAnalysis && existing.symbol->kind == symbol->kind &&
+                    existing.symbol->location == symbol->location) ||
+                   symbolsEquivalent(existing.symbol, symbol);
         });
-        if (!duplicate)
-            symbols.emplace_back(symbol, symbolAnalysis);
+        if (duplicate != symbols.end()) {
+            duplicate->renderInterfaceConnection |= renderInterfaceConnection;
+        }
+        else {
+            symbols.push_back({symbol, symbolAnalysis, renderInterfaceConnection});
+        }
     };
 
     auto localSymbols = analysis->getSymbolsAtToken(declTok);
-    for (auto* symbol : localSymbols)
+    for (auto* symbol : localSymbols) {
         addSymbol(symbol, analysis);
+        if (auto* port = symbol->as_if<ast::InterfacePortSymbol>()) {
+            if (auto* connection = analysis->getActiveInterfaceConnection(*port)) {
+                for (auto* designSymbol : connection->sourcePath)
+                    addSymbol(designSymbol, analysis, false);
+            }
+        }
+    }
     if (std::ranges::any_of(localSymbols, [](const auto* symbol) {
             return symbol->kind == ast::SymbolKind::Genvar;
         })) {
@@ -866,9 +905,9 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
         return result;
     };
 
-    auto makeSymbolTarget = [&](const ast::Symbol* symbol,
-                                const std::shared_ptr<ShallowAnalysis>& symbolAnalysis)
-        -> std::optional<DefinitionInfo::SymbolTarget> {
+    auto makeSymbolTarget =
+        [&](const ast::Symbol* symbol, const std::shared_ptr<ShallowAnalysis>& symbolAnalysis,
+            bool renderInterfaceConnection = true) -> std::optional<DefinitionInfo::SymbolTarget> {
         if (!symbol)
             return {};
         auto syntaxTarget = makeSyntaxTarget(symbol);
@@ -883,9 +922,11 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
                     syntaxes.push_back(std::move(*internalSyntax));
             }
         }
+        auto* designSymbol = symbolAnalysis->getDesignSymbol(*symbol);
         return DefinitionInfo::SymbolTarget{.syntaxes = std::move(syntaxes),
-                                            .symbol = symbol,
+                                            .symbol = designSymbol ? designSymbol : symbol,
                                             .analysis = symbolAnalysis,
+                                            .renderInterfaceConnection = renderInterfaceConnection,
                                             .generatedSignalCount = getGeneratedSignalCount(
                                                 symbol)};
     };
@@ -915,17 +956,29 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
                 targets.emplace_back(std::move(*inner));
             }
         }
+        for (const auto& [symbol, symbolAnalysis, renderInterfaceConnection] : symbols) {
+            auto alreadyRepresented = std::ranges::any_of(localSymbols, [&](const auto* local) {
+                return local == symbol ||
+                       (local->kind == symbol->kind && local->getSyntax() == symbol->getSyntax());
+            });
+            if (!alreadyRepresented) {
+                if (auto target = makeSymbolTarget(symbol, symbolAnalysis,
+                                                   renderInterfaceConnection)) {
+                    targets.emplace_back(std::move(*target));
+                }
+            }
+        }
         if (!targets.empty())
             return DefinitionInfo{sm, std::move(targets)};
     }
 
     std::vector<DefinitionInfo::Target> targets;
     std::vector<const ast::Symbol*> foldedSymbols;
-    for (const auto& [symbol, symbolAnalysis] : symbols) {
+    for (const auto& [symbol, symbolAnalysis, renderInterfaceConnection] : symbols) {
         if (std::ranges::find(foldedSymbols, symbol) != foldedSymbols.end())
             continue;
 
-        auto target = makeSymbolTarget(symbol, symbolAnalysis);
+        auto target = makeSymbolTarget(symbol, symbolAnalysis, renderInterfaceConnection);
         if (!target)
             continue;
 
@@ -944,6 +997,20 @@ std::optional<DefinitionInfo> ServerDriver::getDefinitionInfoAt(const URI& uri,
     if (targets.empty())
         return {};
     return DefinitionInfo{sm, std::move(targets)};
+}
+
+std::optional<std::string> ServerDriver::getDesignInstancePathAt(const URI& uri,
+                                                                 const lsp::Position& position) {
+    auto doc = getDocument(uri);
+    if (!doc)
+        return {};
+
+    auto loc = toSourceLocation(doc->getBuffer(), position, sm);
+    if (!loc)
+        return {};
+
+    auto analysis = doc->getAnalysis();
+    return analysis->getDesignInstancePathAtToken(analysis->syntaxes.getWordTokenAt(*loc));
 }
 
 std::optional<lsp::Hover> ServerDriver::getDocHover(const URI& uri, const lsp::Position& position) {

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -35,7 +35,9 @@
 #include <variant>
 #include <vector>
 
+#include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxPrinter.h"
+#include "slang/syntax/SyntaxVisitor.h"
 #include "slang/text/SourceLocation.h"
 #include "slang/text/SourceManager.h"
 #include "slang/util/OS.h"
@@ -72,6 +74,7 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
     registerCompletionItemResolve();
     registerDocDocumentHighlight();
 
+    registerDocCodeLens();
     registerDocInlayHint();
     registerDocReferences();
     registerDocRename();
@@ -127,19 +130,23 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
         });
     registerCommand<ShowHierLocationArgs, std::monostate, &SlangServer::showHierLocation>(
         "slang.showHierLocation");
-    registerCommand<ShowModuleDefinitionArgs, std::monostate, &SlangServer::showModuleDefinition>(
-        "slang.showModuleDefinition");
+    registerCommand<std::string, std::monostate, &SlangServer::openModuleDefinition>(
+        "slang.openModuleDefinition");
 
     // Terminal Links
     registerCommand<std::string, std::vector<std::string>, &SlangServer::getFilesContainingModule>(
         "slang.getFilesContainingModule");
 
-    // Instances View
+    // Hierarchy and active instance selection
     registerCommand<std::monostate, std::vector<hier::InstanceSet>,
                     &SlangServer::getScopesByModule>("slang.getScopesByModule");
     registerCommand<std::string, std::vector<hier::QualifiedInstance>,
                     &SlangServer::getInstancesOfModule>("slang.getInstancesOfModule");
-
+    registerCommand<std::string, bool, &SlangServer::setActiveInstance>("slang.setActiveInstance");
+    registerCommand<SlangLspClient::ActivateInstanceParams, bool, &SlangServer::activateInstance>(
+        "slang.activateInstance");
+    registerCommand<std::string, std::optional<hier::QualifiedInstance>,
+                    &SlangServer::getActiveInstance>("slang.getActiveInstance");
     // File features
     registerCommand<ExpandMacroArgs, bool, &SlangServer::expandMacros>("slang.expandMacros");
 
@@ -254,6 +261,10 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
                 .documentHighlightProvider = true,
                 .documentSymbolProvider = true,
                 .codeActionProvider = true,
+                .codeLensProvider =
+                    lsp::CodeLensOptions{
+                        .resolveProvider = false,
+                    },
                 .documentLinkProvider =
                     lsp::DocumentLinkOptions{
                         .resolveProvider = false,
@@ -396,17 +407,17 @@ std::vector<hier::QualifiedInstance> SlangServer::getInstancesOfModule(
         ERROR("No compilation available, cannot get instances of module {}", moduleName);
         return {};
     }
-    auto result = m_driver->comp->getInstancesOfModule(moduleName);
-    if (result.empty()) {
+    auto instances = m_driver->comp->getInstancesOfModule(moduleName);
+    if (instances.empty()) {
         m_client.showError(fmt::format("Module {} not found", moduleName));
         return {};
     }
-    std::vector<hier::QualifiedInstance> qualifiedInstances;
-    qualifiedInstances.reserve(result.size());
-    for (const auto* inst : result) {
-        qualifiedInstances.push_back(hier::toQualifiedInstance(*inst, m_driver->sm));
+    std::vector<hier::QualifiedInstance> result;
+    result.reserve(instances.size());
+    for (const auto* inst : instances) {
+        result.push_back(hier::toQualifiedInstance(*inst, m_driver->sm));
     }
-    return qualifiedInstances;
+    return result;
 }
 
 bool SlangServer::expandMacros(ExpandMacroArgs args) {
@@ -450,6 +461,37 @@ std::vector<hier::ScopeStep> SlangServer::getScopes(const std::string& hierPath,
     auto scopes = m_driver->comp->getScopes(hierPath, ctx);
     ctx.info("Resolved {} hierarchy scopes for {}", scopes.size(), hierPath);
     return scopes;
+}
+
+bool SlangServer::setActiveInstance(const std::string& hierPath) {
+    if (!m_driver || !m_driver->setActiveInstance(hierPath)) {
+        m_client.showError(fmt::format("Failed to set active instance {}", hierPath));
+        return false;
+    }
+    return true;
+}
+
+bool SlangServer::activateInstance(const SlangLspClient::ActivateInstanceParams& params,
+                                   const lsp::RequestContext& ctx) {
+    ctx.throwIfCancelled("before activating instance");
+    if (!setActiveInstance(params.hierPath))
+        return false;
+
+    m_client.onActiveInstanceChanged(params);
+    if (params.interactionSource == SlangLspClient::InteractionSource::codeLensGotoInstantiation) {
+        showHierLocation({.hierPath = params.hierPath, .takeFocus = true});
+    }
+    ctx.info("Activated instance {}", params.hierPath);
+    return true;
+}
+
+std::optional<hier::QualifiedInstance> SlangServer::getActiveInstance(
+    const std::string& moduleName) {
+    if (!m_driver->comp) {
+        ERROR("No compilation available, cannot get active instance for {}", moduleName);
+        return std::nullopt;
+    }
+    return m_driver->comp->getActiveInstance(moduleName);
 }
 
 std::optional<lsp::Location> SlangServer::getHierLocation(const std::string& hierPath) {
@@ -507,24 +549,27 @@ std::monostate SlangServer::showHierLocation(const ShowHierLocationArgs& args) {
     return {};
 }
 
-std::monostate SlangServer::showModuleDefinition(const ShowModuleDefinitionArgs& args) {
+std::monostate SlangServer::openModuleDefinition(const std::string& moduleName) {
     if (!m_driver->comp) {
-        ERROR("No compilation available, cannot show module definition for {}", args.moduleName);
+        ERROR("No compilation available, cannot open module definition for {}", moduleName);
         return {};
     }
-    auto instances = m_driver->comp->getInstancesOfModule(args.moduleName);
+    auto instances = m_driver->comp->getInstancesOfModule(moduleName);
     if (instances.empty()) {
-        WARN("showModuleDefinition: module {} has no instances", args.moduleName);
+        WARN("openModuleDefinition: module {} has no instances", moduleName);
         return {};
     }
     auto declLoc = toLocation(instances[0]->getDefinition().location, m_driver->sm);
     if (declLoc.uri.getPath().empty()) {
-        WARN("showModuleDefinition: module {} declaration has no source location", args.moduleName);
+        WARN("openModuleDefinition: module {} declaration has no source location", moduleName);
+        return {};
+    }
+    if (m_driver->isDocumentOpen(declLoc.uri)) {
         return {};
     }
     m_client.onShowDocument(lsp::ShowDocumentParams{
         .uri = declLoc.uri,
-        .takeFocus = args.takeFocus,
+        .takeFocus = false,
         .selection = declLoc.range,
     });
     return {};
@@ -791,6 +836,14 @@ std::monostate SlangServer::addDefine(const std::string& macroName) {
 
 rfl::Variant<lsp::Definition, std::vector<lsp::DefinitionLink>, std::monostate> SlangServer::
     getDocDefinition(const lsp::DefinitionParams& params) {
+    if (auto instance = m_driver->getDesignInstancePathAt(params.textDocument.uri,
+                                                          params.position)) {
+        activateInstance({
+            .hierPath = std::move(*instance),
+            .interactionSource = SlangLspClient::InteractionSource::editor,
+        });
+    }
+
     auto info = m_driver->getDefinitionInfoAt(params.textDocument.uri, params.position);
     if (m_client.capabilities.definitionLinksSupported)
         return info ? info->getDefinitionLspLinks() : std::vector<lsp::DefinitionLink>{};
@@ -998,6 +1051,106 @@ std::optional<std::vector<lsp::InlayHint>> SlangServer::getDocInlayHint(
     auto hints = doc->getAnalysis()->getInlayHints(params.range, m_config.inlayHints.get());
     INFO("Providing {} inlay hints for {}", hints.size(), doc->getWsRelativePath());
     return hints;
+}
+
+std::optional<std::vector<lsp::CodeLens>> SlangServer::getDocCodeLens(
+    const lsp::CodeLensParams& params) {
+    if (!m_driver->comp) {
+        return std::nullopt;
+    }
+    auto doc = m_driver->getDocument(params.textDocument.uri);
+    if (!doc) {
+        return std::nullopt;
+    }
+
+    std::vector<lsp::CodeLens> lenses;
+    auto& meta = doc->getSyntaxTree()->getMetadata();
+    for (const auto& [decl, _] : meta.nodeMeta) {
+        if (!decl || !decl->header) {
+            continue;
+        }
+
+        const auto& nameToken = decl->header->name;
+        auto moduleName = std::string(nameToken.valueText());
+        if (moduleName.empty()) {
+            continue;
+        }
+
+        const auto& instances = m_driver->comp->getInstancesOfModule(moduleName);
+        if (instances.empty()) {
+            continue;
+        }
+
+        // Module isn't reachable from the active build.
+        auto* activeInstance = m_driver->comp->getActiveInstanceSymbol(moduleName);
+        if (!activeInstance) {
+            continue;
+        }
+
+        std::vector<std::string> instancePaths;
+        instancePaths.reserve(instances.size());
+        for (auto* instance : instances)
+            instancePaths.push_back(instance->getHierarchicalPath());
+
+        auto range = toRange(nameToken.location(), m_driver->sm, nameToken.rawText().size());
+        auto title = fmt::format("{} ({})", activeInstance->getHierarchicalPath(),
+                                 instances.size());
+        auto selectCommand = instances.size() == 1
+                                 ? lsp::Command{
+                                       .title = title,
+                                       .tooltip = "Show active instance in hierarchy",
+                                       .command = "slang.showInHierarchy",
+                                       .arguments = std::vector<lsp::LSPAny>{
+                                           rfl::to_generic<rfl::UnderlyingEnums>(
+                                               SlangLspClient::ActivateInstanceParams{
+                                                   .hierPath = activeInstance->getHierarchicalPath(),
+                                                   .interactionSource = SlangLspClient::
+                                                       InteractionSource::codeLensSelect,
+                                               })},
+                                   }
+                                 : m_client.makeQuickPickCommand(
+                                       title, fmt::format("Select active instance for {}", moduleName),
+                                       fmt::format("Select active instance for {}", moduleName),
+                                       activeInstance->getHierarchicalPath(), instancePaths,
+                                       "slang.activateInstance",
+                                       SlangLspClient::InteractionSource::codeLensSelect);
+        lenses.push_back(lsp::CodeLens{
+            .range = range,
+            .command = std::move(selectCommand),
+        });
+        if (!activeInstance->isTopLevel()) {
+            lenses.push_back(lsp::CodeLens{
+                .range = range,
+                .command = m_client.makeActivateInstanceCommand(
+                    "Go to Instantiation", "", activeInstance->getHierarchicalPath(),
+                    SlangLspClient::InteractionSource::codeLensGotoInstantiation),
+            });
+        }
+
+        auto generateVisitor = syntax::makeSyntaxVisitor(
+            [&](auto& visitor, const syntax::LoopGenerateSyntax& loop) {
+                if (auto activeLoop = m_driver->comp->getActiveGenerateLoop(moduleName, loop)) {
+                    auto range = toRange(loop.keyword.location(), m_driver->sm,
+                                         loop.keyword.rawText().size());
+                    lenses.push_back(lsp::CodeLens{
+                        .range = range,
+                        .command = m_client.makeQuickPickCommand(
+                            activeLoop->activePath, "Select active generate iteration",
+                            "Select active generate iteration", activeLoop->activePath,
+                            activeLoop->iterationPaths, "slang.activateInstance",
+                            SlangLspClient::InteractionSource::codeLensSelect),
+                    });
+                }
+                visitor.visitDefault(loop);
+            },
+            [&](auto& visitor, const syntax::ModuleDeclarationSyntax& module) {
+                if (&module == decl)
+                    visitor.visitDefault(module);
+            });
+        generateVisitor.visit(*decl);
+    }
+
+    return lenses;
 }
 
 std::optional<std::vector<lsp::Location>> SlangServer::getDocReferences(

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -121,6 +121,10 @@ lsp::InitializeResult SlangServer::getInitialize(const lsp::InitializeParams& pa
         "slang.getScope");
     registerCommand<std::string, std::vector<hier::ScopeStep>, &SlangServer::getScopes>(
         "slang.getScopes");
+    registerDesignCommand<std::string, hier::HierarchySearchResult>(
+        "slang.searchHierarchy", [](ServerCompilation& comp, const std::string& query) {
+            return comp.searchHierarchy(query);
+        });
     registerCommand<ShowHierLocationArgs, std::monostate, &SlangServer::showHierLocation>(
         "slang.showHierLocation");
     registerCommand<ShowModuleDefinitionArgs, std::monostate, &SlangServer::showModuleDefinition>(
@@ -436,12 +440,16 @@ std::vector<hier::HierItem_t> SlangServer::getScope(const std::string& hierPath)
     return m_driver->comp->getScope(hierPath);
 }
 
-std::vector<hier::ScopeStep> SlangServer::getScopes(const std::string& hierPath) {
+// Returns scopes up to the last resolvable segment of the provided hierarchical path.
+std::vector<hier::ScopeStep> SlangServer::getScopes(const std::string& hierPath,
+                                                    const lsp::RequestContext& ctx) {
     if (!m_driver->comp) {
-        ERROR("No compilation available, cannot get scopes for {}", hierPath);
+        ctx.error("No compilation available, cannot get scopes for {}", hierPath);
         return {};
     }
-    return m_driver->comp->getScopes(hierPath);
+    auto scopes = m_driver->comp->getScopes(hierPath, ctx);
+    ctx.info("Resolved {} hierarchy scopes for {}", scopes.size(), hierPath);
+    return scopes;
 }
 
 std::optional<lsp::Location> SlangServer::getHierLocation(const std::string& hierPath) {

--- a/src/ast/ActiveDesignContext.cpp
+++ b/src/ast/ActiveDesignContext.cpp
@@ -1,0 +1,319 @@
+//------------------------------------------------------------------------------
+// ActiveDesignContext.cpp
+// Projects selected full-design instances onto a shallow compilation
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+
+#include "ast/ActiveDesignContext.h"
+
+#include "ast/ServerCompilationAnalysis.h"
+#include <algorithm>
+#include <string_view>
+
+#include "slang/ast/ASTContext.h"
+#include "slang/ast/Compilation.h"
+#include "slang/ast/Lookup.h"
+#include "slang/ast/expressions/MiscExpressions.h"
+#include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/ParameterSymbols.h"
+#include "slang/ast/symbols/PortSymbols.h"
+#include "slang/syntax/AllSyntax.h"
+#include "slang/util/SmallMap.h"
+
+namespace server {
+
+using namespace slang;
+
+InterfaceConnection resolveInterfaceConnection(const ast::InterfacePortSymbol& port) {
+    InterfaceConnection result;
+    SmallSet<const ast::InterfacePortSymbol*, 8> visited;
+    const ast::Symbol* navigableEndpoint = nullptr;
+    auto addPathSymbol = [&](const ast::Symbol* symbol) {
+        if (symbol && symbol != &port && symbol->getSyntax() &&
+            std::ranges::find(result.sourcePath, symbol) == result.sourcePath.end()) {
+            result.sourcePath.push_back(symbol);
+        }
+    };
+
+    auto* currentPort = &port;
+    while (visited.insert(currentPort).second) {
+        auto [ifaceConnection, expression] = currentPort->getConnectionAndExpr();
+        auto [connection, _modport] = ifaceConnection;
+        if (connection && (!result.resolvedEndpoint ||
+                           result.resolvedEndpoint->kind == ast::SymbolKind::InterfacePort)) {
+            result.resolvedEndpoint = connection;
+        }
+
+        const ast::InterfacePortSymbol* nextPort = nullptr;
+        if (auto* arbitrary = expression ? expression->as_if<ast::ArbitrarySymbolExpression>()
+                                         : nullptr) {
+            for (const auto& element : arbitrary->hierRef.path) {
+                auto* forwardedPort = element.symbol->as_if<ast::InterfacePortSymbol>();
+                if (forwardedPort) {
+                    addPathSymbol(forwardedPort);
+                    if (!visited.contains(forwardedPort))
+                        nextPort = forwardedPort;
+                }
+            }
+            if (!navigableEndpoint || navigableEndpoint->kind == ast::SymbolKind::InterfacePort)
+                navigableEndpoint = arbitrary->symbol;
+        }
+        else if (!navigableEndpoint || navigableEndpoint->kind == ast::SymbolKind::InterfacePort) {
+            navigableEndpoint = connection;
+        }
+
+        if (!nextPort && connection)
+            nextPort = connection->as_if<ast::InterfacePortSymbol>();
+        if (!nextPort || visited.contains(nextPort))
+            break;
+        currentPort = nextPort;
+    }
+    addPathSymbol(navigableEndpoint);
+    return result;
+}
+
+namespace {
+
+class InterfacePortSyntaxIndex {
+public:
+    template<typename TPredicate>
+    InterfacePortSyntaxIndex(const ast::DefinitionSymbol& definition,
+                             TPredicate&& isInterfacePort) {
+        auto* portList = definition.portList;
+        if (!portList)
+            return;
+
+        if (portList->kind == syntax::SyntaxKind::AnsiPortList) {
+            for (auto* port : portList->as<syntax::AnsiPortListSyntax>().ports) {
+                if (auto* implicit = port->as_if<syntax::ImplicitAnsiPortSyntax>()) {
+                    auto& declarator = *implicit->declarator;
+                    auto name = declarator.name.valueText();
+                    if (isInterfacePort(name))
+                        m_ports.emplace(name, &declarator);
+                }
+            }
+            return;
+        }
+
+        if (portList->kind != syntax::SyntaxKind::NonAnsiPortList)
+            return;
+
+        std::unordered_map<std::string_view, const syntax::SyntaxNode*> declarations;
+        auto* definitionSyntax = definition.getSyntax();
+        if (!definitionSyntax || !syntax::ModuleDeclarationSyntax::isKind(definitionSyntax->kind)) {
+            return;
+        }
+
+        for (auto* member : definitionSyntax->as<syntax::ModuleDeclarationSyntax>().members) {
+            if (auto* declaration = member->as_if<syntax::PortDeclarationSyntax>()) {
+                for (auto* declarator : declaration->declarators)
+                    declarations.emplace(declarator->name.valueText(), declarator);
+            }
+            else if (auto* declaration = member->as_if<syntax::DataDeclarationSyntax>()) {
+                for (auto* declarator : declaration->declarators)
+                    declarations.emplace(declarator->name.valueText(), declarator);
+            }
+        }
+
+        for (auto* port : portList->as<syntax::NonAnsiPortListSyntax>().ports) {
+            const syntax::PortExpressionSyntax* expression = nullptr;
+            std::string_view portName;
+            if (auto* implicit = port->as_if<syntax::ImplicitNonAnsiPortSyntax>()) {
+                expression = implicit->expr;
+            }
+            else if (auto* explicitPort = port->as_if<syntax::ExplicitNonAnsiPortSyntax>()) {
+                portName = explicitPort->name.valueText();
+                expression = explicitPort->expr;
+            }
+
+            auto* reference = expression ? expression->as_if<syntax::PortReferenceSyntax>()
+                                         : nullptr;
+            if (!reference)
+                continue;
+            if (portName.empty())
+                portName = reference->name.valueText();
+            if (!isInterfacePort(portName))
+                continue;
+
+            auto declaration = declarations.find(reference->name.valueText());
+            if (declaration != declarations.end())
+                m_ports.emplace(portName, declaration->second);
+        }
+    }
+
+    const syntax::SyntaxNode* get(std::string_view name) const {
+        auto it = m_ports.find(name);
+        return it == m_ports.end() ? nullptr : it->second;
+    }
+
+private:
+    std::unordered_map<std::string_view, const syntax::SyntaxNode*> m_ports;
+};
+
+const ast::InstanceBodySymbol* getContainingInstanceBody(const ast::Symbol& symbol) {
+    if (auto* body = symbol.as_if<ast::InstanceBodySymbol>())
+        return body;
+
+    for (auto* scope = symbol.getParentScope(); scope; scope = scope->asSymbol().getParentScope()) {
+        if (auto* body = scope->asSymbol().as_if<ast::InstanceBodySymbol>())
+            return body;
+    }
+    return nullptr;
+}
+
+const ast::InstanceSymbol* getFirstInterfaceInstance(const ast::Symbol* symbol) {
+    if (auto* instance = symbol ? symbol->as_if<ast::InstanceSymbol>() : nullptr)
+        return instance;
+    if (auto* array = symbol ? symbol->as_if<ast::InstanceArraySymbol>() : nullptr) {
+        for (auto* element : array->elements) {
+            if (auto* instance = getFirstInterfaceInstance(element))
+                return instance;
+        }
+    }
+    return nullptr;
+}
+
+void copyParameterOverrides(ast::HierarchyOverrideNode& shallowOverride,
+                            const ast::InstanceBodySymbol& designBody,
+                            const ast::DefinitionSymbol& shallowDefinition) {
+    for (auto* parameterBase : designBody.getParameters()) {
+        if (parameterBase->isLocalParam())
+            continue;
+
+        const auto& symbol = parameterBase->symbol;
+        auto declaration = std::ranges::find(shallowDefinition.parameters, symbol.name,
+                                             &ast::DefinitionSymbol::ParameterDecl::name);
+        if (declaration == shallowDefinition.parameters.end() || !declaration->hasSyntax)
+            continue;
+
+        const syntax::SyntaxNode* syntax =
+            declaration->isTypeParam ? static_cast<const syntax::SyntaxNode*>(declaration->typeDecl)
+                                     : declaration->valueDecl;
+        if (!syntax)
+            continue;
+
+        if (auto* parameter = symbol.as_if<ast::ParameterSymbol>()) {
+            const auto& value = parameter->getValue();
+            if (!value.bad()) {
+                shallowOverride.paramOverrides.insert_or_assign(
+                    syntax, ast::HierarchyOverrideNode::ValueParamOverride{value});
+            }
+        }
+        else if (auto* parameter = symbol.as_if<ast::TypeParameterSymbol>()) {
+            const auto& type = parameter->targetType.getType();
+            if (!type.isError()) {
+                shallowOverride.paramOverrides.insert_or_assign(
+                    syntax, ast::HierarchyOverrideNode::TypeParamOverride{
+                                &type, parameter->targetType.getResolvedTypeSyntax()});
+            }
+        }
+    }
+}
+
+} // namespace
+
+void ActiveDesignContext::bindInstance(const ast::InstanceSymbol& instance) {
+    DefinitionBinding binding{.instance = &instance};
+    for (auto* symbol : instance.body.getPortList()) {
+        if (auto* port = symbol->as_if<ast::InterfacePortSymbol>()) {
+            binding.interfaceConnections.emplace(std::string(port->name),
+                                                 resolveInterfaceConnection(*port));
+        }
+    }
+    m_definitions.insert_or_assign(std::string(instance.getDefinition().name), std::move(binding));
+}
+
+void ActiveDesignContext::applyOverrides(ast::Compilation& shallowCompilation) const {
+    std::unordered_map<std::string_view, const ast::DefinitionSymbol*> shallowDefinitions;
+    for (auto* symbol : shallowCompilation.getDefinitions()) {
+        if (auto* definition = symbol->as_if<ast::DefinitionSymbol>())
+            shallowDefinitions.emplace(definition->name, definition);
+    }
+
+    for (const auto& [name, binding] : m_definitions) {
+        auto shallowDefinitionIt = shallowDefinitions.find(name);
+        if (shallowDefinitionIt == shallowDefinitions.end())
+            continue;
+
+        auto* shallowDefinition = shallowDefinitionIt->second;
+        auto* shallowDefinitionSyntax = shallowDefinition->getSyntax();
+        if (!shallowDefinitionSyntax)
+            continue;
+
+        InterfacePortSyntaxIndex shallowPorts(*shallowDefinition, [&](std::string_view portName) {
+            return std::ranges::any_of(binding.interfaceConnections,
+                                       [&](const auto& entry) { return entry.first == portName; });
+        });
+        auto& shallowOverride = shallowCompilation.getOrAddTopLevelHierarchyOverride(
+            *shallowDefinitionSyntax);
+        copyParameterOverrides(shallowOverride, binding.instance->body, *shallowDefinition);
+
+        for (const auto& [portName, connection] : binding.interfaceConnections) {
+            auto* shallowPortSyntax = shallowPorts.get(portName);
+            if (!shallowPortSyntax)
+                continue;
+
+            auto* designInterfaceInstance = getFirstInterfaceInstance(connection.resolvedEndpoint);
+            if (!designInterfaceInstance)
+                continue;
+
+            auto shallowInterfaceIt = shallowDefinitions.find(
+                designInterfaceInstance->getDefinition().name);
+            if (shallowInterfaceIt == shallowDefinitions.end())
+                continue;
+
+            copyParameterOverrides(shallowOverride.childNodes[*shallowPortSyntax],
+                                   designInterfaceInstance->body, *shallowInterfaceIt->second);
+        }
+    }
+}
+
+const ast::Symbol* ActiveDesignContext::getDesignSymbol(const ast::Symbol& shallowSymbol) const {
+    if (auto* definition = shallowSymbol.as_if<ast::DefinitionSymbol>()) {
+        auto it = m_definitions.find(std::string(definition->name));
+        return it == m_definitions.end() ? nullptr : &it->second.instance->getDefinition();
+    }
+
+    auto* body = getContainingInstanceBody(shallowSymbol);
+    if (!body || !body->parentInstance)
+        return nullptr;
+
+    auto binding = m_definitions.find(std::string(body->getDefinition().name));
+    if (binding == m_definitions.end())
+        return nullptr;
+    if (&shallowSymbol == body)
+        return &binding->second.instance->body;
+
+    auto shallowInstancePath = body->parentInstance->getHierarchicalPath();
+    auto symbolPath = shallowSymbol.getHierarchicalPath();
+    if (!std::string_view(symbolPath).starts_with(shallowInstancePath))
+        return nullptr;
+
+    auto designPath = binding->second.instance->getHierarchicalPath();
+    designPath.append(std::string_view(symbolPath).substr(shallowInstancePath.size()));
+
+    auto& compilation = m_analysis->compilation;
+    ast::LookupResult result;
+    ast::ASTContext context(compilation.getRoot(), ast::LookupLocation::max);
+    ast::Lookup::name(compilation.parseName(designPath), context,
+                      ast::LookupFlags::AllowUnnamedGenerate, result);
+    return result.found;
+}
+
+const InterfaceConnection* ActiveDesignContext::getInterfaceConnection(
+    const ast::InterfacePortSymbol& port) const {
+    auto* body = getContainingInstanceBody(port);
+    if (!body)
+        return nullptr;
+
+    auto binding = m_definitions.find(std::string(body->getDefinition().name));
+    if (binding == m_definitions.end())
+        return nullptr;
+
+    auto connection = binding->second.interfaceConnections.find(std::string(port.name));
+    return connection == binding->second.interfaceConnections.end() ? nullptr : &connection->second;
+}
+
+} // namespace server

--- a/src/ast/ServerCompilation.cpp
+++ b/src/ast/ServerCompilation.cpp
@@ -14,7 +14,10 @@
 #include "util/Converters.h"
 #include "util/Logging.h"
 #include <algorithm>
+#include <cctype>
 #include <memory>
+#include <ranges>
+#include <tuple>
 
 #include "slang/ast/Compilation.h"
 #include "slang/text/SourceManager.h"
@@ -292,6 +295,8 @@ void ServerCompilation::indexModuleDocs() {
 void ServerCompilation::refresh() {
     m_analysis = std::make_unique<ServerCompilationAnalysis>(m_documents, m_options,
                                                              m_sourceManager);
+    m_hierarchySearchItems.clear();
+    m_hierarchySearchIndexed = false;
 }
 
 std::vector<hier::InstanceSet> ServerCompilation::getScopesByModule() {
@@ -330,10 +335,12 @@ std::vector<hier::HierItem_t> ServerCompilation::getScope(const std::string& hie
     return scopeChildren.value_or(std::vector<hier::HierItem_t>{});
 }
 
-std::vector<hier::ScopeStep> ServerCompilation::getScopes(const std::string& hierPath) {
+std::vector<hier::ScopeStep> ServerCompilation::getScopes(const std::string& hierPath,
+                                                          const lsp::RequestContext& ctx) {
     std::vector<hier::ScopeStep> result;
     auto& compilation = m_analysis->compilation;
 
+    ctx.throwIfCancelled("before resolving root hierarchy scope");
     auto rootChildren = tryGetScopeChildren(compilation, m_sourceManager, std::string_view{});
     if (!rootChildren) {
         return result;
@@ -345,12 +352,160 @@ std::vector<hier::ScopeStep> ServerCompilation::getScopes(const std::string& hie
     }
 
     for (const auto* sym : lookupScopeChain(compilation, hierPath)) {
+        ctx.throwIfCancelled("while resolving hierarchy scopes");
         result.push_back({
             .path = sym->getHierarchicalPath(),
             .children = getChildrenForScopeSymbol(*sym, m_sourceManager),
         });
     }
 
+    return result;
+}
+
+hier::HierarchySearchResult ServerCompilation::searchHierarchy(const std::string& query) {
+    constexpr size_t maxResults = 100;
+    hier::HierarchySearchResult result{};
+
+    auto& compilation = m_analysis->compilation;
+
+    if (!m_hierarchySearchIndexed) {
+        auto roots = tryGetScopeChildren(compilation, m_sourceManager, std::string_view{});
+        auto collect = [&](auto&& self, const std::vector<hier::HierItem_t>& items,
+                           std::string_view parentPath, bool concatenateNames,
+                           std::string_view containerName) -> void {
+            for (const auto& item : items) {
+                rfl::visit(
+                    [&](const auto& entry) {
+                        using Entry = std::decay_t<decltype(entry)>;
+                        std::string path;
+                        if (parentPath.empty()) {
+                            path = entry.instName;
+                        }
+                        else {
+                            path = fmt::format("{}{}{}", parentPath, concatenateNames ? "" : ".",
+                                               entry.instName);
+                        }
+
+                        auto labelStart = path.rfind('.');
+                        auto label = labelStart == std::string::npos ? path
+                                                                     : path.substr(labelStart + 1);
+                        std::optional<std::string> description;
+                        if constexpr (std::is_same_v<Entry, hier::Var>) {
+                            description = entry.type;
+                            if (entry.value)
+                                *description += fmt::format(" = {}", *entry.value);
+                        }
+                        else if constexpr (std::is_same_v<Entry, hier::Scope>) {
+                            description = entry.type.value_or("scope");
+                        }
+                        else {
+                            description = entry.declName;
+                        }
+
+                        m_hierarchySearchItems.push_back({
+                            .name = std::move(label),
+                            .path = path,
+                            .kind = entry.kind,
+                            .description = std::move(description),
+                            .containerName = containerName.empty()
+                                                 ? std::nullopt
+                                                 : std::optional(std::string(containerName)),
+                        });
+
+                        if constexpr (std::is_same_v<Entry, hier::Scope>) {
+                            std::string childContainerName(containerName);
+                            if (entry.kind == hier::SlangKind::InterfacePort ||
+                                entry.kind == hier::SlangKind::InterfacePortArray) {
+                                if (entry.type)
+                                    childContainerName = *entry.type;
+                            }
+                            else {
+                                if (!childContainerName.empty() &&
+                                    !entry.instName.starts_with("[")) {
+                                    childContainerName += ".";
+                                }
+                                childContainerName += entry.instName;
+                            }
+                            self(self, entry.children, path,
+                                 entry.kind == hier::SlangKind::ScopeArray ||
+                                     entry.kind == hier::SlangKind::InterfacePortArray,
+                                 childContainerName);
+                        }
+                        else if constexpr (std::is_same_v<Entry, hier::Instance>) {
+                            if (!entry.children.empty()) {
+                                self(self, entry.children, path,
+                                     entry.kind == hier::SlangKind::InstanceArray, entry.declName);
+                            }
+                            else if (entry.hasChildren) {
+                                if (auto* symbol = lookupHierSymbol(compilation, path)) {
+                                    auto children = getChildrenForScopeSymbol(*symbol,
+                                                                              m_sourceManager);
+                                    self(self, children, path, false, entry.declName);
+                                }
+                            }
+                        }
+                    },
+                    item);
+            }
+        };
+        if (roots)
+            collect(collect, *roots, std::string_view{}, false, std::string_view{});
+        m_hierarchySearchIndexed = true;
+    }
+
+    auto lowercase = [](std::string_view text) {
+        std::string lowered;
+        lowered.reserve(text.size());
+        for (char c : text)
+            lowered.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+        return lowered;
+    };
+    auto lowerQuery = lowercase(query);
+    auto fuzzyMatches = [](std::string_view needle, std::string_view haystack) {
+        auto next = needle.begin();
+        for (char c : haystack) {
+            if (next != needle.end() && *next == c)
+                ++next;
+        }
+        return next == needle.end();
+    };
+
+    struct Match {
+        const hier::HierarchySearchItem* item;
+        int rank;
+    };
+    std::vector<Match> matches;
+    for (const auto& item : m_hierarchySearchItems) {
+        auto lowerLabel = lowercase(item.name);
+        auto lowerPath = lowercase(item.path);
+        int rank;
+        if (lowerQuery.empty())
+            rank = 0;
+        else if (lowerLabel == lowerQuery)
+            rank = 0;
+        else if (lowerLabel.starts_with(lowerQuery))
+            rank = 1;
+        else if (lowerLabel.find(lowerQuery) != std::string::npos)
+            rank = 2;
+        else if (lowerPath.find(lowerQuery) != std::string::npos)
+            rank = 3;
+        else if (fuzzyMatches(lowerQuery, lowerPath))
+            rank = 4;
+        else
+            continue;
+        matches.push_back({.item = &item, .rank = rank});
+    }
+
+    auto resultCount = std::min(matches.size(), maxResults);
+    std::ranges::partial_sort(
+        matches, matches.begin() + resultCount, [](const Match& left, const Match& right) {
+            return std::tuple(left.rank, left.item->path.size(), left.item->path) <
+                   std::tuple(right.rank, right.item->path.size(), right.item->path);
+        });
+    result.totalResults = matches.size();
+    result.matches.reserve(resultCount);
+    for (const auto& match : matches | std::views::take(resultCount))
+        result.matches.push_back(*match.item);
     return result;
 }
 

--- a/src/ast/ServerCompilation.cpp
+++ b/src/ast/ServerCompilation.cpp
@@ -20,11 +20,145 @@
 #include <tuple>
 
 #include "slang/ast/Compilation.h"
+#include "slang/ast/symbols/PortSymbols.h"
+#include "slang/syntax/AllSyntax.h"
 #include "slang/text/SourceManager.h"
+
+namespace fs = std::filesystem;
 
 namespace server {
 
 namespace {
+
+// Among instances of the same module, pick the one closest to the root, breaking ties by
+// source location, then by hierarchical path. Used as a deterministic default "active"
+// instance when the user hasn't picked one.
+const slang::ast::InstanceSymbol* choosePreferredInstance(
+    const std::vector<const slang::ast::InstanceSymbol*>& instances) {
+    auto depth = [](const slang::ast::InstanceSymbol& i) {
+        auto p = i.getHierarchicalPath();
+        return std::count(p.begin(), p.end(), '.');
+    };
+    auto sortLoc = [](const slang::ast::InstanceSymbol& i) {
+        auto* syntax = i.getSyntax();
+        return syntax ? syntax->sourceRange().start() : i.location;
+    };
+
+    auto less = [&](const slang::ast::InstanceSymbol* a, const slang::ast::InstanceSymbol* b) {
+        if (auto da = depth(*a), db = depth(*b); da != db) {
+            return da < db;
+        }
+        auto la = sortLoc(*a), lb = sortLoc(*b);
+        if (la.valid() != lb.valid()) {
+            return la.valid();
+        }
+        if (la.valid() && la != lb) {
+            return la < lb;
+        }
+        return a->getHierarchicalPath() < b->getHierarchicalPath();
+    };
+
+    const slang::ast::InstanceSymbol* preferred = nullptr;
+    for (const auto* inst : instances) {
+        if (!preferred || less(inst, preferred)) {
+            preferred = inst;
+        }
+    }
+    return preferred;
+}
+
+void setActiveInterfaceInstance(
+    const slang::ast::Symbol& symbol,
+    std::unordered_map<std::string, hier::QualifiedInstance>& activeInstancesByModule,
+    const SourceManager& sourceManager) {
+    if (auto inst = symbol.as_if<slang::ast::InstanceSymbol>()) {
+        activeInstancesByModule[std::string(inst->getDefinition().name)] =
+            hier::toQualifiedInstance(*inst, sourceManager);
+        return;
+    }
+
+    if (auto arr = symbol.as_if<slang::ast::InstanceArraySymbol>()) {
+        for (const auto* element : arr->elements) {
+            if (element) {
+                setActiveInterfaceInstance(*element, activeInstancesByModule, sourceManager);
+            }
+        }
+    }
+    else if (auto* port = symbol.as_if<slang::ast::InterfacePortSymbol>()) {
+        auto connection = resolveInterfaceConnection(*port);
+        if (connection.resolvedEndpoint && connection.resolvedEndpoint != &symbol)
+            setActiveInterfaceInstance(*connection.resolvedEndpoint, activeInstancesByModule,
+                                       sourceManager);
+    }
+}
+
+void setConnectedInterfaceInstances(
+    const slang::ast::InstanceSymbol& inst,
+    std::unordered_map<std::string, hier::QualifiedInstance>& activeInstancesByModule,
+    const SourceManager& sourceManager) {
+    for (const auto* conn : inst.getPortConnections()) {
+        if (!conn || conn->port.kind != slang::ast::SymbolKind::InterfacePort) {
+            continue;
+        }
+
+        auto [connectedSym, _modport] = conn->getIfaceConn();
+        if (!connectedSym) {
+            continue;
+        }
+
+        setActiveInterfaceInstance(*connectedSym, activeInstancesByModule, sourceManager);
+    }
+}
+
+const slang::ast::InstanceSymbol* getEnclosingInstance(const slang::ast::Symbol& symbol) {
+    for (auto* scope = symbol.getParentScope(); scope; scope = scope->asSymbol().getParentScope()) {
+        auto& scopeSymbol = scope->asSymbol();
+        if (auto* body = scopeSymbol.as_if<slang::ast::InstanceBodySymbol>()) {
+            return body->parentInstance;
+        }
+    }
+    return nullptr;
+}
+
+void setActiveInstanceChain(
+    const slang::ast::InstanceSymbol& target,
+    std::unordered_map<std::string, hier::QualifiedInstance>& activeInstancesByModule,
+    const SourceManager& sourceManager) {
+    std::vector<const slang::ast::InstanceSymbol*> chain;
+    auto* current = &target;
+    while (current) {
+        chain.push_back(current);
+        current = getEnclosingInstance(*current);
+    }
+
+    for (auto* instance : chain | std::views::reverse) {
+        setConnectedInterfaceInstances(*instance, activeInstancesByModule, sourceManager);
+        // Let deeper selections override interface connections discovered on their ancestors.
+        activeInstancesByModule[std::string(instance->getDefinition().name)] =
+            hier::toQualifiedInstance(*instance, sourceManager);
+    }
+}
+
+void setActiveGenerateScopes(
+    const slang::ast::Symbol& symbol,
+    std::unordered_map<std::string, std::string>& activeGenerateScopesByArray) {
+    auto setActiveGenerateScope = [&](const slang::ast::GenerateBlockSymbol& block) {
+        auto* parentScope = block.getParentScope();
+        auto* array = parentScope
+                          ? parentScope->asSymbol().as_if<slang::ast::GenerateBlockArraySymbol>()
+                          : nullptr;
+        if (array) {
+            activeGenerateScopesByArray[array->getHierarchicalPath()] = block.getHierarchicalPath();
+        }
+    };
+
+    if (auto* block = symbol.as_if<slang::ast::GenerateBlockSymbol>())
+        setActiveGenerateScope(*block);
+    for (auto* scope = symbol.getParentScope(); scope; scope = scope->asSymbol().getParentScope()) {
+        if (auto* block = scope->asSymbol().as_if<slang::ast::GenerateBlockSymbol>())
+            setActiveGenerateScope(*block);
+    }
+}
 
 const slang::ast::Symbol* lookupHierSymbol(slang::ast::Compilation& compilation,
                                            std::string_view path) {
@@ -88,6 +222,66 @@ bool isHierarchicalScope(const slang::ast::Symbol& sym) {
         default:
             return false;
     }
+}
+
+void collectGenerateArrays(const slang::ast::Scope& scope,
+                           const slang::syntax::LoopGenerateSyntax& loop,
+                           std::vector<const slang::ast::GenerateBlockArraySymbol*>& result) {
+    for (auto& member : scope.members()) {
+        if (auto* array = member.as_if<slang::ast::GenerateBlockArraySymbol>()) {
+            if (array->getSyntax() == &loop)
+                result.push_back(array);
+            for (auto* entry : array->entries)
+                collectGenerateArrays(*entry, loop, result);
+        }
+        else if (auto* block = member.as_if<slang::ast::GenerateBlockSymbol>()) {
+            collectGenerateArrays(*block, loop, result);
+        }
+    }
+}
+
+std::optional<size_t> getActiveAncestorCount(
+    const slang::ast::GenerateBlockArraySymbol& array,
+    const std::unordered_map<std::string, std::string>& activeGenerateScopesByArray) {
+    size_t count = 0;
+    for (auto* scope = array.getParentScope(); scope; scope = scope->asSymbol().getParentScope()) {
+        auto* block = scope->asSymbol().as_if<slang::ast::GenerateBlockSymbol>();
+        if (!block)
+            continue;
+
+        auto* parentScope = block->getParentScope();
+        auto* parentArray =
+            parentScope ? parentScope->asSymbol().as_if<slang::ast::GenerateBlockArraySymbol>()
+                        : nullptr;
+        if (!parentArray)
+            continue;
+
+        auto active = activeGenerateScopesByArray.find(parentArray->getHierarchicalPath());
+        if (active == activeGenerateScopesByArray.end())
+            continue;
+        if (active->second != block->getHierarchicalPath())
+            return std::nullopt;
+        count++;
+    }
+    return count;
+}
+
+const slang::ast::GenerateBlockArraySymbol* chooseGenerateArray(
+    const std::vector<const slang::ast::GenerateBlockArraySymbol*>& arrays,
+    const std::unordered_map<std::string, std::string>& activeGenerateScopesByArray) {
+    const slang::ast::GenerateBlockArraySymbol* best = nullptr;
+    std::tuple<int, int, std::string> bestKey;
+    for (auto* array : arrays) {
+        auto activeAncestorCount = getActiveAncestorCount(*array, activeGenerateScopesByArray);
+        auto key = std::tuple(activeAncestorCount ? 0 : 1,
+                              -static_cast<int>(activeAncestorCount.value_or(0)),
+                              array->getHierarchicalPath());
+        if (!best || key < bestKey) {
+            best = array;
+            bestKey = std::move(key);
+        }
+    }
+    return best;
 }
 
 std::vector<hier::HierItem_t> getChildrenForScopeSymbol(const slang::ast::Symbol& sym,
@@ -212,6 +406,7 @@ std::optional<lsp::ShowDocumentParams> makeShowDocumentParams(const SourceLocati
 
 } // namespace
 
+// Resolve through the owning document so edits use current locations without rebuilding others.
 const slang::ast::Symbol* ServerCompilation::toShallowSymbol(
     const slang::ast::Symbol& symbol) const {
     using slang::ast::SymbolKind;
@@ -269,8 +464,13 @@ const slang::ast::Symbol* ServerCompilation::toShallowSymbol(
 ServerCompilation::ServerCompilation(std::vector<std::shared_ptr<SlangDoc>> documents, Bag options,
                                      SourceManager& sourceManager, lsp::LspClient& client,
                                      std::optional<std::string> top) :
-    m_documents(std::move(documents)), m_options(std::move(options)), m_top(std::move(top)),
-    m_sourceManager(sourceManager), m_client(client) {
+    m_options(std::move(options)), m_top(std::move(top)), m_sourceManager(sourceManager),
+    m_client(client) {
+
+    m_documents.reserve(documents.size());
+    for (auto& doc : documents) {
+        m_documents.emplace(doc->getPath(), std::move(doc));
+    }
 
     if (m_top) {
         m_options.insertOrGet<slang::ast::CompilationOptions>().topModules = {*m_top};
@@ -281,7 +481,7 @@ ServerCompilation::ServerCompilation(std::vector<std::shared_ptr<SlangDoc>> docu
 
 void ServerCompilation::indexModuleDocs() {
     m_moduleToDoc.clear();
-    for (const auto& doc : m_documents) {
+    for (const auto& [path, doc] : m_documents) {
         auto tree = doc->getSyntaxTree();
         if (!tree) {
             continue;
@@ -293,10 +493,11 @@ void ServerCompilation::indexModuleDocs() {
 }
 
 void ServerCompilation::refresh() {
-    m_analysis = std::make_unique<ServerCompilationAnalysis>(m_documents, m_options,
+    m_analysis = std::make_shared<ServerCompilationAnalysis>(m_documents, m_options,
                                                              m_sourceManager);
     m_hierarchySearchItems.clear();
     m_hierarchySearchIndexed = false;
+    syncActiveInstances();
 }
 
 std::vector<hier::InstanceSet> ServerCompilation::getScopesByModule() {
@@ -312,8 +513,8 @@ std::vector<hier::InstanceSet> ServerCompilation::getScopesByModule() {
             .declLoc = toLocation(definition.getSyntax()->sourceRange(), m_sourceManager),
             .instCount = instances.size(),
         };
-        if (instances.size() == 1) {
-            instSet.inst = hier::toQualifiedInstance(*instances[0], m_sourceManager);
+        if (auto activeInstance = getActiveInstanceSelection(instSet.declName)) {
+            instSet.inst = std::move(*activeInstance);
         }
         result.push_back(instSet);
     }
@@ -328,6 +529,187 @@ const std::vector<const slang::ast::InstanceSymbol*>& ServerCompilation::getInst
         return empty;
     }
     return it->second;
+}
+
+std::optional<hier::QualifiedInstance> ServerCompilation::getActiveInstanceSelection(
+    std::string_view moduleName) const {
+    auto activeIt = m_activeInstancesByModule.find(std::string(moduleName));
+    if (activeIt == m_activeInstancesByModule.end()) {
+        return std::nullopt;
+    }
+    return activeIt->second;
+}
+
+const slang::ast::InstanceSymbol* ServerCompilation::getActiveInstanceSymbol(
+    std::string_view moduleName) const {
+    auto it = m_analysis->instances.moduleToInstances.find(std::string(moduleName));
+    if (it == m_analysis->instances.moduleToInstances.end()) {
+        return nullptr;
+    }
+
+    if (auto activeInstance = getActiveInstanceSelection(moduleName)) {
+        for (const auto* instance : it->second) {
+            if (instance->getHierarchicalPath() == activeInstance->instPath)
+                return instance;
+        }
+    }
+
+    if (!it->second.empty()) {
+        return choosePreferredInstance(it->second);
+    }
+
+    return nullptr;
+}
+
+ActiveDesignContext ServerCompilation::createActiveDesignContext(
+    std::span<const std::string_view> definitionNames) const {
+    ActiveDesignContext result(m_analysis);
+    for (auto name : definitionNames) {
+        if (auto* instance = getActiveInstanceSymbol(name))
+            result.bindInstance(*instance);
+    }
+    return result;
+}
+
+std::optional<ActiveGenerateLoop> ServerCompilation::getActiveGenerateLoop(
+    std::string_view moduleName, const syntax::LoopGenerateSyntax& loop) const {
+    auto* activeInstance = getActiveInstanceSymbol(moduleName);
+    if (!activeInstance)
+        return std::nullopt;
+
+    std::vector<const ast::GenerateBlockArraySymbol*> arrays;
+    collectGenerateArrays(activeInstance->body, loop, arrays);
+    if (arrays.empty())
+        return std::nullopt;
+
+    auto* array = chooseGenerateArray(arrays, m_activeGenerateScopesByArray);
+    if (!array || array->entries.empty())
+        return std::nullopt;
+
+    ActiveGenerateLoop result;
+    result.iterationPaths.reserve(array->entries.size());
+    auto selected = m_activeGenerateScopesByArray.find(array->getHierarchicalPath());
+    for (auto* entry : array->entries) {
+        auto path = entry->getHierarchicalPath();
+        result.iterationPaths.push_back(path);
+        if (selected != m_activeGenerateScopesByArray.end() && selected->second == path)
+            result.activePath = path;
+    }
+    if (result.activePath.empty())
+        result.activePath = result.iterationPaths.front();
+    return result;
+}
+
+std::optional<std::string> ServerCompilation::getPreferredSymbolPath(std::string_view name) const {
+    auto& compilation = m_analysis->compilation;
+    auto& root = compilation.getRoot();
+
+    if (auto def = compilation.tryGetDefinition(name, root); def.definition) {
+        auto loc = m_sourceManager.getFullyOriginalLoc(def.definition->location);
+        auto fullPath = m_sourceManager.getFullPath(loc.buffer());
+        if (!fullPath.empty()) {
+            return fullPath.string();
+        }
+    }
+
+    if (auto pkg = compilation.getPackage(name)) {
+        auto syntax = pkg->getSyntax();
+        if (syntax) {
+            auto fullPath = m_sourceManager.getFullPath(
+                m_sourceManager.getFullyOriginalLoc(syntax->sourceRange().start()).buffer());
+            if (!fullPath.empty()) {
+                return fullPath.string();
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+bool ServerCompilation::setActiveInstance(const std::string& hierPath) {
+    auto* sym = lookupHierSymbol(m_analysis->compilation, hierPath);
+    if (!sym) {
+        return false;
+    }
+
+    setActiveGenerateScopes(*sym, m_activeGenerateScopesByArray);
+
+    if (auto* port = sym->as_if<ast::InterfacePortSymbol>()) {
+        if (auto* enclosing = getEnclosingInstance(*port)) {
+            setActiveInstanceChain(*enclosing, m_activeInstancesByModule, m_sourceManager);
+        }
+        auto connection = resolveInterfaceConnection(*port);
+        for (auto* connected : connection.sourcePath) {
+            setActiveGenerateScopes(*connected, m_activeGenerateScopesByArray);
+            if (auto* connectedPort = connected->as_if<ast::InterfacePortSymbol>()) {
+                if (auto* enclosing = getEnclosingInstance(*connectedPort)) {
+                    setActiveInstanceChain(*enclosing, m_activeInstancesByModule, m_sourceManager);
+                }
+            }
+        }
+        if (connection.resolvedEndpoint &&
+            std::ranges::find(connection.sourcePath, connection.resolvedEndpoint) ==
+                connection.sourcePath.end()) {
+            setActiveGenerateScopes(*connection.resolvedEndpoint, m_activeGenerateScopesByArray);
+        }
+        sym = connection.resolvedEndpoint;
+    }
+
+    if (auto* target = sym ? sym->as_if<ast::InstanceSymbol>() : nullptr) {
+        setActiveInstanceChain(*target, m_activeInstancesByModule, m_sourceManager);
+        return true;
+    }
+
+    if (!sym)
+        return false;
+    if (auto* enclosing = getEnclosingInstance(*sym)) {
+        setActiveInstanceChain(*enclosing, m_activeInstancesByModule, m_sourceManager);
+        return true;
+    }
+    return false;
+}
+
+std::optional<hier::QualifiedInstance> ServerCompilation::getActiveInstance(
+    const std::string& moduleName) {
+    auto& byModule = m_analysis->instances.moduleToInstances;
+    if (byModule.find(moduleName) == byModule.end()) {
+        return std::nullopt;
+    }
+    // Prefer the stored path verbatim, even if the latest recompile dropped the
+    // corresponding instance symbol; otherwise fall back to the preferred instance.
+    if (auto activeInstance = getActiveInstanceSelection(moduleName)) {
+        return activeInstance;
+    }
+    if (auto* inst = getActiveInstanceSymbol(moduleName)) {
+        return hier::toQualifiedInstance(*inst, m_sourceManager);
+    }
+    return std::nullopt;
+}
+
+void ServerCompilation::syncActiveInstances() {
+    std::unordered_map<std::string, hier::QualifiedInstance> nextActiveInstances;
+    for (const auto& [moduleName, instances] : m_analysis->instances.moduleToInstances) {
+        if (instances.empty()) {
+            continue;
+        }
+
+        if (auto activeInstance = getActiveInstanceSelection(moduleName)) {
+            auto stillExists = std::ranges::any_of(instances, [&](const auto* instance) {
+                return instance->getHierarchicalPath() == activeInstance->instPath;
+            });
+            if (stillExists) {
+                nextActiveInstances[moduleName] = std::move(*activeInstance);
+                continue;
+            }
+        }
+
+        if (instances.size() == 1) {
+            nextActiveInstances[moduleName] = hier::toQualifiedInstance(*instances[0],
+                                                                        m_sourceManager);
+        }
+    }
+
+    m_activeInstancesByModule = std::move(nextActiveInstances);
 }
 
 std::vector<hier::HierItem_t> ServerCompilation::getScope(const std::string& hierPath) {
@@ -523,7 +905,7 @@ std::optional<lsp::Location> ServerCompilation::getHierLocation(const std::strin
     // Edit fallback: the full compilation is stale (only refreshed on save). A signal
     // typed since the last build won't resolve in the full comp, so split the path at
     // the deepest dot-segment that still resolves to an instance and look up the
-    // remainder against that module's shallow compilation (which rebuilds per-edit).
+    // remainder against that module's *shallow* compilation (which rebuilds per-edit).
     if (!sym) {
         for (auto dot = hierPath.rfind('.'); dot != std::string::npos;
              dot = hierPath.rfind('.', dot - 1)) {
@@ -542,17 +924,16 @@ std::optional<lsp::Location> ServerCompilation::getHierLocation(const std::strin
             if (!freshDef) {
                 break;
             }
-
+            // Build a path rooted at the module name in its own shallow comp:
+            //   "<moduleName>.<remainder>"
             std::string remainder = hierPath.substr(dot + 1);
             auto modulePath = fmt::format("{}.{}", freshDef->name, remainder);
-            auto fullPath = m_sourceManager.getFullPath(freshDef->location.buffer()).string();
-            auto docIt = std::ranges::find_if(m_documents, [&](const auto& doc) {
-                return doc->getPath() == fullPath;
-            });
-            if (docIt == m_documents.end()) {
+            auto it = m_documents.find(
+                m_sourceManager.getFullPath(freshDef->location.buffer()).string());
+            if (it == m_documents.end()) {
                 break;
             }
-            auto& shallowComp = *(*docIt)->getAnalysis()->getCompilation();
+            auto& shallowComp = *it->second->getAnalysis()->getCompilation();
             sym = lookupHierSymbol(shallowComp, modulePath);
             break;
         }
@@ -569,6 +950,8 @@ std::optional<lsp::Location> ServerCompilation::getHierLocation(const std::strin
         sym = freshSym;
     }
 
+    // Instances: prefer the instantiation site, fall back to the definition.
+    std::optional<lsp::ShowDocumentParams> params;
     if (auto* inst = sym->as_if<slang::ast::InstanceSymbol>()) {
         auto* syntax = inst->getSyntax();
         if (!syntax) {
@@ -577,19 +960,21 @@ std::optional<lsp::Location> ServerCompilation::getHierLocation(const std::strin
         if (!syntax) {
             return std::nullopt;
         }
-        auto params = makeShowDocumentParams(syntax->sourceRange(), m_sourceManager);
+        params = makeShowDocumentParams(syntax->sourceRange(), m_sourceManager);
+    }
+    else {
+        // Non-instance: try .location first. Interface ports and other parameterized
+        // symbols often have synthesized locations though, so fall back to the syntax
+        // range when location-based fails (makeShowDocumentParams already walks
+        // macro expansions / fully-original locs for both paths).
+        params = makeShowDocumentParams(sym->location, sym->name.length(), m_sourceManager);
         if (!params || !params->selection) {
-            return std::nullopt;
+            if (auto* syntax = sym->getSyntax()) {
+                params = makeShowDocumentParams(syntax->sourceRange(), m_sourceManager);
+            }
         }
-        return lsp::Location{.uri = params->uri, .range = *params->selection};
     }
 
-    auto params = makeShowDocumentParams(sym->location, sym->name.length(), m_sourceManager);
-    if (!params || !params->selection) {
-        if (auto* syntax = sym->getSyntax()) {
-            params = makeShowDocumentParams(syntax->sourceRange(), m_sourceManager);
-        }
-    }
     if (!params || !params->selection) {
         return std::nullopt;
     }
@@ -598,18 +983,13 @@ std::optional<lsp::Location> ServerCompilation::getHierLocation(const std::strin
 
 std::vector<std::string> ServerCompilation::getInstances(
     const lsp::TextDocumentPositionParams& params) {
-    std::shared_ptr<SlangDoc> doc;
-    // NOCOMMIT -- be better, index by URI
-    for (const auto& document : m_documents) {
-        if (document->getPath() == params.textDocument.uri.getPath()) {
-            doc = document;
-            break;
-        }
-    }
-    if (!doc) {
-        ERROR("Unknown doc: {}", params.textDocument.uri.getPath());
+    auto path = std::string(params.textDocument.uri.getPath());
+    auto it = m_documents.find(path);
+    if (it == m_documents.end()) {
+        ERROR("Unknown doc: {}", path);
         return {};
     }
+    auto& doc = it->second;
     auto location = toSourceLocation(doc->getBuffer(), params.position, m_sourceManager);
     if (location) {
         inst::InstanceVisitor visitor(*location);

--- a/src/ast/ServerCompilationAnalysis.cpp
+++ b/src/ast/ServerCompilationAnalysis.cpp
@@ -18,13 +18,14 @@
 namespace server {
 
 ServerCompilationAnalysis::ServerCompilationAnalysis(
-    std::vector<std::shared_ptr<SlangDoc>>& documents, Bag& options, SourceManager& sourceManager) :
+    const std::unordered_map<std::string, std::shared_ptr<SlangDoc>>& documents, Bag& options,
+    SourceManager& sourceManager) :
     compilation(options),
     m_analysisOptions(options.getOrDefault<slang::analysis::AnalysisOptions>()) {
     std::vector<BufferID> bufferIds;
     std::unordered_set<BufferID> seenBuffers;
 
-    for (auto& doc : documents) {
+    for (auto& [_, doc] : documents) {
         auto tree = doc->getSyntaxTree();
         compilation.addSyntaxTree(tree);
 
@@ -45,6 +46,16 @@ ServerCompilationAnalysis::ServerCompilationAnalysis(
     m_references.reset();
 }
 
+slang::analysis::AnalysisManager& ServerCompilationAnalysis::getAnalysisManager() {
+    if (!m_driverAnalysis) {
+        m_driverAnalysis = std::make_unique<slang::analysis::AnalysisManager>(m_analysisOptions);
+        compilation.freeze();
+        m_driverAnalysis->analyze(compilation);
+        compilation.unfreeze();
+    }
+    return *m_driverAnalysis;
+}
+
 void ServerCompilationAnalysis::issueDiagnosticsTo(slang::DiagnosticEngine& diagEngine) {
     // Semantic diagnostics from compilation
     for (auto& diag : compilation.getSemanticDiagnostics()) {
@@ -53,14 +64,16 @@ void ServerCompilationAnalysis::issueDiagnosticsTo(slang::DiagnosticEngine& diag
 
     // Driver analysis diagnostics (multi-driven, unused, etc)
     // Use stored options with numThreads=1 to avoid persistent thread pool
-    slang::analysis::AnalysisManager driverAnalysis(m_analysisOptions);
-    compilation.freeze();
-    driverAnalysis.analyze(compilation);
-    compilation.unfreeze();
+    auto& driverAnalysis = getAnalysisManager();
     INFO("Driver analysis found {} diagnostics", driverAnalysis.getDiagnostics().size());
     for (auto& diag : driverAnalysis.getDiagnostics()) {
         diagEngine.issue(diag);
     }
+}
+
+std::vector<const slang::analysis::ValueDriver*> ServerCompilationAnalysis::getDrivers(
+    const slang::ast::ValueSymbol& symbol) {
+    return getAnalysisManager().getDrivers(symbol);
 }
 
 } // namespace server

--- a/src/document/DefinitionInfo.cpp
+++ b/src/document/DefinitionInfo.cpp
@@ -592,7 +592,7 @@ void renderSymbolValue(markup::Paragraph& infoPg, const ast::Symbol& symbol,
         auto& enumVal = symbol.as<ast::EnumValueSymbol>();
         const auto& value = enumVal.getValue();
         if (!value.bad()) {
-            infoPg.appendText("Value: ").appendCode(value.toString()).newLine();
+            infoPg.appendText("Value: ").appendCode(formatConstantValue(value)).newLine();
         }
     }
 }
@@ -659,6 +659,26 @@ RenderedSymbolHover renderSymbolHover(const DefinitionInfo::SymbolTarget& target
     if (!label.empty())
         result.header.appendBold(label);
     renderSymbolHeader(result.header, *target.symbol);
+
+    // Show design info for iface ports
+    if (auto* ifacePort = target.renderInterfaceConnection
+                              ? target.symbol->as_if<ast::InterfacePortSymbol>()
+                              : nullptr) {
+        if (auto* activeConnection = target.analysis->getActiveInterfaceConnection(*ifacePort);
+            activeConnection && !activeConnection->sourcePath.empty()) {
+            auto* connection = activeConnection->sourcePath.back();
+            if (sm.getFullyOriginalLoc(connection->location) !=
+                sm.getFullyOriginalLoc(ifacePort->location)) {
+                result.header.appendText("Connected to ");
+                if (!appendSourceLink(result.header, connection->location, sm,
+                                      connection->getHierarchicalPath())) {
+                    result.header.appendCode(connection->getHierarchicalPath());
+                }
+                result.header.newLine();
+            }
+        }
+    }
+
     renderSymbolType(result.type, *target.symbol, sm);
     if (target.generatedSignalCount > 1) {
         result.generatedSignals.appendText("Generated signals: ")

--- a/src/document/InlayHintCollector.cpp
+++ b/src/document/InlayHintCollector.cpp
@@ -15,6 +15,7 @@
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/MemberSymbols.h"
+#include "slang/ast/symbols/ParameterSymbols.h"
 #include "slang/ast/symbols/PortSymbols.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxKind.h"
@@ -39,9 +40,34 @@ InlayHintCollector::InlayHintCollector(const ShallowAnalysis& analysis, lsp::Ran
                                        const Config::InlayHints& config) :
     m_analysis(analysis), m_range(range), m_portTypes(config.portTypes.value()),
     m_assignmentPatternTypes(config.assignmentPatternTypes.value()),
+    m_activeParameterValues(config.activeParameterValues.value()),
     m_orderedInstanceNames(config.orderedInstanceNames.value()),
     m_wildcardNames(config.wildcardNames.value()), m_funcArgNames(config.funcArgNames.value()),
     m_macroArgNames(config.macroArgNames.value()) {
+}
+
+void InlayHintCollector::handle(const ParameterDeclarationSyntax& syntax) {
+    if (!m_activeParameterValues)
+        return;
+
+    for (auto* declarator : syntax.declarators) {
+        auto* shallowSymbol = m_analysis.getSymbolAtToken(&declarator->name);
+        auto* designSymbol = shallowSymbol ? m_analysis.getDesignSymbol(*shallowSymbol) : nullptr;
+        auto* parameter = designSymbol ? designSymbol->as_if<ast::ParameterSymbol>() : nullptr;
+        if (!parameter)
+            continue;
+
+        const auto& value = parameter->getValue();
+        if (value.bad())
+            continue;
+
+        result.push_back(lsp::InlayHint{
+            .position = toPosition(declarator->name.range().end(), m_analysis.m_sourceManager),
+            .label = formatConstantValue(value),
+            .kind = lsp::InlayHintKind::Parameter,
+            .paddingLeft = true,
+        });
+    }
 }
 
 void InlayHintCollector::handle(const HierarchyInstantiationSyntax& syntax) {
@@ -439,6 +465,9 @@ void InlayHintCollector::collectHints() {
 
     for (auto it = start; it != end; ++it) {
         switch (it->second->kind) {
+            case syntax::SyntaxKind::ParameterDeclaration:
+                handle(it->second->as<ParameterDeclarationSyntax>());
+                break;
             case syntax::SyntaxKind::HierarchyInstantiation:
                 handle(it->second->as<HierarchyInstantiationSyntax>());
                 break;

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -8,6 +8,7 @@
 
 #include "document/ShallowAnalysis.h"
 
+#include "ast/ServerCompilation.h"
 #include "document/InlayHintCollector.h"
 #include "lsp/LspTypes.h"
 #include "util/Converters.h"
@@ -64,7 +65,8 @@ static bool symbolsMatch(const ast::Symbol* a, const ast::Symbol* b) {
 }
 ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID buffer,
                                  std::shared_ptr<syntax::SyntaxTree> tree, slang::Bag options,
-                                 const std::vector<std::shared_ptr<syntax::SyntaxTree>>& allTrees) :
+                                 const std::vector<std::shared_ptr<syntax::SyntaxTree>>& allTrees,
+                                 const ServerCompilation* design) :
     syntaxes(*tree), m_sourceManager(sourceManager), m_buffer(buffer), m_tree(tree),
     m_allTrees(allTrees), m_analysisOptions(options.getOrDefault<analysis::AnalysisOptions>()),
     m_symbolTreeVisitor(m_sourceManager), m_symbolIndexer(buffer) {
@@ -106,6 +108,15 @@ ShallowAnalysis::ShallowAnalysis(SourceManager& sourceManager, slang::BufferID b
     for (auto& depTree : m_allTrees) {
         m_compilation->addSyntaxTree(depTree);
     }
+    if (design) {
+        std::vector<std::string_view> definitionNames;
+        for (auto* symbol : m_compilation->getDefinitions()) {
+            if (auto* definition = symbol->as_if<ast::DefinitionSymbol>())
+                definitionNames.push_back(definition->name);
+        }
+        m_activeDesign = design->createActiveDesignContext(definitionNames);
+        m_activeDesign->applyOverrides(*m_compilation);
+    }
 
     // Elaborate and index
     // - token -> symbol defs
@@ -129,6 +140,73 @@ const Diagnostics& ShallowAnalysis::getSemanticDiagnostics() {
     }
 
     return m_compilation->getSemanticDiagnostics();
+}
+
+const InterfaceConnection* ShallowAnalysis::getActiveInterfaceConnection(
+    const ast::InterfacePortSymbol& port) const {
+    return m_activeDesign ? m_activeDesign->getInterfaceConnection(port) : nullptr;
+}
+
+const ast::Symbol* ShallowAnalysis::getDesignSymbol(const ast::Symbol& shallowSymbol) const {
+    return m_activeDesign ? m_activeDesign->getDesignSymbol(shallowSymbol) : nullptr;
+}
+
+std::optional<std::string> ShallowAnalysis::getDesignInstancePathAtToken(
+    const parsing::Token* token) const {
+    if (!m_activeDesign || !token)
+        return {};
+
+    auto* syntax = syntaxes.getTokenParent(token);
+    if (!syntax)
+        return {};
+
+    const syntax::HierarchicalInstanceSyntax* instanceSyntax = nullptr;
+    if (auto* port = syntax->as_if<syntax::NamedPortConnectionSyntax>()) {
+        if (&port->name != token)
+            return {};
+
+        for (auto parent = syntax->parent; parent; parent = parent->parent) {
+            if (auto* instance = parent->as_if<syntax::HierarchicalInstanceSyntax>()) {
+                instanceSyntax = instance;
+                break;
+            }
+        }
+    }
+    else {
+        const syntax::HierarchyInstantiationSyntax* instantiation = nullptr;
+        if (auto* hierarchy = syntax->as_if<syntax::HierarchyInstantiationSyntax>()) {
+            if (&hierarchy->type == token)
+                instantiation = hierarchy;
+        }
+        else if (auto* parameter = syntax->as_if<syntax::NamedParamAssignmentSyntax>()) {
+            if (&parameter->name != token)
+                return {};
+
+            for (auto parent = syntax->parent; parent; parent = parent->parent) {
+                if (auto* hierarchy = parent->as_if<syntax::HierarchyInstantiationSyntax>()) {
+                    instantiation = hierarchy;
+                    break;
+                }
+            }
+        }
+
+        // A shared type or parameter token cannot distinguish comma-separated instances.
+        if (!instantiation || instantiation->instances.size() != 1)
+            return {};
+        instanceSyntax = instantiation->instances[0];
+    }
+
+    auto* shallowInstance = instanceSyntax ? m_symbolIndexer.getSymbol(instanceSyntax) : nullptr;
+    auto* designInstance = shallowInstance ? getDesignSymbol(*shallowInstance) : nullptr;
+    while (auto* array = designInstance ? designInstance->as_if<ast::InstanceArraySymbol>()
+                                        : nullptr) {
+        if (array->elements.empty())
+            return {};
+        designInstance = array->elements.front();
+    }
+
+    auto* instance = designInstance ? designInstance->as_if<ast::InstanceSymbol>() : nullptr;
+    return instance ? std::optional(instance->getHierarchicalPath()) : std::nullopt;
 }
 
 std::vector<lsp::DocumentSymbol> ShallowAnalysis::getDocSymbols() {
@@ -1084,6 +1162,12 @@ const slang::analysis::AnalysisManager* ShallowAnalysis::getAnalysisManager() {
 
 std::vector<const slang::analysis::ValueDriver*> ShallowAnalysis::getDrivers(
     const slang::ast::ValueSymbol& symbol) {
+    if (m_activeDesign) {
+        auto* designSymbol = getDesignSymbol(symbol);
+        if (auto* designValue = designSymbol ? designSymbol->as_if<ast::ValueSymbol>() : nullptr)
+            return m_activeDesign->getAnalysis().getDrivers(*designValue);
+    }
+
     auto* manager = getAnalysisManager();
     if (!manager) {
         return {};

--- a/src/document/SlangDoc.cpp
+++ b/src/document/SlangDoc.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<ShallowAnalysis> SlangDoc::refreshAnalysis(const lsp::RequestCon
     auto trees = m_driver.getDependentTrees(tree);
     trees.insert(trees.begin(), tree);
     auto analysis = std::make_shared<ShallowAnalysis>(m_sourceManager, m_buffer.id, tree, m_options,
-                                                      trees);
+                                                      trees, m_driver.comp.get());
     auto topNames = analysis->getCompilation()->getRoot().topInstances |
                     std::views::transform([](const auto& top) { return top->name; });
     ctx.info("Analyzed {} with tops: {}", getWsRelativePath(), fmt::join(topNames, ", "));

--- a/src/document/SyntaxIndexer.cpp
+++ b/src/document/SyntaxIndexer.cpp
@@ -59,6 +59,12 @@ void SyntaxIndexer::visit(const slang::syntax::SyntaxNode& node) {
             collectedHints.emplace(static_cast<uint32_t>(node.getFirstToken().location().offset()),
                                    &node);
             break;
+        case syntax::SyntaxKind::ParameterDeclaration:
+            if (node.getFirstToken().location().buffer() == m_buffer) {
+                collectedHints.emplace(
+                    static_cast<uint32_t>(node.getFirstToken().location().offset()), &node);
+            }
+            break;
         default:
             break;
     }

--- a/src/util/Formatting.cpp
+++ b/src/util/Formatting.cpp
@@ -623,6 +623,12 @@ bool isValidUtf8(std::string_view s) {
 }
 
 std::string formatConstantValue(const ConstantValue& value) {
+    if (value.isInteger()) {
+        const auto& integer = value.integer();
+        if (integer.getBitWidth() == 1 && !integer.hasUnknown())
+            return value.isTrue() ? "1" : "0";
+    }
+
     if (value.isString()) {
         const auto& str = value.str();
         if (isValidUtf8(str)) {
@@ -634,7 +640,7 @@ std::string formatConstantValue(const ConstantValue& value) {
             return escapeInvalidUtf8(str);
         }
     }
-    // For non-string values, use default toString
+    // For other values, use default toString
     return value.toString();
 }
 

--- a/tests/cpp/ActiveInstanceTests.cpp
+++ b/tests/cpp/ActiveInstanceTests.cpp
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "utils/ServerHarness.h"
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+TEST_CASE("EditingDocumentsPreservesActiveInstanceHover") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto doc = server.openFile("logger.sv");
+    auto interfaceDoc = server.openFile("valid_data.sv");
+    auto valueParameter = doc.before("width,");
+    auto typeParameter = doc.before("data_t\n");
+    auto signal = doc.before("typed_data;");
+    auto interfaceWidth = doc.after("data_bus.");
+    auto interfacePort = doc.before("data_bus\n");
+    auto interfaceValueParameter = interfaceDoc.before("width = 1");
+    auto interfaceTypeParameter = interfaceDoc.before("payload_t = logic");
+    auto getHoverContent = [&](const Cursor& cursor) {
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        return rfl::get<lsp::MarkupContent>(hover->contents).value;
+    };
+    auto getInterfaceHoverContent = [&](const Cursor& cursor) {
+        auto hover = interfaceDoc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        return rfl::get<lsp::MarkupContent>(hover->contents).value;
+    };
+
+    REQUIRE(server.setActiveInstance("top.tap8"));
+    doc.append("\n");
+    doc.publishChanges();
+
+    CHECK(getHoverContent(valueParameter).find("Value: `8`") != std::string::npos);
+    CHECK(getHoverContent(typeParameter).find("Value: `byte`") != std::string::npos);
+    auto signalHover = getHoverContent(signal);
+    CHECK(signalHover.find("Width: `8`") != std::string::npos);
+    CHECK(signalHover.find("Driven by continuous assignment") != std::string::npos);
+    CHECK(getHoverContent(interfaceWidth).find("Value: `8`") != std::string::npos);
+    CHECK(getHoverContent(interfacePort).find("Connected to [`top.bus8`](<file:") !=
+          std::string::npos);
+
+    auto signalInfo = doc.getDefinitionInfoAt(signal.m_offset);
+    REQUIRE(signalInfo);
+    auto* signalTarget = std::get_if<server::DefinitionInfo::SymbolTarget>(
+        &signalInfo->primaryTarget());
+    REQUIRE(signalTarget);
+    CHECK(signalTarget->symbol->getHierarchicalPath() == "top.tap8.typed_data");
+
+    REQUIRE(server.setActiveInstance("top.wrapper8.tap.data_bus"));
+    auto forwardedPortHover = getHoverContent(interfacePort);
+    auto connectionSummary = forwardedPortHover.find("Connected to ");
+    REQUIRE(connectionSummary != std::string::npos);
+    CHECK(forwardedPortHover.find("Connected to ", connectionSummary + 1) == std::string::npos);
+
+    interfaceDoc.append("\n");
+    interfaceDoc.publishChanges();
+
+    CHECK(getInterfaceHoverContent(interfaceValueParameter).find("Value: `8`") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceTypeParameter).find("Value: `byte`") !=
+          std::string::npos);
+}
+
+TEST_CASE("InlayHintsShowActiveInstanceParameterValues") {
+    ServerHarness server("active_instance_hover");
+    server.setBuildFile("design.f");
+
+    auto doc = server.openFile("leaf.sv");
+    auto checkValues = [&](std::string_view instancePath, std::string_view width,
+                           std::string_view enabled, std::string_view doubleWidth) {
+        REQUIRE(server.setActiveInstance(std::string(instancePath)));
+        auto hints = doc.getAllInlayHints();
+        REQUIRE(hints.size() == 3);
+        CHECK(rfl::get<std::string>(hints[0].label) == width);
+        CHECK(rfl::get<std::string>(hints[1].label) == enabled);
+        CHECK(rfl::get<std::string>(hints[2].label) == doubleWidth);
+        CHECK(hints[0].position == doc.after("parameter int WIDTH").getPosition());
+        CHECK(hints[1].position == doc.after("parameter bit ENABLED").getPosition());
+        CHECK(hints[2].position == doc.after("localparam int DOUBLE_WIDTH").getPosition());
+    };
+
+    checkValues("top.leaf8", "8", "0", "16");
+    checkValues("top.leaf16", "16", "1", "32");
+
+    doc.append("\n");
+    doc.publishChanges();
+    checkValues("top.leaf8", "8", "0", "16");
+}
+
+TEST_CASE("GotoDefinitionSelectsReferencedActiveInstance") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto declarations = server.openFile("logger.sv");
+    auto top = server.openFile("top.sv");
+    auto moduleDeclaration = declarations.after("module ");
+    auto parameterDeclaration = declarations.after("parameter int ");
+    auto portDeclaration = declarations.before("data_in,");
+
+    auto checkGoto = [&](Cursor reference, const Cursor& declaration,
+                         std::optional<std::string_view> expectedDesignPath = std::nullopt) {
+        REQUIRE(server.setActiveInstance("top.tap16"));
+
+        auto definitions = reference.getDefinitions();
+        CHECK(std::ranges::any_of(definitions, [&](const auto& definition) {
+            return definition.targetUri == declaration.getUri() &&
+                   definition.targetSelectionRange.start == declaration.getPosition();
+        }));
+
+        REQUIRE_FALSE(server.client.m_activeInstanceChanges.empty());
+        auto changed = server.client.m_activeInstanceChanges.front();
+        server.client.m_activeInstanceChanges.pop_front();
+        CHECK(changed.hierPath == "top.tap8");
+        CHECK(changed.interactionSource == SlangLspClient::InteractionSource::editor);
+
+        auto active = server.getActiveInstance("StageTap");
+        REQUIRE(active);
+        CHECK(active->instPath == "top.tap8");
+
+        if (expectedDesignPath) {
+            auto info = reference.m_doc.getDefinitionInfoAt(reference.m_offset);
+            REQUIRE(info);
+            REQUIRE(info->symbol());
+            CHECK(info->symbol()->getHierarchicalPath() == *expectedDesignPath);
+        }
+    };
+
+    auto tap8Module = top.before("StageTap #(.width(8)");
+    checkGoto(tap8Module, moduleDeclaration);
+    checkGoto(tap8Module.after("#(."), parameterDeclaration, "top.tap8.width");
+    checkGoto(top.after("tap8(\n        ."), portDeclaration, "top.tap8.data_in");
+}
+
+TEST_CASE("ActivateInstanceCommandNotifiesClientAndOnlyGotoOpensEditor") {
+    ServerHarness server("active_instance_hover");
+    server.setBuildFile("design.f");
+
+    auto activate = [&](std::string hierPath, SlangLspClient::InteractionSource source) {
+        auto params = SlangLspClient::ActivateInstanceParams{
+            .hierPath = std::move(hierPath),
+            .interactionSource = source,
+        };
+        auto result = server.executeCommand({
+            .command = "slang.activateInstance",
+            .arguments = std::vector<lsp::LSPAny>{rfl::to_generic<rfl::UnderlyingEnums>(params)},
+        });
+        REQUIRE(result);
+        auto activated = rfl::from_generic<bool>(*result);
+        REQUIRE(activated);
+        CHECK(*activated);
+        return params;
+    };
+
+    auto selected = activate("top.leaf16", SlangLspClient::InteractionSource::codeLensSelect);
+    auto active = server.getActiveInstance("leaf");
+    REQUIRE(active);
+    CHECK(active->instPath == "top.leaf16");
+    REQUIRE(server.client.m_activeInstanceChanges.size() == 1);
+    CHECK(server.client.m_activeInstanceChanges.front().hierPath == selected.hierPath);
+    CHECK(server.client.m_activeInstanceChanges.front().interactionSource ==
+          selected.interactionSource);
+    CHECK(server.client.m_showDocuments.empty());
+
+    auto opened = activate("top.leaf8",
+                           SlangLspClient::InteractionSource::codeLensGotoInstantiation);
+    active = server.getActiveInstance("leaf");
+    REQUIRE(active);
+    CHECK(active->instPath == "top.leaf8");
+    REQUIRE(server.client.m_activeInstanceChanges.size() == 2);
+    CHECK(server.client.m_activeInstanceChanges.back().hierPath == opened.hierPath);
+    CHECK(server.client.m_activeInstanceChanges.back().interactionSource ==
+          opened.interactionSource);
+    REQUIRE(server.client.m_showDocuments.size() == 1);
+    CHECK(server.client.m_showDocuments.front().takeFocus);
+}
+
+TEST_CASE("RefreshDropsMissingActiveInstance") {
+    ServerHarness server("active_instance_hover");
+    server.setBuildFile("design.f");
+
+    auto top = server.openFile("top.sv");
+    REQUIRE(server.setActiveInstance("top.leaf16"));
+
+    top.replaceAll(R"(
+module top;
+    leaf #(.WIDTH(8), .ENABLED(1'b0)) leaf8();
+endmodule
+)");
+    top.save();
+
+    auto active = server.getActiveInstance("leaf");
+    REQUIRE(active);
+    CHECK(active->instPath == "top.leaf8");
+}

--- a/tests/cpp/CodeLensTests.cpp
+++ b/tests/cpp/CodeLensTests.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+
+#include "SlangLspClient.h"
+#include "lsp/LspTypes.h"
+#include "utils/ServerHarness.h"
+#include <ranges>
+#include <vector>
+
+using namespace server;
+
+TEST_CASE("CodeLensModuleActiveInstance") {
+    ServerHarness server("comp_repo");
+    server.setBuildFile("cpu_design.f");
+
+    auto hdl = server.openFile("cpu.sv");
+    auto activeInstance = server.getActiveInstance("cpu");
+    REQUIRE(activeInstance);
+
+    auto lenses = server.getDocCodeLens(lsp::CodeLensParams{
+        .textDocument = lsp::TextDocumentIdentifier{.uri = hdl.m_uri},
+    });
+    REQUIRE(lenses);
+
+    auto expectedTitle = activeInstance->instPath + " (1)";
+    bool found = false;
+    for (const auto& lens : *lenses) {
+        if (!lens.command || lens.command->title != expectedTitle) {
+            continue;
+        }
+
+        CHECK(lens.command->title == expectedTitle);
+        CHECK(lens.command->command == "slang.showInHierarchy");
+        REQUIRE(lens.command->arguments);
+        REQUIRE(lens.command->arguments->size() == 1);
+        auto params =
+            rfl::from_generic<SlangLspClient::ActivateInstanceParams, rfl::UnderlyingEnums>(
+                lens.command->arguments->at(0));
+        REQUIRE(params);
+        CHECK(params->interactionSource == SlangLspClient::InteractionSource::codeLensSelect);
+        CHECK(params->hierPath == activeInstance->instPath);
+        found = true;
+        break;
+    }
+
+    CHECK(found);
+}
+
+TEST_CASE("CodeLensModuleDefaultsToFirstInstance") {
+    ServerHarness server("active_instance_hover");
+    server.setBuildFile("design.f");
+
+    auto hdl = server.openFile("leaf.sv");
+
+    auto lenses = server.getDocCodeLens(lsp::CodeLensParams{
+        .textDocument = lsp::TextDocumentIdentifier{.uri = hdl.m_uri},
+    });
+    REQUIRE(lenses);
+
+    bool found = false;
+    for (const auto& lens : *lenses) {
+        if (!lens.command || lens.command->title != "top.leaf8 (2)") {
+            continue;
+        }
+
+        CHECK(lens.command->title == "top.leaf8 (2)");
+        CHECK(lens.command->command == "slang.quickPick");
+        REQUIRE(lens.command->arguments);
+        REQUIRE(lens.command->arguments->size() == 1);
+        auto params = rfl::from_generic<SlangLspClient::QuickPickParams>(
+            lens.command->arguments->at(0));
+        REQUIRE(params);
+        CHECK(params->onSelectCommand == "slang.activateInstance");
+        CHECK(params->placeholder == "Select active instance for leaf");
+        REQUIRE(params->items.size() == 2);
+        CHECK(params->items[0].label == "top.leaf8");
+        CHECK(params->items[0].description == "(current)");
+        CHECK(params->items[1].label == "top.leaf16");
+        CHECK_FALSE(params->items[1].description);
+        found = true;
+        break;
+    }
+
+    CHECK(found);
+}
+
+TEST_CASE("CodeLensModuleGoToInstantiation") {
+    ServerHarness server("active_instance_hover");
+    server.setBuildFile("design.f");
+
+    auto hdl = server.openFile("leaf.sv");
+
+    auto lenses = server.getDocCodeLens(lsp::CodeLensParams{
+        .textDocument = lsp::TextDocumentIdentifier{.uri = hdl.m_uri},
+    });
+    REQUIRE(lenses);
+
+    bool found = false;
+    for (const auto& lens : *lenses) {
+        if (!lens.command || lens.command->title != "Go to Instantiation") {
+            continue;
+        }
+
+        CHECK(lens.command->command == "slang.activateInstance");
+        REQUIRE(lens.command->arguments);
+        REQUIRE(lens.command->arguments->size() == 1);
+        auto params =
+            rfl::from_generic<SlangLspClient::ActivateInstanceParams, rfl::UnderlyingEnums>(
+                lens.command->arguments->at(0));
+        REQUIRE(params);
+        CHECK(params->hierPath == "top.leaf8");
+        CHECK(params->interactionSource ==
+              SlangLspClient::InteractionSource::codeLensGotoInstantiation);
+        found = true;
+        break;
+    }
+
+    CHECK(found);
+}
+
+TEST_CASE("CodeLensInterfaceSelectionUpdatesGoToInstantiation") {
+    ServerHarness server("active_interface_codelens");
+    server.setBuildFile("design.f");
+
+    auto hdl = server.openFile("bus.sv");
+    auto getLenses = [&] {
+        auto lenses = server.getDocCodeLens(lsp::CodeLensParams{
+            .textDocument = lsp::TextDocumentIdentifier{.uri = hdl.m_uri},
+        });
+        REQUIRE(lenses);
+        return *lenses;
+    };
+
+    auto lenses = getLenses();
+    auto selectLens = std::ranges::find_if(lenses, [](const auto& lens) {
+        return lens.command && lens.command->command == "slang.quickPick";
+    });
+    REQUIRE(selectLens != lenses.end());
+    REQUIRE(selectLens->command->arguments);
+    auto quickPick = rfl::from_generic<SlangLspClient::QuickPickParams>(
+        selectLens->command->arguments->at(0));
+    REQUIRE(quickPick);
+
+    auto selected = std::ranges::find(quickPick->items, "top.holder.selected",
+                                      &SlangLspClient::QuickPickItem::label);
+    REQUIRE(selected != quickPick->items.end());
+    auto activated = server.executeCommand({
+        .command = quickPick->onSelectCommand,
+        .arguments = std::vector<lsp::LSPAny>{selected->value},
+    });
+    REQUIRE(activated);
+    auto activationResult = rfl::from_generic<bool>(*activated);
+    REQUIRE(activationResult);
+    CHECK(*activationResult);
+
+    auto active = server.getActiveInstance("StreamBus");
+    REQUIRE(active);
+    CHECK(active->instPath == "top.holder.selected");
+
+    lenses = getLenses();
+    auto gotoLens = std::ranges::find_if(lenses, [](const auto& lens) {
+        return lens.command && lens.command->title == "Go to Instantiation";
+    });
+    REQUIRE(gotoLens != lenses.end());
+    REQUIRE(gotoLens->command->arguments);
+    auto gotoParams =
+        rfl::from_generic<SlangLspClient::ActivateInstanceParams, rfl::UnderlyingEnums>(
+            gotoLens->command->arguments->at(0));
+    REQUIRE(gotoParams);
+    CHECK(gotoParams->hierPath == "top.holder.selected");
+}
+
+TEST_CASE("ActiveInstanceTracksGenerateScope") {
+    ServerHarness server("active_instance_hover");
+    server.setBuildFile("design.f");
+
+    REQUIRE(server.setActiveInstance("top.leaf16.lanes[1].lane"));
+
+    auto generatedLeaf = server.getActiveInstance("generated_leaf");
+    REQUIRE(generatedLeaf);
+    CHECK(generatedLeaf->instPath == "top.leaf16.lanes[1].lane");
+
+    auto leaf = server.getActiveInstance("leaf");
+    REQUIRE(leaf);
+    CHECK(leaf->instPath == "top.leaf16");
+
+    REQUIRE(server.setActiveInstance("top.leaf8.lanes[0]"));
+    leaf = server.getActiveInstance("leaf");
+    REQUIRE(leaf);
+    CHECK(leaf->instPath == "top.leaf8");
+}
+
+TEST_CASE("CodeLensGenerateLoopActiveIteration") {
+    ServerHarness server("active_instance_hover");
+    server.setBuildFile("design.f");
+    REQUIRE(server.setActiveInstance("top.leaf16.lanes[1]"));
+    REQUIRE(server.setActiveInstance("top.leaf16.channels[2]"));
+
+    auto hdl = server.openFile("leaf.sv");
+    auto lenses = server.getDocCodeLens(lsp::CodeLensParams{
+        .textDocument = lsp::TextDocumentIdentifier{.uri = hdl.m_uri},
+    });
+    REQUIRE(lenses);
+
+    auto lens = std::ranges::find_if(*lenses, [](const auto& candidate) {
+        return candidate.command && candidate.command->title == "top.leaf16.lanes[1]";
+    });
+    REQUIRE(lens != lenses->end());
+    CHECK(lens->command->title == "top.leaf16.lanes[1]");
+    REQUIRE(lens->command->arguments);
+    REQUIRE(lens->command->arguments->size() == 1);
+
+    auto params = rfl::from_generic<SlangLspClient::QuickPickParams>(
+        lens->command->arguments->at(0));
+    REQUIRE(params);
+    CHECK(params->onSelectCommand == "slang.activateInstance");
+    CHECK(params->interactionSource == SlangLspClient::InteractionSource::codeLensSelect);
+    REQUIRE(params->items.size() == 2);
+    CHECK(params->items[0].label == "top.leaf16.lanes[0]");
+    CHECK_FALSE(params->items[0].description);
+    CHECK(params->items[1].label == "top.leaf16.lanes[1]");
+    CHECK(params->items[1].description == "(current)");
+    auto selectedValue =
+        rfl::from_generic<SlangLspClient::ActivateInstanceParams, rfl::UnderlyingEnums>(
+            params->items[1].value);
+    REQUIRE(selectedValue);
+    CHECK(selectedValue->hierPath == "top.leaf16.lanes[1]");
+    CHECK(selectedValue->interactionSource == SlangLspClient::InteractionSource::codeLensSelect);
+
+    auto siblingLens = std::ranges::find_if(*lenses, [](const auto& candidate) {
+        return candidate.command && candidate.command->title == "top.leaf16.channels[2]";
+    });
+    REQUIRE(siblingLens != lenses->end());
+    CHECK(siblingLens->command->command == "slang.quickPick");
+}

--- a/tests/cpp/FormattingTests.cpp
+++ b/tests/cpp/FormattingTests.cpp
@@ -1,10 +1,20 @@
 #include "util/Formatting.h"
 #include <catch2/catch_test_macros.hpp>
 
+#include "slang/numeric/ConstantValue.h"
+
 using namespace server;
 
 TEST_CASE("ToCamelCase") {
     CHECK(toCamelCase("THEUPPERCASEMODULE") == "theuppercasemodule");
     CHECK(toCamelCase("UpperThenMoreUpper") == "upperThenMoreUpper");
     CHECK(toCamelCase("SOMEUpperCase") == "someUpperCase");
+}
+
+TEST_CASE("FormatScalarBitValues") {
+    CHECK(formatConstantValue(slang::ConstantValue(slang::SVInt(1, 0, false))) == "0");
+    CHECK(formatConstantValue(slang::ConstantValue(slang::SVInt(1, 1, false))) == "1");
+    CHECK(formatConstantValue(slang::ConstantValue(slang::SVInt(slang::logic_t::x))) == "1'bx");
+    CHECK(formatConstantValue(slang::ConstantValue(slang::SVInt(slang::logic_t::z))) == "1'bz");
+    CHECK(formatConstantValue(slang::ConstantValue(slang::SVInt(2, 1, false))) == "2'b1");
 }

--- a/tests/cpp/HierarchyTests.cpp
+++ b/tests/cpp/HierarchyTests.cpp
@@ -297,6 +297,25 @@ TEST_CASE("GetInstancesOfModule") {
     golden.record("cpu_instances", cpuInstances);
 }
 
+TEST_CASE("OpenModuleDefinitionOnlyWhenClosed") {
+    ServerHarness server("comp_repo");
+    server.setBuildFile("cpu_design.f");
+
+    server.openModuleDefinition("alu");
+
+    REQUIRE(server.client.m_showDocuments.size() == 1);
+    REQUIRE(server.client.m_showDocuments.front().takeFocus);
+    CHECK_FALSE(*server.client.m_showDocuments.front().takeFocus);
+    auto shownUri = server.client.m_showDocuments.front().uri;
+    server.client.m_showDocuments.clear();
+
+    auto module = server.openFile("alu.sv");
+    CHECK(shownUri == module.m_uri);
+
+    server.openModuleDefinition("alu");
+    CHECK(server.client.m_showDocuments.empty());
+}
+
 TEST_CASE("GetModulesInFile") {
     ServerHarness server("comp_repo");
     JsonGoldenTest golden;

--- a/tests/cpp/HierarchyTests.cpp
+++ b/tests/cpp/HierarchyTests.cpp
@@ -56,6 +56,87 @@ TEST_CASE("GetScopeNested") {
     golden.record("mem_ctrl_scope", memCtrlScope);
 }
 
+TEST_CASE("GetScopesCommandHonorsRequestCancellation") {
+    ServerHarness server("comp_repo");
+    server.setBuildFile("cpu_design.f");
+
+    lsp::RequestContext ctx("workspace/executeCommand", lsp::ID_t{1});
+    ctx.cancel();
+    CHECK_THROWS_AS(server.executeCommand(
+                        {
+                            .command = "slang.getScopes",
+                            .arguments = std::vector<lsp::LSPAny>{rfl::to_generic(
+                                std::string("cpu_testbench.dut.alu_inst"))},
+                        },
+                        ctx),
+                    lsp::RequestCancelled);
+}
+
+TEST_CASE("SearchHierarchyMembers") {
+    ServerHarness server("comp_repo");
+    server.setBuildFile("cpu_design.f");
+
+    auto containsPath = [](const hier::HierarchySearchResult& result, std::string_view path) {
+        return std::ranges::any_of(result.matches,
+                                   [&](const auto& item) { return item.path == path; });
+    };
+
+    auto instances = server.m_driver->comp->searchHierarchy("ALU_INST");
+    CHECK(containsPath(instances, "cpu_testbench.dut.alu_inst"));
+
+    auto signals = server.m_driver->comp->searchHierarchy("instruction");
+    CHECK(containsPath(signals, "cpu_testbench.dut.instruction"));
+    auto instruction = std::ranges::find(signals.matches, "cpu_testbench.dut.instruction",
+                                         &hier::HierarchySearchItem::path);
+    REQUIRE(instruction != signals.matches.end());
+    CHECK(instruction->containerName == "cpu");
+
+    auto parameters = server.m_driver->comp->searchHierarchy("data_width");
+    CHECK(containsPath(parameters, "cpu_testbench.dut.DATA_WIDTH"));
+
+    auto generateScopes = server.m_driver->comp->searchHierarchy("gen_alu_array[1]");
+    CHECK(containsPath(generateScopes, "cpu_testbench.dut.gen_alu_array[1]"));
+
+    auto generatedSignals = server.m_driver->comp->searchHierarchy("gen_alu_result");
+    auto generatedSignal = std::ranges::find(generatedSignals.matches,
+                                             "cpu_testbench.dut.gen_alu_array[1].gen_alu_result",
+                                             &hier::HierarchySearchItem::path);
+    REQUIRE(generatedSignal != generatedSignals.matches.end());
+    CHECK(generatedSignal->containerName == "cpu.gen_alu_array[1]");
+
+    auto empty = server.m_driver->comp->searchHierarchy("");
+    CHECK(empty.totalResults > 0);
+    CHECK(empty.matches.size() <= 100);
+}
+
+TEST_CASE("SearchHierarchyIncludesInterfacePortMembers") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto result = server.m_driver->comp->searchHierarchy("tap8.data_bus.payload");
+    CHECK(std::ranges::any_of(result.matches, [](const auto& item) {
+        return item.path == "top.tap8.data_bus.payload";
+    }));
+}
+
+TEST_CASE("SearchHierarchyCapsTransferredMatches") {
+    ServerHarness server;
+    std::string source = "module top;\n";
+    for (int i = 0; i < 150; i++)
+        source += "logic signal_" + std::to_string(i) + ";\n";
+    source += "endmodule\n";
+
+    auto doc = server.openFile("hierarchy_search_limit.sv", source);
+    server.setTopLevel(std::string(doc.m_uri.getPath()));
+
+    auto result = server.m_driver->comp->searchHierarchy("signal");
+    CHECK(result.totalResults == 150);
+    CHECK(result.matches.size() == 100);
+    CHECK(std::ranges::all_of(result.matches, [](const auto& item) {
+        return item.kind == hier::SlangKind::Logic;
+    }));
+}
+
 TEST_CASE("GetScopeBranches") {
     ServerHarness server("comp_repo");
     JsonGoldenTest golden;

--- a/tests/cpp/HoverTests.cpp
+++ b/tests/cpp/HoverTests.cpp
@@ -931,6 +931,192 @@ endmodule
     CHECK(content.value.find("/// another line") != std::string::npos);
 }
 
+TEST_CASE("HoverConnectedInterfaceParametersUseActiveInstance") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto doc = server.openFile("logger.sv");
+    auto interfaceDoc = server.openFile("valid_data.sv");
+    auto topDoc = server.openFile("top.sv");
+    auto payload = doc.before("payload);");
+    auto typedPayload = doc.before("typed_payload);");
+    auto interfaceWidth = doc.after("data_bus.");
+    auto interfacePort = doc.before("data_bus\n");
+    auto interfaceWidthDeclaration = interfaceDoc.before("width = 1");
+    auto interfaceTypeDeclaration = interfaceDoc.before("payload_t = logic");
+    auto forwardedPort = topDoc.before("data_bus\n");
+    auto connectedInstance = topDoc.before("bus8();");
+    auto selectedForwardedPort = topDoc.before("bundle\n");
+    auto selectedInstance = topDoc.before("nested_bus();");
+    auto getInterfaceHoverContent = [&](const Cursor& cursor) {
+        auto hover = interfaceDoc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        return rfl::get<lsp::MarkupContent>(hover->contents).value;
+    };
+    auto getHoverContent = [&](const Cursor& cursor) {
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        return rfl::get<lsp::MarkupContent>(hover->contents).value;
+    };
+
+    REQUIRE(server.setActiveInstance("top.tap8"));
+    CHECK(getHoverContent(payload).find("Width: `8`") != std::string::npos);
+    CHECK(getHoverContent(typedPayload).find("Width: `8`") != std::string::npos);
+    CHECK(getHoverContent(interfaceWidth).find("Value: `8`") != std::string::npos);
+    CHECK(getHoverContent(interfacePort).find("Connected to [`top.bus8`](<file:") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceWidthDeclaration).find("Value: `8`") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceTypeDeclaration).find("Value: `byte`") !=
+          std::string::npos);
+
+    REQUIRE(server.setActiveInstance("top.tap16"));
+    CHECK(getHoverContent(payload).find("Width: `16`") != std::string::npos);
+    CHECK(getHoverContent(typedPayload).find("Width: `64`") != std::string::npos);
+    CHECK(getHoverContent(interfaceWidth).find("Value: `16`") != std::string::npos);
+    CHECK(getHoverContent(interfacePort).find("Connected to [`top.bus16`](<file:") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceWidthDeclaration).find("Value: `16`") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceTypeDeclaration).find("Value: `longint`") !=
+          std::string::npos);
+
+    REQUIRE(server.setActiveInstance("top.wrapper8.tap.data_bus"));
+    CHECK(getHoverContent(interfacePort).find("Connected to [`top.bus8`](<file:") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceWidthDeclaration).find("Value: `8`") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceTypeDeclaration).find("Value: `byte`") !=
+          std::string::npos);
+
+    auto definitions = interfacePort.getDefinitions();
+    CHECK(definitions.size() == 3);
+    auto hasDefinition = [&](const Cursor& expected) {
+        return std::ranges::any_of(definitions, [&](const auto& definition) {
+            return definition.targetUri == expected.getUri() &&
+                   definition.targetSelectionRange.start == expected.getPosition();
+        });
+    };
+    CHECK(hasDefinition(interfacePort));
+    CHECK(hasDefinition(forwardedPort));
+    CHECK(hasDefinition(connectedInstance));
+
+    REQUIRE(server.setActiveInstance("top.selected_wrapper.selected_tap.data_bus"));
+    CHECK(getHoverContent(interfacePort).find("Connected to [`top.bundle.nested_bus`](<file:") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceWidthDeclaration).find("Value: `16`") !=
+          std::string::npos);
+    CHECK(getInterfaceHoverContent(interfaceTypeDeclaration).find("Value: `longint`") !=
+          std::string::npos);
+
+    definitions = interfacePort.getDefinitions();
+    CHECK(definitions.size() == 3);
+    CHECK(hasDefinition(interfacePort));
+    CHECK(hasDefinition(selectedForwardedPort));
+    CHECK(hasDefinition(selectedInstance));
+}
+
+TEST_CASE("HoverAndGotoActiveInterfaceArrayConnection") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto doc = server.openFile("logger.sv");
+    auto topDoc = server.openFile("top.sv");
+    auto interfacePort = doc.before("buses[2]");
+    auto connectedArray = topDoc.before("bus_array[2]");
+
+    REQUIRE(server.setActiveInstance("top.array_tap"));
+    auto hover = doc.getHoverAt(interfacePort.m_offset);
+    REQUIRE(hover);
+    auto content = rfl::get<lsp::MarkupContent>(hover->contents).value;
+    CHECK(content.find("Connected to [`top.bus_array`](<file:") != std::string::npos);
+
+    auto definitions = interfacePort.getDefinitions();
+    REQUIRE(definitions.size() == 2);
+    auto hasDefinition = [&](const Cursor& expected) {
+        return std::ranges::any_of(definitions, [&](const auto& definition) {
+            return definition.targetUri == expected.getUri() &&
+                   definition.targetSelectionRange.start == expected.getPosition();
+        });
+    };
+    CHECK(hasDefinition(interfacePort));
+    CHECK(hasDefinition(connectedArray));
+}
+
+TEST_CASE("HoverParameterValueUsesActiveInstance") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto doc = server.openFile("logger.sv");
+    auto cursor = doc.before("width,");
+    auto getHoverContent = [&]() {
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        return rfl::get<lsp::MarkupContent>(hover->contents).value;
+    };
+
+    REQUIRE(server.setActiveInstance("top.tap8"));
+    auto tap8Hover = getHoverContent();
+    CHECK(countSubstring(tap8Hover, "Value: `8`") == 1);
+    CHECK(tap8Hover.find("Value: `16`") == std::string::npos);
+
+    REQUIRE(server.setActiveInstance("top.tap16"));
+    auto tap16Hover = getHoverContent();
+    CHECK(countSubstring(tap16Hover, "Value: `16`") == 1);
+    CHECK(tap16Hover.find("Value: `8`") == std::string::npos);
+}
+
+TEST_CASE("SavingDesignRefreshesActiveInstanceHover") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto doc = server.openFile("logger.sv");
+    auto top = server.openFile("top.sv");
+    auto cursor = doc.before("width,");
+    auto getHoverContent = [&]() {
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        return rfl::get<lsp::MarkupContent>(hover->contents).value;
+    };
+
+    REQUIRE(server.setActiveInstance("top.tap8"));
+    CHECK(getHoverContent().find("Value: `8`") != std::string::npos);
+
+    auto tap = top.getText().find("StageTap #(.width(8)");
+    REQUIRE(tap != std::string::npos);
+    auto width = top.getText().find('8', tap);
+    REQUIRE(width != std::string::npos);
+    top.erase(width, width + 1);
+    top.insert(width, "12");
+    top.save();
+
+    auto refreshedHover = getHoverContent();
+    CHECK(refreshedHover.find("Value: `12`") != std::string::npos);
+    CHECK(refreshedHover.find("Value: `8`") == std::string::npos);
+}
+
+TEST_CASE("HoverTypeParameterAndDependentSignalUseActiveInstance") {
+    ServerHarness server("active_interface_port_hover");
+    server.setBuildFile("design.f");
+
+    auto doc = server.openFile("logger.sv");
+    auto typeParameter = doc.before("data_t\n");
+    auto signal = doc.before("typed_data;");
+    auto getHoverContent = [&](const Cursor& cursor) {
+        auto hover = doc.getHoverAt(cursor.m_offset);
+        REQUIRE(hover);
+        return rfl::get<lsp::MarkupContent>(hover->contents).value;
+    };
+
+    REQUIRE(server.setActiveInstance("top.tap8"));
+    CHECK(getHoverContent(typeParameter).find("Value: `byte`") != std::string::npos);
+    CHECK(getHoverContent(signal).find("Width: `8`") != std::string::npos);
+
+    REQUIRE(server.setActiveInstance("top.tap16"));
+    CHECK(getHoverContent(typeParameter).find("Value: `int`") != std::string::npos);
+    CHECK(getHoverContent(signal).find("Width: `32`") != std::string::npos);
+}
+
 TEST_CASE("HoverSystemTask") {
     ServerHarness server;
     GoldenTest golden;

--- a/tests/cpp/golden/FindSymbolRefHdl.out
+++ b/tests/cpp/golden/FindSymbolRefHdl.out
@@ -770,7 +770,7 @@ module NoDefaults #(
 
 
     if (gen_branch) begin : gen_branch_block
-        ^^^^^^^^^^ Ref -> **Parameter** `gen_branch` in `NoDefaults`  \n\Type: `bit`  \n\Value: `1'b0`  \n\\n\\n\---\n\\n\`parameter bit gen_branch = 0`
+        ^^^^^^^^^^ Ref -> **Parameter** `gen_branch` in `NoDefaults`  \n\Type: `bit`  \n\Value: `0`  \n\\n\\n\---\n\\n\`parameter bit gen_branch = 0`
                             ^^^^^^^^^^^^^^^^ Sym gen_branch_block : GenerateBlock
 
         Sub #(

--- a/tests/cpp/golden/GetScopeBranches.json
+++ b/tests/cpp/golden/GetScopeBranches.json
@@ -18,7 +18,7 @@
           }
         },
         "type": "bit",
-        "value": "1'b1"
+        "value": "1"
       },
       {
         "kind": "Scope",

--- a/tests/cpp/utils/ClientHarness.h
+++ b/tests/cpp/utils/ClientHarness.h
@@ -75,10 +75,15 @@ public:
     }
 
     std::deque<lsp::ShowDocumentParams> m_showDocuments;
+    std::deque<ActivateInstanceParams> m_activeInstanceChanges;
 
     void onShowDocument(const lsp::ShowDocumentParams& params) final {
         m_showDocuments.push_back(params);
         // TODO -- ServerHarness::openFile() once the client and server harnesses are merged
+    }
+
+    void onActiveInstanceChanged(const ActivateInstanceParams& params) final {
+        m_activeInstanceChanges.push_back(params);
     }
 
 private:

--- a/tests/cpp/utils/ServerHarness.h
+++ b/tests/cpp/utils/ServerHarness.h
@@ -91,6 +91,11 @@ public:
     void checkConeCommand(const std::string& command, const std::string& path,
                           const std::set<ExpectedConeResult>& expected);
 
+    std::optional<lsp::LSPAny> executeCommand(const lsp::ExecuteCommandParams& params,
+                                              const lsp::RequestContext& ctx = {}) {
+        return getWorkspaceExecuteCommand(params, ctx);
+    }
+
     std::shared_ptr<server::SlangDoc> getDoc(const URI& uri);
 
     // Wrapper for getModulesInFile that handles relative paths

--- a/tests/data/active_instance_hover/design.f
+++ b/tests/data/active_instance_hover/design.f
@@ -1,0 +1,3 @@
+generated_leaf.sv
+leaf.sv
+top.sv

--- a/tests/data/active_instance_hover/generated_leaf.sv
+++ b/tests/data/active_instance_hover/generated_leaf.sv
@@ -1,0 +1,2 @@
+module generated_leaf;
+endmodule

--- a/tests/data/active_instance_hover/leaf.sv
+++ b/tests/data/active_instance_hover/leaf.sv
@@ -1,0 +1,15 @@
+module leaf #(
+    parameter int WIDTH = 1,
+    parameter bit ENABLED = 1'b0
+) ();
+    localparam int DOUBLE_WIDTH = WIDTH * 2;
+    logic [WIDTH-1:0] data;
+
+    for (genvar i = 0; i < 2; i++) begin : lanes
+        generated_leaf lane();
+    end
+
+    for (genvar j = 0; j < 3; j++) begin : channels
+        generated_leaf channel();
+    end
+endmodule

--- a/tests/data/active_instance_hover/top.sv
+++ b/tests/data/active_instance_hover/top.sv
@@ -1,0 +1,4 @@
+module top;
+    leaf #(.WIDTH(8), .ENABLED(1'b0)) leaf8();
+    leaf #(.WIDTH(16), .ENABLED(1'b1)) leaf16();
+endmodule

--- a/tests/data/active_interface_codelens/bus.sv
+++ b/tests/data/active_interface_codelens/bus.sv
@@ -1,0 +1,2 @@
+interface StreamBus;
+endinterface

--- a/tests/data/active_interface_codelens/design.f
+++ b/tests/data/active_interface_codelens/design.f
@@ -1,0 +1,2 @@
+bus.sv
+top.sv

--- a/tests/data/active_interface_codelens/top.sv
+++ b/tests/data/active_interface_codelens/top.sv
@@ -1,0 +1,8 @@
+module BusHolder(StreamBus upstream);
+    StreamBus selected();
+endmodule
+
+module top;
+    StreamBus upstream();
+    BusHolder holder(.upstream);
+endmodule

--- a/tests/data/active_interface_port_hover/design.f
+++ b/tests/data/active_interface_port_hover/design.f
@@ -1,0 +1,3 @@
+valid_data.sv
+logger.sv
+top.sv

--- a/tests/data/active_interface_port_hover/logger.sv
+++ b/tests/data/active_interface_port_hover/logger.sv
@@ -1,0 +1,17 @@
+module StageTap #(
+    parameter int width,
+    parameter type data_t
+) (
+    input wire [width-1:0] data_in,
+    input wire data_clk,
+    StreamBus.source data_bus
+);
+    data_t typed_data;
+    assign typed_data = data_in;
+    localparam int interface_width = data_bus.width;
+    localparam int bus_width = $bits(data_bus.payload);
+    localparam int typed_bus_width = $bits(data_bus.typed_payload);
+endmodule
+
+module BusArrayTap(StreamBus.source buses[2]);
+endmodule

--- a/tests/data/active_interface_port_hover/top.sv
+++ b/tests/data/active_interface_port_hover/top.sv
@@ -1,0 +1,67 @@
+interface StreamBusBundle;
+    StreamBus #(.width(16), .payload_t(longint)) nested_bus();
+endinterface
+
+module StageTapWrapper #(
+    parameter int width,
+    parameter type data_t
+) (
+    input wire [width-1:0] data_in,
+    input wire data_clk,
+    StreamBus.source data_bus
+);
+    StageTap #(.width(width), .data_t(data_t)) tap(
+        .data_in,
+        .data_clk,
+        .data_bus(data_bus)
+    );
+endmodule
+
+module SelectedStageTapWrapper(
+    input wire [15:0] data_in,
+    input wire data_clk,
+    StreamBusBundle bundle
+);
+    StageTap #(.width(16), .data_t(longint)) selected_tap(
+        .data_in,
+        .data_clk,
+        .data_bus(bundle.nested_bus)
+    );
+endmodule
+
+module top;
+    logic [7:0] lane_data8;
+    logic [15:0] lane_data16;
+    logic lane_clk;
+
+    StreamBus #(.width(8), .payload_t(byte)) bus8();
+    StreamBus #(.width(16), .payload_t(longint)) bus16();
+    StreamBus #(.width(32), .payload_t(shortint)) bus_array[2]();
+    StreamBusBundle bundle();
+
+    StageTap #(.width(8), .data_t(byte)) tap8(
+        .data_in(lane_data8),
+        .data_clk(lane_clk),
+        .data_bus(bus8)
+    );
+
+    StageTap #(.width(16), .data_t(int)) tap16(
+        .data_in(lane_data16),
+        .data_clk(lane_clk),
+        .data_bus(bus16)
+    );
+
+    StageTapWrapper #(.width(8), .data_t(byte)) wrapper8(
+        .data_in(lane_data8),
+        .data_clk(lane_clk),
+        .data_bus(bus8)
+    );
+
+    SelectedStageTapWrapper selected_wrapper(
+        .data_in(lane_data16),
+        .data_clk(lane_clk),
+        .bundle(bundle)
+    );
+
+    BusArrayTap array_tap(.buses(bus_array));
+endmodule

--- a/tests/data/active_interface_port_hover/valid_data.sv
+++ b/tests/data/active_interface_port_hover/valid_data.sv
@@ -1,0 +1,8 @@
+interface StreamBus #(
+    parameter int width = 1,
+    parameter type payload_t = logic
+) ();
+    logic [width-1:0] payload;
+    payload_t typed_payload;
+    modport source(output payload, typed_payload);
+endinterface


### PR DESCRIPTION
- Hierarchy View
  - Show data by default now
  - Clicking sets the active instances for module up to the selection
- Modules View
  - Shows only the opened module's instances
  - Clicking now takes you to active instance; The 'file' button now takes you to the instantiation
- Adds codelenses for active instance to select, along with goto instantiation lens
- Switch to server-supported search that now includes arbitrary symbols, not just hierarchy
- Re-target symbols onto saved AST, showing params values, iface defs, etc from focused instance.
  - Show active parameter values as inlay hints
  - Gotodefs on iface ports go up the iface port chain to the instantiation
  - More work to be done here to make routes like goto def / refs apply for just the selected design