### PR TITLE
Rework incomingCalls backend to reuse slang's analysis pass

### DIFF
--- a/include/ast/ServerCompilationAnalysis.h
+++ b/include/ast/ServerCompilationAnalysis.h
@@ -11,10 +11,13 @@
 #include "InstanceIndexer.h"
 #include "ReferenceIndexer.h"
 #include "document/SlangDoc.h"
+#include <algorithm>
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "slang/analysis/AnalysisOptions.h"
+#include "slang/analysis/ValueDriver.h"
 #include "slang/util/Bag.h"
 
 namespace server {
@@ -37,13 +40,9 @@ public:
     /// Issue all semantic diagnostics from the compilation to the diagnostic engine
     void issueDiagnosticsTo(slang::DiagnosticEngine& diagEngine);
 
-    template<bool isDrivers>
-    struct ConeSelector;
-
     /// Get cone leaves (drivers or loads depending on template parameter) for a given RTL path
     template<bool isDrivers>
     std::set<ConeLeaf> getCone(const std::string& path) {
-        using ConeSelector_t = typename ConeSelector<isDrivers>::type;
         slang::ast::LookupResult result;
         slang::ast::ASTContext context(compilation.getRoot(), slang::ast::LookupLocation::max);
         slang::ast::Lookup::name(compilation.parseName(path), context,
@@ -53,6 +52,80 @@ public:
                 fmt::format("Could not find path in compiled design: {}", path));
         }
 
+        if constexpr (isDrivers) {
+            return getDriverCone(path, result);
+        }
+        else {
+            return getLoadCone(path, result);
+        }
+    }
+
+private:
+    std::set<ConeLeaf> getDriverCone(const std::string& path,
+                                     const slang::ast::LookupResult& result) {
+        if (!m_analysisManager) {
+            m_analysisManager.emplace(m_analysisOptions);
+            compilation.freeze();
+            m_analysisManager->analyze(compilation);
+            compilation.unfreeze();
+        }
+
+        const slang::ast::ValueSymbol* lookupSymbol =
+            result.found->as_if<slang::ast::ValueSymbol>();
+        const slang::ast::ValueSymbol* resultSymbol =
+            ConeLeaf::concreteSymbol(result.found)->as_if<slang::ast::ValueSymbol>();
+        if (!lookupSymbol || !resultSymbol) {
+            throw std::runtime_error(fmt::format("Path is not a value symbol: {}", path));
+        }
+
+        auto drivers = m_analysisManager->getDriversForInstance(*resultSymbol);
+        if (lookupSymbol != resultSymbol) {
+            for (auto* driver : m_analysisManager->getDriversForInstance(*lookupSymbol)) {
+                if (std::ranges::find(drivers, driver) == drivers.end()) {
+                    drivers.push_back(driver);
+                }
+            }
+        }
+        if (drivers.empty()) {
+            throw std::runtime_error(fmt::format("Could not find reference to: {}", path));
+        }
+
+        std::set<ConeLeaf> leaves;
+        DriversTracer tracer(resultSymbol);
+        for (auto* driver : drivers) {
+            // slang sets the containingSymbol on an input port driver to the
+            // instance body. Visit the parent InstanceSymbol instead so we
+            // include the port's connection expression in the driver.
+            if (driver->isInputPort()) {
+                auto* body = driver->containingSymbol->as_if<ast::InstanceBodySymbol>();
+                if (body && body->parentInstance) {
+                    body->parentInstance->visit(tracer);
+                    continue;
+                }
+            }
+
+            // Side-effect drivers use the instance symbol as the containing
+            // symbol, while the actual use of the symbol was in the instance
+            // body. The drivers tracer does not descend from an instance
+            // symbol into the instance body, to prevent a symbol that is
+            // connected to an instance's output port from inheriting that
+            // output's drivers within the instance body.
+            if (driver->flags.has(analysis::DriverFlags::FromSideEffect)) {
+                if (auto* instance = driver->containingSymbol->as_if<ast::InstanceSymbol>()) {
+                    instance->body.visit(tracer);
+                    continue;
+                }
+            }
+            driver->containingSymbol->visit(tracer);
+        }
+
+        auto tracedLeaves = tracer.getLeaves();
+        leaves.insert(tracedLeaves.begin(), tracedLeaves.end());
+        return leaves;
+    }
+
+    std::set<ConeLeaf> getLoadCone(const std::string& path,
+                                   const slang::ast::LookupResult& result) {
         if (!m_references) {
             m_references.emplace();
             m_references->reset(&compilation.getRoot());
@@ -64,7 +137,7 @@ public:
             throw std::runtime_error(fmt::format("Could not find reference to: {}", path));
         }
 
-        ConeSelector_t coneTracer(result.found);
+        LoadsTracer coneTracer(result.found);
         for (const auto symbol : it->second) {
             symbol->visit(coneTracer);
         }
@@ -72,25 +145,15 @@ public:
         return coneTracer.getLeaves();
     }
 
-private:
     /// Retained buffer data to prevent deallocation while this compilation exists
     std::vector<std::shared_ptr<void>> m_retainedBuffers;
 
     /// Analysis options from the bag, used for driver analysis
     slang::analysis::AnalysisOptions m_analysisOptions;
 
+    std::optional<slang::analysis::AnalysisManager> m_analysisManager = std::nullopt;
     /// Index of value symbol -> uses (e.g. processes or continuous assignments)
     std::optional<ReferenceIndexer> m_references = std::nullopt;
-};
-
-template<>
-struct ServerCompilationAnalysis::ConeSelector<true> {
-    using type = DriversTracer;
-};
-
-template<>
-struct ServerCompilationAnalysis::ConeSelector<false> {
-    using type = LoadsTracer;
 };
 
 } // namespace server

--- a/include/document/ShallowAnalysis.h
+++ b/include/document/ShallowAnalysis.h
@@ -110,7 +110,7 @@ public:
     /// @brief Ensures the shallow compilation has been analyzed and returns the slang
     /// `AnalysisManager`. Returns nullptr if analysis could not be run, for example no top
     /// instances.
-    const slang::analysis::AnalysisManager* getAnalysisManager();
+    slang::analysis::AnalysisManager* getAnalysisManager();
 
     /// @brief Gets a list of drivers for a given value symbol
     std::vector<const slang::analysis::ValueDriver*> getDrivers(

--- a/src/ast/ServerCompilationAnalysis.cpp
+++ b/src/ast/ServerCompilationAnalysis.cpp
@@ -53,12 +53,15 @@ void ServerCompilationAnalysis::issueDiagnosticsTo(slang::DiagnosticEngine& diag
 
     // Driver analysis diagnostics (multi-driven, unused, etc)
     // Use stored options with numThreads=1 to avoid persistent thread pool
-    slang::analysis::AnalysisManager driverAnalysis(m_analysisOptions);
-    compilation.freeze();
-    driverAnalysis.analyze(compilation);
-    compilation.unfreeze();
-    INFO("Driver analysis found {} diagnostics", driverAnalysis.getDiagnostics().size());
-    for (auto& diag : driverAnalysis.getDiagnostics()) {
+    if (!m_analysisManager) {
+        m_analysisManager.emplace(m_analysisOptions);
+        compilation.freeze();
+        m_analysisManager->analyze(compilation);
+        compilation.unfreeze();
+    }
+
+    INFO("Driver analysis found {} diagnostics", m_analysisManager->getDiagnostics().size());
+    for (auto& diag : m_analysisManager->getDiagnostics()) {
         diagEngine.issue(diag);
     }
 }

--- a/src/document/ShallowAnalysis.cpp
+++ b/src/document/ShallowAnalysis.cpp
@@ -1054,7 +1054,7 @@ Diagnostics ShallowAnalysis::getAnalysisDiags() {
     return *m_cachedAnalysisDiags;
 }
 
-const slang::analysis::AnalysisManager* ShallowAnalysis::getAnalysisManager() {
+slang::analysis::AnalysisManager* ShallowAnalysis::getAnalysisManager() {
     if (m_driverAnalysis) {
         return m_driverAnalysis.get();
     }
@@ -1089,7 +1089,7 @@ std::vector<const slang::analysis::ValueDriver*> ShallowAnalysis::getDrivers(
         return {};
     }
 
-    return manager->getDrivers(symbol);
+    return manager->getDriversForInstance(symbol);
 }
 
 } // namespace server

--- a/tests/cpp/golden/FindSymbolRefHdl.out
+++ b/tests/cpp/golden/FindSymbolRefHdl.out
@@ -397,7 +397,7 @@ module TestModule #(
                              ^^^^^^^^ Ref -> `Sub[4]` `sub_inst` in `TestModule`  \n\\n\\n\---\n\\n\`Sub #(.WIDTH(16)) sub_inst [NUM_SUBS] (\n\    .clk(clk),\n\    .rst(rst),\n\    .data_in(sub_data_in),\n\    .data_out(sub_data_out)\n\);`
                                          ^^^^^^^^ Ref -> **Output Variable** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`\n\\n\---\n\\n\Driven by always_ff at [hdl_test.sv:79:5](<file:///tests/data/hdl_test.sv#L79,5>)  \n\`always_ff @(posedge clk or posedge rst) begin\n\    if (rst) begin\n\        data_out <= '0;\n\    end else begin\n\        data_out <= data_in;\n\    end\n\end`
                                                     ^^^^^^^^ Ref -> `Sub[4]` `sub_inst` in `TestModule`  \n\\n\\n\---\n\\n\`Sub #(.WIDTH(16)) sub_inst [NUM_SUBS] (\n\    .clk(clk),\n\    .rst(rst),\n\    .data_in(sub_data_in),\n\    .data_out(sub_data_out)\n\);`
-                                                                ^^^^^^^^ Ref -> **Output Variable** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`
+                                                                ^^^^^^^^ Ref -> **Output Variable** `data_out` in `Sub`  \n\Type: `logic[15:0]`  \n\Width: `16`  \n\\n\\n\---\n\\n\`output logic [WIDTH-1:0] data_out`\n\\n\---\n\\n\Driven by always_ff at [hdl_test.sv:79:5](<file:///tests/data/hdl_test.sv#L79,5>)  \n\`always_ff @(posedge clk or posedge rst) begin\n\    if (rst) begin\n\        data_out <= '0;\n\    end else begin\n\        data_out <= data_in;\n\    end\n\end`
 
 
 
@@ -693,15 +693,15 @@ module NoDefaults #(
                              ^^^^^^^^^^^^^ Sym gen_sub_array : InstanceArray
 
             .clk(clk),
-             ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic clk`
+             ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic clk`\n\\n\---\n\\n\Driven via port from `Sub gen_sub_array` at [hdl_test.sv:73:5](<file:///tests/data/hdl_test.sv#L73,5>)  \n\`input logic clk`
                  ^^^ Ref -> **Input Net** `clk` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
 
             .rst(rst),
-             ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic rst`
+             ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic rst`\n\\n\---\n\\n\Driven via port from `Sub gen_sub_array` at [hdl_test.sv:74:5](<file:///tests/data/hdl_test.sv#L74,5>)  \n\`input logic rst`
                  ^^^ Ref -> **Input Net** `rst` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
 
             .data_in(data_in),
-             ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Declared Type: `logic [WIDTH-1:0]`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+             ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Declared Type: `logic [WIDTH-1:0]`  \n\Generated signals: `3`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`\n\\n\---\n\\n\Driven via port from `Sub gen_sub_array` at [hdl_test.sv:75:5](<file:///tests/data/hdl_test.sv#L75,5>)  \n\`input logic [WIDTH-1:0] data_in`
                      ^^^^^^^ Ref -> **Input Net** `data_in` in `NoDefaults`  \n\Declared Type: `logic [WIDTH-1:0]`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
 
             .data_out()
@@ -815,15 +815,15 @@ module NoDefaults #(
           ^^^^^^^^^^^^^ Sym sub_no_branch : Instance
 
             .clk(clk),
-             ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
+             ^^^ Ref -> **Input Net** `clk` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`\n\\n\---\n\\n\Driven via port from `Sub sub_no_branch` at [hdl_test.sv:73:5](<file:///tests/data/hdl_test.sv#L73,5>)  \n\`input logic clk`
                  ^^^ Ref -> **Input Net** `clk` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic clk`
 
             .rst(rst),
-             ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
+             ^^^ Ref -> **Input Net** `rst` in `Sub`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`\n\\n\---\n\\n\Driven via port from `Sub sub_no_branch` at [hdl_test.sv:74:5](<file:///tests/data/hdl_test.sv#L74,5>)  \n\`input logic rst`
                  ^^^ Ref -> **Input Net** `rst` in `NoDefaults`  \n\Type: `logic`  \n\\n\\n\---\n\\n\`input logic rst`
 
             .data_in(data_in),
-             ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Declared Type: `logic [WIDTH-1:0]`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
+             ^^^^^^^ Ref -> **Input Net** `data_in` in `Sub`  \n\Declared Type: `logic [WIDTH-1:0]`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`\n\\n\---\n\\n\Driven via port from `Sub sub_no_branch` at [hdl_test.sv:75:5](<file:///tests/data/hdl_test.sv#L75,5>)  \n\`input logic [WIDTH-1:0] data_in`
                      ^^^^^^^ Ref -> **Input Net** `data_in` in `NoDefaults`  \n\Declared Type: `logic [WIDTH-1:0]`  \n\\n\\n\---\n\\n\`input logic [WIDTH-1:0] data_in`
 
             .data_out(data_out)


### PR DESCRIPTION
slang performs an analysis pass which finds the drivers for all symbols in a design. slang-server now uses that to report the drivers of a symbol on an incomingCalls request instead of re-walking the whole AST. Includes changes to slang.
slang's deduplication means that non-canonical instances of a module are not analyzed, so the new `AnalysisManager::getDriversForInstance` method maps non-canonical values to their counterpart on the canonical instance, creates new drivers for the non-canonical symbols, and adds them to the `DriverTracker`.
`getDriversForInstance` is currently not thread-safe because concurrent accesses could both try to populate the drivers for the same non-canonical instance's symbols, causing duplicate drivers.
The drivers shown on hover now use this method as well. Fixed a bug where hovering on a non-canonical instance showed no drivers.

Code for non-canonical to canonical mapping largely comes from this slang-netlist PR: https://github.com/jameshanlon/slang-netlist/pull/75