### PR TITLE
neovim: versioning.md checks

### DIFF
--- a/clients/neovim/ftplugin/systemverilog.lua
+++ b/clients/neovim/ftplugin/systemverilog.lua
@@ -1,5 +1,18 @@
 local _CMD = "SlangServer"
 
+-- Advertise this plugin's name and version to slang-server so it can warn on a
+-- version mismatch. This is additive to whatever the user (or nvim-lspconfig)
+-- already configured, and is a no-op if the client is already running.
+if vim.lsp.config then
+   vim.lsp.config("slang_server", {
+      capabilities = {
+         experimental = {
+            slangClient = require("slang-server._lsp.capabilities").client_info(),
+         },
+      },
+   })
+end
+
 local subcommands = {}
 subcommands = vim.tbl_deep_extend("error", subcommands, require("slang-server._commands.setTopLevel"))
 subcommands = vim.tbl_deep_extend("error", subcommands, require("slang-server._commands.setBuildFile"))

--- a/clients/neovim/lua/slang-server/_lsp/capabilities.lua
+++ b/clients/neovim/lua/slang-server/_lsp/capabilities.lua
@@ -1,31 +1,57 @@
 local M = {}
 
-M.MIN_SERVER_VERSION = "0.2.2"
+-- Identity advertised to the server through the `experimental.slangClient`
+-- initialization capability. The server warns when our major/minor version is
+-- older than its own; we warn when the server's is older than ours. Patch
+-- differences are ignored in both directions. See docs/development/versioning.md.
+M.CLIENT_NAME = "neovim-slang"
+M.CLIENT_VERSION = "0.2.1"
 
 local UPGRADE_HINT = "Please upgrade slang-server and possibly also this plugin."
 local SOURCE_FILETYPES = { "verilog", "systemverilog" }
 
+---Parse the major and minor components of a semantic version. Tolerates a
+---leading "v", a "+githash" build suffix, and surrounding whitespace, e.g.
+---the server's "0.2.10+0492171\n".
 ---@param v string
----@return integer, integer, integer
-local function parse_version(v)
-   v = vim.trim(v):match("^[^+]+") or v
-   local major, minor, patch = v:match("^(%d+)%.(%d+)%.(%d+)")
-   return tonumber(major) or 0, tonumber(minor) or 0, tonumber(patch) or 0
+---@return integer? major, integer? minor
+local function parse_major_minor(v)
+   v = vim.trim(v):gsub("^v", "")
+   local major, minor = v:match("^(%d+)%.(%d+)")
+   if not major then
+      return nil, nil
+   end
+   return tonumber(major), tonumber(minor)
 end
 
----@param have string
----@param want string
----@return boolean
-local function version_at_least(have, want)
-   local hM, hm, hp = parse_version(have)
-   local wM, wm, wp = parse_version(want)
+---@return boolean true when `have` is an older major/minor than `want`
+local function is_older_major_minor(have, want)
+   local hM, hm = parse_major_minor(have)
+   local wM, wm = parse_major_minor(want)
+   if not hM or not wM then
+      return false
+   end
    if hM ~= wM then
-      return hM > wM
+      return hM < wM
    end
-   if hm ~= wm then
-      return hm > wm
-   end
-   return hp >= wp
+   return hm < wm
+end
+
+---This plugin's name and version, as sent to the server.
+---@return { name: string, version: string }
+function M.client_info()
+   return { name = M.CLIENT_NAME, version = M.CLIENT_VERSION }
+end
+
+---Add this plugin's identity to a set of LSP client capabilities.
+---@param base lsp.ClientCapabilities? defaults to Neovim's stock capabilities
+---@return lsp.ClientCapabilities
+function M.make_client_capabilities(base)
+   return vim.tbl_deep_extend("force", base or vim.lsp.protocol.make_client_capabilities(), {
+      experimental = {
+         slangClient = M.client_info(),
+      },
+   })
 end
 
 ---@param bufnr integer
@@ -62,35 +88,66 @@ end
 
 -- Per-client cached commands set. Keyed by client.id; populated lazily on the
 -- first successful static-check pass for that client and held for the client's
--- lifetime (server_info and server_capabilities don't change after the LSP
--- initialize handshake). Evicted by the LspDetach autocmd registered below.
+-- lifetime (server_capabilities doesn't change after the LSP initialize
+-- handshake). Evicted by the LspDetach autocmd registered below.
 ---@type table<integer, table<string, true>>
 local client_cache = {}
+
+-- Client ids already warned about a version mismatch, so the notification is
+-- shown once per server rather than on every command.
+---@type table<integer, true>
+local version_warned = {}
 
 vim.api.nvim_create_autocmd("LspDetach", {
    group = vim.api.nvim_create_augroup("slang-server.capabilities", { clear = true }),
    callback = function(args)
       client_cache[args.data.client_id] = nil
+      version_warned[args.data.client_id] = nil
    end,
 })
+
+---Warn if the server predates this plugin's feature set. This is the mirror of
+---the server's own check on `experimental.slangClient`: the server warns when we
+---are older, we warn when it is. Only advisory -- an older server still runs any
+---command it advertises, and unsupported ones are reported individually.
+---@param client vim.lsp.Client
+local function check_server_version(client)
+   if version_warned[client.id] then
+      return
+   end
+
+   local version = client.server_info and client.server_info.version
+   if not version then
+      version_warned[client.id] = true
+      vim.notify(
+         "slang-server: server did not report a version. " .. UPGRADE_HINT,
+         vim.log.levels.WARN
+      )
+      return
+   end
+
+   if is_older_major_minor(version, M.CLIENT_VERSION) then
+      version_warned[client.id] = true
+      vim.notify(
+         string.format(
+            "slang-server: server v%s is older than this plugin's v%s. Please upgrade slang-server.",
+            vim.trim(version),
+            M.CLIENT_VERSION
+         ),
+         vim.log.levels.WARN
+      )
+   end
+end
 
 ---Validate a client's static info and return its supported-command set.
 ---@param client vim.lsp.Client
 ---@return table<string, true>? commands, string? err_msg
 local function get_info(client)
+   check_server_version(client)
+
    local cmds = client_cache[client.id]
    if cmds then
       return cmds, nil
-   end
-
-   local version = client.server_info and client.server_info.version
-   if version and not version_at_least(version, M.MIN_SERVER_VERSION) then
-      return nil,
-         string.format(
-            "slang-server: server version %s is too old (need >= %s). Please upgrade slang-server.",
-            vim.trim(version),
-            M.MIN_SERVER_VERSION
-         )
    end
 
    local ecp = client.server_capabilities and client.server_capabilities.executeCommandProvider

--- a/clients/neovim/slang-server.nvim-scm-1.rockspec
+++ b/clients/neovim/slang-server.nvim-scm-1.rockspec
@@ -1,5 +1,7 @@
 rockspec_format = "3.0"
 package = "slang-server.nvim"
+-- NB: this rockspec is for CI purposes only and is not intended to control
+--     versioning or to be released on luarocks
 version = "scm-1"
 source = {
    url = "git+https://github.com/hudson-trading/slang-server.nvim",

--- a/clients/neovim/spec/plugin_spec.lua
+++ b/clients/neovim/spec/plugin_spec.lua
@@ -47,6 +47,36 @@ local function capture_notifications(fn)
    return messages
 end
 
+-- Number of `:messages` lines already accounted for, so each check only looks
+-- at what appeared since the previous one.
+local seen_message_lines = 0
+
+---@return string[]
+local function message_lines()
+   local output = vim.api.nvim_exec2("messages", { output = true }).output or ""
+   if output == "" then
+      return {}
+   end
+   return vim.split(output, "\n", { trimempty = true })
+end
+
+-- The server reports version mismatches and other problems via
+-- window/showMessage, which Neovim's default handler prints to `:messages`
+-- rather than raising an error. Nothing the tests do should provoke one, so
+-- treat any new line as a failure.
+local function assert_no_new_messages()
+   local lines = message_lines()
+   local new = vim.list_slice(lines, seen_message_lines + 1, #lines)
+   seen_message_lines = #lines
+   assert.are.same(
+      {},
+      new,
+      "slang-server wrote to :messages during this test (most likely a window/showMessage "
+         .. "notification from the server, which Neovim prints instead of raising). New :messages lines:\n  "
+         .. table.concat(new, "\n  ")
+   )
+end
+
 describe("SlangServer", function()
    -- load test SV
    vim.cmd("edit tests/foo.sv")
@@ -58,6 +88,7 @@ describe("SlangServer", function()
       cmd = { server_bin },
       filetypes = { "systemverilog" },
       root_dir = vim.uv.cwd(),
+      capabilities = require("slang-server._lsp.capabilities").make_client_capabilities(),
    })
    assert(client)
    -- wait for client to attach to this buffer
@@ -70,6 +101,10 @@ describe("SlangServer", function()
    vim.cmd("luafile lua/slang-server/init.lua")
    -- compile design
    vim.cmd("SlangServer setTopLevel")
+
+   -- Catches anything the server complained about, including messages emitted
+   -- during startup, which land before the first test runs.
+   after_each(assert_no_new_messages)
 
    it("Hierarchy no args", function()
       vim.cmd("SlangServer hierarchy")

--- a/docs/development/versioning.md
+++ b/docs/development/versioning.md
@@ -1,6 +1,6 @@
 # Versioning and releases
 
-The `slang-server` binary and VS Code extension use independent semantic
+The `slang-server` binary and editor extensions use independent semantic
 versions. Patch versions can advance independently, but the major and minor
 versions describe the shared feature set. Each side warns when the other has an
 older major or minor version.
@@ -11,12 +11,19 @@ older major or minor version.
 | --- | --- | --- |
 | Server | [`VERSION`](https://github.com/hudson-trading/slang-server/blob/main/VERSION) | `release.yml` |
 | VS Code extension | [`clients/vscode/package.json`](https://github.com/hudson-trading/slang-server/blob/main/clients/vscode/package.json) | `vscode-publish.yml` |
+| Neovim plugin | [`CLIENT_VERSION`](https://github.com/hudson-trading/slang-server/blob/main/clients/neovim/lua/slang-server/_lsp/capabilities.lua) in `_lsp/capabilities.lua` | `neovim-sync.yml` (mirror only) |
+
+The Neovim plugin is mirrored to
+[slang-server.nvim](https://github.com/hudson-trading/slang-server.nvim) rather
+than published to a registry, so its version is not derived from a package
+manifest. The rockspec is used for CI only and stays at `scm-1`; bump
+`CLIENT_VERSION` by hand when the plugin gains or requires new server features.
 
 ## Compatibility
 
-The VS Code extension requires a server with at least its major and minor
-version. The server also warns when the extension has an older major or minor
-version. Patch differences do not generate compatibility warnings.
+Editor extensions require a server with at least their major and minor version.
+The server also warns when an extension has an older major or minor version.
+Patch differences do not generate compatibility warnings.
 
 The extension advertises its name and version through the
 `experimental.slangClient` initialization capability. The server uses this

--- a/src/SlangServer.cpp
+++ b/src/SlangServer.cpp
@@ -327,13 +327,30 @@ std::monostate SlangServer::setTopLevel(const std::string& path) {
         setExplore();
         return std::monostate{};
     }
-    INFO("Setting top level to {}", path);
-    m_topFile = path;
 
     const auto workspacePath = m_workspaceFolder ? std::optional<std::string_view>(
                                                        m_workspaceFolder->uri.getPath())
                                                  : std::nullopt;
-    m_driver = ServerDriver::createFromTop(m_indexer, m_client, m_config, URI::fromFile(path),
+
+    // Resolve relative paths against the workspace folder. The driver keys its documents by
+    // absolute-path URI, so an unresolved relative path matches nothing and the top level
+    // silently fails to load.
+    auto topPath = fs::path(path);
+    if (topPath.is_relative()) {
+        if (!workspacePath) {
+            m_client.showError(fmt::format(
+                "Cannot set top level to relative path {}: no workspace folder to resolve it "
+                "against. Use an absolute path.",
+                path));
+            return std::monostate{};
+        }
+        topPath = (fs::path(*workspacePath) / topPath).lexically_normal();
+    }
+
+    INFO("Setting top level to {}", topPath.string());
+    m_topFile = topPath.string();
+
+    m_driver = ServerDriver::createFromTop(m_indexer, m_client, m_config, URI::fromFile(topPath),
                                            workspacePath, m_driver.get());
 
     return std::monostate{};


### PR DESCRIPTION
Mirror `slangClient` from vscode extension and associated checks.